### PR TITLE
Feature/docserv2 dc adjustments sle11sp4

### DIFF
--- a/DC-SLE-all
+++ b/DC-SLE-all
@@ -14,11 +14,3 @@ PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sle;"
-PRODUCTNAMEREG="&slereg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLE-apparmor-quick
+++ b/DC-SLE-apparmor-quick
@@ -12,19 +12,8 @@ PDFNAME="apparmor_quickstart"
 PROFOS="sles;sled"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
-## Provo
-HTMLROOT="apparmor"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sle;"
-PRODUCTNAMEREG="&slereg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLE-audit-quick
+++ b/DC-SLE-audit-quick
@@ -12,19 +12,9 @@ PDFNAME="audit_quickstart"
 PROFOS="sled;sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
-## Provo
-HTMLROOT="audit"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sle;"
-PRODUCTNAMEREG="&slereg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -9,7 +9,7 @@ ROOTID="book.sle.admin"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -11,18 +11,8 @@ ROOTID="book.sle.admin"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -12,7 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -10,18 +10,7 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -11,6 +11,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -8,7 +8,7 @@ MAIN="MAIN.SLEDS.xml"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-apparmor-quick
+++ b/DC-SLED-apparmor-quick
@@ -13,7 +13,5 @@ PROFOS="sled"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-apparmor-quick
+++ b/DC-SLED-apparmor-quick
@@ -1,5 +1,5 @@
 ## ---------------------------- 
-## Doc Config File for SLES/SLED
+## Doc Config File for SLED
 ## AppArmor (2.3.1) Quick Start
 ## ----------------------------
 ##
@@ -9,7 +9,7 @@ ROOTID="art.aaquick"
 PDFNAME="apparmor_quickstart"
 
 ## Profiling
-PROFOS="sles;sled"
+PROFOS="sled"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location

--- a/DC-SLED-apps
+++ b/DC-SLED-apps
@@ -11,18 +11,8 @@ ROOTID="book.apps"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-apps
+++ b/DC-SLED-apps
@@ -12,7 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-apps
+++ b/DC-SLED-apps
@@ -9,7 +9,7 @@ ROOTID="book.apps"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-audit-quick
+++ b/DC-SLED-audit-quick
@@ -1,16 +1,20 @@
 ## ---------------------------- 
-## Doc Config File for SLES/SLED
-## Special configuration file for builds of the complete set
+## Doc Config File for SLED
+## Linux Audit Quick Start
 ## ----------------------------
 ##
 ## Basics
 MAIN="MAIN.SLEDS.xml"
+ROOTID="art.auditquick"
+PDFNAME="audit_quickstart"
 
 ## Profiling
-PROFOS="sled;sles"
+PROFOS="sled"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+

--- a/DC-SLED-audit-quick
+++ b/DC-SLED-audit-quick
@@ -10,7 +10,7 @@ PDFNAME="audit_quickstart"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-audit-quick
+++ b/DC-SLED-audit-quick
@@ -13,8 +13,5 @@ PROFOS="sled"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -9,7 +9,7 @@ ROOTID="book.sle.deployment"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -11,18 +11,8 @@ ROOTID="book.sle.deployment"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -12,7 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-gnomequick
+++ b/DC-SLED-gnomequick
@@ -11,19 +11,9 @@ ROOTID="art.gnomequick"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-gnomequick
+++ b/DC-SLED-gnomequick
@@ -9,7 +9,7 @@ ROOTID="art.gnomequick"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-gnomequick
+++ b/DC-SLED-gnomequick
@@ -12,8 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -11,18 +11,8 @@ ROOTID="book.gnomeuser"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -9,7 +9,7 @@ ROOTID="book.gnomeuser"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -12,7 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -14,11 +14,3 @@ PROFARCH="x86;amd64;em64t"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -11,6 +11,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -8,7 +8,7 @@ MAIN="MAIN.SLEDS.xml"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -9,7 +9,7 @@ ROOTID="art.sled.installquick"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -11,19 +11,9 @@ ROOTID="art.sled.installquick"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -12,8 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-kdequick
+++ b/DC-SLED-kdequick
@@ -11,19 +11,8 @@ ROOTID="art.kdequick"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-kdequick
+++ b/DC-SLED-kdequick
@@ -9,7 +9,7 @@ ROOTID="art.kdequick"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-kdequick
+++ b/DC-SLED-kdequick
@@ -12,7 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-kdeuser
+++ b/DC-SLED-kdeuser
@@ -9,7 +9,7 @@ ROOTID="book.kdeuser"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-kdeuser
+++ b/DC-SLED-kdeuser
@@ -12,6 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-kdeuser
+++ b/DC-SLED-kdeuser
@@ -11,18 +11,7 @@ ROOTID="book.kdeuser"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-libreofficequick
+++ b/DC-SLED-libreofficequick
@@ -9,7 +9,7 @@ ROOTID="art.oofficequick"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-libreofficequick
+++ b/DC-SLED-libreofficequick
@@ -11,19 +11,9 @@ ROOTID="art.oofficequick"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-libreofficequick
+++ b/DC-SLED-libreofficequick
@@ -12,8 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -11,18 +11,7 @@ ROOTID="book.security"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -12,6 +12,5 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -9,7 +9,7 @@ ROOTID="book.security"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -11,18 +11,8 @@ ROOTID="book.sle.tuning"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -12,7 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -9,7 +9,7 @@ ROOTID="book.sle.tuning"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLED-xen
+++ b/DC-SLED-xen
@@ -12,7 +12,6 @@ PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLED-xen
+++ b/DC-SLED-xen
@@ -11,18 +11,8 @@ ROOTID="book.xen"
 PROFOS="sled"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sled11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sled;"
-PRODUCTNAMEREG="&sledreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLED-xen
+++ b/DC-SLED-xen
@@ -9,7 +9,7 @@ ROOTID="book.xen"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -11,18 +11,8 @@ ROOTID="book.sle.admin"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -10,6 +10,7 @@ ROOTID="book.sle.admin"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -11,7 +11,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -10,18 +10,8 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-apparmor-quick
+++ b/DC-SLES-apparmor-quick
@@ -1,0 +1,19 @@
+## ---------------------------- 
+## Doc Config File for SLES
+## AppArmor (2.3.1) Quick Start
+## ----------------------------
+##
+## Basics
+MAIN="MAIN.SLEDS.xml"
+ROOTID="art.aaquick"
+PDFNAME="apparmor_quickstart"
+
+## Profiling
+PROFOS="sles"
+PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
+
+## stylesheet location
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
+#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"

--- a/DC-SLES-apparmor-quick
+++ b/DC-SLES-apparmor-quick
@@ -13,7 +13,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-apparmor-quick
+++ b/DC-SLES-apparmor-quick
@@ -10,7 +10,8 @@ PDFNAME="apparmor_quickstart"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-audit-quick
+++ b/DC-SLES-audit-quick
@@ -11,6 +11,7 @@ PDFNAME="audit_quickstart"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-audit-quick
+++ b/DC-SLES-audit-quick
@@ -13,7 +13,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-audit-quick
+++ b/DC-SLES-audit-quick
@@ -1,5 +1,5 @@
 ## ---------------------------- 
-## Doc Config File for SLES/SLED
+## Doc Config File for SLES
 ## Linux Audit Quick Start
 ## ----------------------------
 ##
@@ -9,7 +9,7 @@ ROOTID="art.auditquick"
 PDFNAME="audit_quickstart"
 
 ## Profiling
-PROFOS="sled;sles"
+PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
@@ -17,4 +17,3 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-

--- a/DC-SLES-autoupgrade
+++ b/DC-SLES-autoupgrade
@@ -11,7 +11,5 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-autoupgrade
+++ b/DC-SLES-autoupgrade
@@ -10,19 +10,8 @@ MAIN="art.automated_upgrade.xml"
 PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -16,10 +16,3 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -9,7 +9,8 @@ ROOTID="book.sle.deployment"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -11,18 +11,8 @@ ROOTID="book.sle.deployment"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-hardening
+++ b/DC-SLES-hardening
@@ -12,6 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-hardening
+++ b/DC-SLES-hardening
@@ -11,18 +11,7 @@ ROOTID="book.hardening"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-hardening
+++ b/DC-SLES-hardening
@@ -10,6 +10,7 @@ ROOTID="book.hardening"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -11,7 +11,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -15,10 +15,3 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -11,19 +11,8 @@ ROOTID="art.sles.installquick"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -9,7 +9,8 @@ ROOTID="art.sles.installquick"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="ipf;x86;amd64;em64t;s390;zseries;ipseries"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-kvm
+++ b/DC-SLES-kvm
@@ -9,7 +9,7 @@ ROOTID="book.kvm"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 PROFCONDITION="kvm4x86"
 
 ## stylesheet location

--- a/DC-SLES-kvm
+++ b/DC-SLES-kvm
@@ -13,7 +13,6 @@ PROFARCH="amd64;em64t"
 PROFCONDITION="kvm4x86"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLES-kvm
+++ b/DC-SLES-kvm
@@ -12,18 +12,8 @@ PROFOS="sles"
 PROFARCH="amd64;em64t"
 PROFCONDITION="kvm4x86"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-kvm4zseries
+++ b/DC-SLES-kvm4zseries
@@ -13,18 +13,8 @@ PROFOS="sles"
 PROFARCH="zseries"
 PROFCONDITION="kvm4zSeries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-kvm4zseries
+++ b/DC-SLES-kvm4zseries
@@ -14,7 +14,6 @@ PROFARCH="zseries"
 PROFCONDITION="kvm4zSeries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 

--- a/DC-SLES-lxcquick
+++ b/DC-SLES-lxcquick
@@ -11,19 +11,9 @@ ROOTID="art.lxcquick"
 PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-lxcquick
+++ b/DC-SLES-lxcquick
@@ -12,8 +12,5 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-lxcquick
+++ b/DC-SLES-lxcquick
@@ -9,7 +9,8 @@ ROOTID="art.lxcquick"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -11,18 +11,8 @@ ROOTID="book.security"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -10,6 +10,7 @@ ROOTID="book.security"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -10,18 +10,7 @@ ROOTID="stor_admin"
 ## Profiling
 PROFOS="sles"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -11,6 +11,5 @@ ROOTID="stor_admin"
 PROFOS="sles"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -9,6 +9,8 @@ ROOTID="stor_admin"
 
 ## Profiling
 PROFOS="sles"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -11,18 +11,8 @@ ROOTID="book.sle.tuning"
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -10,6 +10,7 @@ ROOTID="book.sle.tuning"
 ## Profiling
 PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-xen
+++ b/DC-SLES-xen
@@ -9,7 +9,8 @@ ROOTID="book.xen"
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="x86;amd64;em64t"
+PROFARCH="ipf;x86;amd64;em64t;ipseries;s390;zseries"
+PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/DC-SLES-xen
+++ b/DC-SLES-xen
@@ -12,7 +12,5 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-xen
+++ b/DC-SLES-xen
@@ -11,18 +11,8 @@ ROOTID="book.xen"
 PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
 
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -12,8 +12,5 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
-#HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
-#EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -11,20 +11,9 @@ ROOTID="art.sles.xen2kvmquick"
 PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
-## Provo
-HTMLROOT="sles11"
-
 ## stylesheet location
 #STYLEROOT="/usr/share/xml/docbook/stylesheet/suse/flyer"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 #HTML_CSS="/usr/share/xml/docbook/stylesheet/suse/html/susebooks.css"
 #EPUB_CSS="/usr/share/xml/docbook/stylesheet/suse/epub/susebooks.css"
-
-## obsolete
-DISTVER="11 SP2"
-PRODUCTNAME="&sls;"
-PRODUCTNAMEREG="&slsreg;"
-
-## enable sourcing
-export DOCCONF=$BASH_SOURCE


### PR DESCRIPTION
- align the profiling info in the DC files for  SLES/SLED
   * for those where HTML is build with DC-SLES/D-all
   * align sorting order of PROFARCH values
   * add PROFCOND (where missing)
- DC-SLE-*:
  * splitted ```DC-SLE-apparmor-quick``` and ```DC-SLE-audit-quick``` into separate files for SLES/SLED
  * removed DC-SLE-all
- removed obsolete parameters for all DC files
- replace old stylesheets with pointers to current ones (on behalf of sknorr) 