### PR TITLE
Convert SLEHA11SP4 translation to DocBook5

### DIFF
--- a/ja/DC-SLE-ha-all
+++ b/ja/DC-SLE-ha-all
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/ja/DC-SLE-ha-guide
+++ b/ja/DC-SLE-ha-guide
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/ja/xml/MAIN.SLEHA.xml
+++ b/ja/xml/MAIN.SLEHA.xml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<!DOCTYPE set PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE set>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<set lang="ja">
- <title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>ドキュメント</title>
- <setinfo>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
- </setinfo>
+<set xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:lang="ja"><title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>ドキュメント</title><info><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber></info>
+ 
+ 
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_haguide.xml" parse="xml"/>
+ <xi:include href="book_sle_haguide.xml" parse="xml"/>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_ha_techguides.xml" parse="xml"/>
+ <xi:include href="book_sle_ha_techguides.xml" parse="xml"/>
 </set>

--- a/ja/xml/art_sle_ha_nfs_quick.xml
+++ b/ja/xml/art_sle_ha_nfs_quick.xml
@@ -1,33 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE article PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE article>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<?provo dirname="nfs_quick/"?>
-<article xml:base="art_sle_ha_nfs_quick.xml" lang="en" id="art-ha-quick-nfs">
-<?suse-quickstart columns="no" version="2"?>
-
-
- <title>Highly Available NFS Storage with DRBD and Pacemaker</title>
- <subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle>
- <articleinfo>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productname role="abbrev">SLE HA</productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <authorgroup>
-   <author><firstname>Florian</firstname><surname>Haas</surname>
-   </author>
-   <author><firstname>Tanja</firstname><surname>Roth</surname>
-   </author>
-  </authorgroup>
- </articleinfo>
-
- <abstract>
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="art_sle_ha_nfs_quick.xml" xml:lang="en" xml:id="art-ha-quick-nfs"><?suse-quickstart columns="no" version="2"?><title>Highly Available NFS Storage with DRBD and Pacemaker</title><subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productname role="abbrev">SLE HA</productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><authorgroup>
+   <author><personname><firstname>Florian</firstname><surname>Haas</surname></personname></author>
+   <author><personname><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+  </authorgroup><abstract>
   <para os="sles">
    This document describes how to set up highly available NFS storage in a
    2-node cluster, using the following components that are shipped with
@@ -35,12 +20,20 @@ Please see LICENSE.txt for this document's license.
    (Logical Volume Manager version 2), and Pacemaker, the cluster resource
    management framework.
   </para>
- </abstract>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_intro_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_install_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_use_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_failover_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides_quick.xml" parse="xml"/>
+ </abstract></info>
+
+
+
+ 
+ 
+ 
+
+ 
+ <xi:include href="ha_nfs_quick_intro_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_install_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_config_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_use_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_failover_i.xml" parse="xml"/>
+ <xi:include href="copyright_techguides_quick.xml" parse="xml"/>
 </article>

--- a/ja/xml/book_sle_ha_techguides.xml
+++ b/ja/xml/book_sle_ha_techguides.xml
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml"
-                 title="Profiling step"?>
-<book xml:base="book_sle_ha_techguides.xml" lang="en" id="book-sleha-techguides">
- <bookinfo>
-  <title>Technical Guides</title><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
-<?dbtimestamp format="B d, Y"?></date>
-
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="art_sle_ha_nfs_quick.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_ha_techguides.xml" xml:lang="en" xml:id="book-sleha-techguides"><title>Technical Guides</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
+<?dbtimestamp format="B d, Y"?></date><xi:include href="copyright_techguides.xml" parse="xml"/></info>
+ 
+ <xi:include href="art_sle_ha_nfs_quick.xml" parse="xml"/>
  
 
 </book>

--- a/ja/xml/book_sle_haguide.xml
+++ b/ja/xml/book_sle_haguide.xml
@@ -1,61 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<?provo dirname="ha/"?>
-<book xml:base="book_sle_haguide.xml" lang="ja" id="book-sleha">
- <bookinfo>
-  <title>高可用性ガイド</title>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_copyright_gfdl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_authors.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_intro.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_haguide.xml" xml:lang="ja" xml:id="book-sleha"><title>高可用性ガイド</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date><xi:include href="common_copyright_gfdl.xml" parse="xml"/><xi:include href="ha_authors.xml" parse="xml"/></info>
+ 
+ <xi:include href="ha_intro.xml" parse="xml"/>
 
 
 
- <part id="part-install">
-  <title>インストールおよびセットアップ</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_concepts.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_requirements.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_installation.xml" parse="xml"/>
+ <part xml:id="part-install"><title>インストールおよびセットアップ</title><info/>
+  
+  <xi:include href="ha_concepts.xml" parse="xml"/>
+  <xi:include href="ha_requirements.xml" parse="xml"/>
+  <xi:include href="ha_installation.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-config">
-  <title>設定および管理</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_basics.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_hawk.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_gui.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_cli.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_agents.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_fencing.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_acl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_netbonding.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_lvs.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_geocluster.xml" parse="xml"/>
+ <part xml:id="part-config"><title>設定および管理</title><info/>
+  
+  <xi:include href="ha_config_basics.xml" parse="xml"/>
+  <xi:include href="ha_config_hawk.xml" parse="xml"/>
+  <xi:include href="ha_config_gui.xml" parse="xml"/>
+  <xi:include href="ha_config_cli.xml" parse="xml"/>
+  <xi:include href="ha_agents.xml" parse="xml"/>
+  <xi:include href="ha_fencing.xml" parse="xml"/>
+  <xi:include href="ha_acl.xml" parse="xml"/>
+  <xi:include href="ha_netbonding.xml" parse="xml"/>
+  <xi:include href="ha_lvs.xml" parse="xml"/>
+  <xi:include href="ha_geocluster.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-storage">
-  <title>ストレージおよびデータレプリケーション</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_ocfs2.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_drbd.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_clvm.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_storage_protection.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_samba.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_rear.xml" parse="xml"/>
+ <part xml:id="part-storage"><title>ストレージおよびデータレプリケーション</title><info/>
+  
+  <xi:include href="ha_ocfs2.xml" parse="xml"/>
+  <xi:include href="ha_drbd.xml" parse="xml"/>
+  <xi:include href="ha_clvm.xml" parse="xml"/>
+  <xi:include href="ha_storage_protection.xml" parse="xml"/>
+  <xi:include href="ha_samba.xml" parse="xml"/>
+  <xi:include href="ha_rear.xml" parse="xml"/>
  </part>
   
   
@@ -63,17 +55,17 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <part id="part-appendix">
-  <title>付録</title>
+ <part xml:id="part-appendix"><title>付録</title><info/>
   
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_troubleshooting.xml" parse="xml"/>
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_naming.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_management.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_migration.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_news.xml" parse="xml"/>
+  
+  <xi:include href="ha_troubleshooting.xml" parse="xml"/>
+   <xi:include href="ha_naming.xml" parse="xml"/>
+  <xi:include href="ha_example.xml" parse="xml"/>
+  <xi:include href="ha_config_example.xml" parse="xml"/>
+  <xi:include href="ha_management.xml" parse="xml"/>
+  <xi:include href="ha_migration.xml" parse="xml"/>
+  <xi:include href="ha_news.xml" parse="xml"/>
  </part>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_glossary.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_legal.xml" parse="xml"/>
+ <xi:include href="ha_glossary.xml" parse="xml"/>
+ <xi:include href="common_legal.xml" parse="xml"/>
 </book>

--- a/ja/xml/common_copyright_gfdl.xml
+++ b/ja/xml/common_copyright_gfdl.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="common_copyright_gfdl.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="common_copyright_gfdl.xml">
  <para>
   Copyright © 2006–<?dbtimestamp format="Y"?>
 
@@ -16,7 +20,7 @@ Please see LICENSE.txt for this document's license.
   この文書は、GNUフリー文書ライセンスのバージョン1.2または(オプションとして)バージョン1.3の条項に従って、複製、頒布、および/または改変が許可されています。ただし、この著作権表示およびライセンスは変更せずに記載すること。ライセンスバージョン1.2のコピーは、<quote>GNUフリー文書ライセンス</quote>セクションに含まれています。
  </para>
  <para>
-  SUSEおよびNovellの商標については、商標とサービスマークの一覧<ulink url="http://www.novell.com/company/legal/trademarks/tmlist.html"/>を参照してください。他のすべての第三者の商標は、各商標権者が所有しています。商標記号(®、™など) は、SUSEまたはNovellの商標を示し、アスタリスク(*)は、サードパーティの商標を示します。
+  SUSEおよびNovellの商標については、商標とサービスマークの一覧<link version="5.1" xlink:href="http://www.novell.com/company/legal/trademarks/tmlist.html"/>を参照してください。他のすべての第三者の商標は、各商標権者が所有しています。商標記号(®、™など) は、SUSEまたはNovellの商標を示し、アスタリスク(*)は、サードパーティの商標を示します。
  </para>
  <para>
   本書のすべての情報は、細心の注意を払って編集されています。しかし、このことは絶対に正確であることを保証するものではありません。SUSE LLC、その関係者、著者、翻訳者のいずれも誤りまたはその結果に対して一切責任を負いかねます。

--- a/ja/xml/common_gfdl1.2_i.xml
+++ b/ja/xml/common_gfdl1.2_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml" 
-                 title="Profiling step"?>
-<sect1 xml:base="common_gfdl1.2_i.xml" role="legal">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_gfdl1.2_i.xml" role="legal">
  <title>GNU Free Documentation License</title>
 
  <para>
@@ -498,7 +499,7 @@ Please see LICENSE.txt for this document's license.
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to
   address new problems or concerns. See
-  <ulink url="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</ulink>.
+  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>
@@ -548,4 +549,4 @@ Please see LICENSE.txt for this document's license.
   software license, such as the GNU General Public License, to permit their
   use in free software.
  </para>
-</sect1>
+</section>

--- a/ja/xml/common_intro_feedback_i.xml
+++ b/ja/xml/common_intro_feedback_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_feedback_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_feedback_i.xml">
  <title>フィードバック</title>
 
  <para>
@@ -18,10 +22,10 @@ Please see LICENSE.txt for this document's license.
    <term>バグと機能拡張の要求</term>
    <listitem>
     <para>
-     ご使用の製品に利用できるサービスとサポートのオプションについては、<ulink url="http://www.suse.com/support/"/>を参照してください。
+     ご使用の製品に利用できるサービスとサポートのオプションについては、<link xlink:href="http://www.suse.com/support/"/>を参照してください。
     </para>
     <para>
-     製品コンポーネントのバグを報告するには、<ulink url="http://www.suse.com/support/"/>からNovell Customer Centerにログインし、<menuchoice><guimenu>マイサポート</guimenu><guimenu>サービス要求</guimenu></menuchoice>の順に選択します。
+     製品コンポーネントのバグを報告するには、<link xlink:href="http://www.suse.com/support/"/>からNovell Customer Centerにログインし、<menuchoice><guimenu>マイサポート</guimenu><guimenu>サービス要求</guimenu></menuchoice>の順に選択します。
     </para>
    </listitem>
   </varlistentry>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    <term>ユーザからのコメント</term>
    <listitem>
     <para>
-     本マニュアルおよびこの製品に含まれているその他のマニュアルについて、皆様のご意見やご要望をお寄せください。オンラインドキュメントの各ページの下にあるユーザコメント機能を使用するか、または<ulink url="http://www.suse.com/doc/feedback.html"/>にアクセスして、コメントを入力してください。
+     本マニュアルおよびこの製品に含まれているその他のマニュアルについて、皆様のご意見やご要望をお寄せください。オンラインドキュメントの各ページの下にあるユーザコメント機能を使用するか、または<link xlink:href="http://www.suse.com/doc/feedback.html"/>にアクセスして、コメントを入力してください。
 
     </para>
    </listitem>
@@ -43,4 +47,4 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </varlistentry>
  </variablelist>
-</sect1>
+</section>

--- a/ja/xml/common_intro_making_i.xml
+++ b/ja/xml/common_intro_making_i.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_making_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_making_i.xml">
  <title>本マニュアルの作成について</title>
 
  <para>
-  本書は、DocBook(<ulink url="http://www.docbook.org"/>を参照)のサブセットであるNovdocで作成されています。XMLソースファイルは<command>xmllint</command>によって検証され、<command>xsltproc</command>によって処理され、Norman Walshによるスタイルシートのカスタマイズ版を使用してXSL-FOに変換されました。最終的なPDFは、RenderXのXEPによってフォーマットされています。 
+  本書は、DocBook(<link xlink:href="http://www.docbook.org"/>を参照)のサブセットであるNovdocで作成されています。XMLソースファイルは<command>xmllint</command>によって検証され、<command>xsltproc</command>によって処理され、Norman Walshによるスタイルシートのカスタマイズ版を使用してXSL-FOに変換されました。最終的なPDFは、RenderXのXEPによってフォーマットされています。 
  </para>
-</sect1>
+</section>

--- a/ja/xml/common_intro_typografie_i.xml
+++ b/ja/xml/common_intro_typografie_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_typografie_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_typografie_i.xml">
 
 
  <title>マニュアルの表記規則</title>
@@ -64,4 +68,4 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
-</sect1>
+</section>

--- a/ja/xml/common_legal.xml
+++ b/ja/xml/common_legal.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="common_legal.xml" role="legal">
- <title>GNU利用許諾契約書</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_legal.xml" role="legal"><title>GNU利用許諾契約書</title><info/>
+ 
  <para>
   この付録には、GNU Free Documentation Licenseバージョン1.2が含まれています。
  </para>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_gfdl1.2_i.xml" parse="xml"/>
+ <xi:include href="common_gfdl1.2_i.xml" parse="xml"/>
 </appendix>

--- a/ja/xml/copyright_techguides.xml
+++ b/ja/xml/copyright_techguides.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="copyright_techguides.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="copyright_techguides.xml">
  <para>
   Copyright © 2011 Novell Inc., doc-team@suse.de. Used with
   permission.
@@ -31,12 +35,12 @@ Please see LICENSE.txt for this document's license.
   </para>
  </formalpara>
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link version="5.1" xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
 </legalnotice>

--- a/ja/xml/copyright_techguides_quick.xml
+++ b/ja/xml/copyright_techguides_quick.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="copyright_techguides_quick.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="copyright_techguides_quick.xml">
  <title>Legal Notice</title>
 
  <para>
@@ -37,13 +41,13 @@ Please see LICENSE.txt for this document's license.
  </formalpara>
 
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
 
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
-</sect1>
+</section>

--- a/ja/xml/ha_acl.xml
+++ b/ja/xml/ha_acl.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_acl.xml" id="cha-ha-acl">
- <title>アクセス制御リスト</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_acl.xml" xml:id="cha-ha-acl"><title>アクセス制御リスト</title><info><abstract>
   <para>
    crmシェル(crmsh)、Hawk、Pacemaker GUIなどのクラスタ管理ツールは、<systemitem class="username">root</systemitem>ユーザまたは<systemitem class="groupname">haclient</systemitem>グループに属するユーザが使用できます。デフォルトで、これらのユーザは完全な読み込み/書き込みのアクセス権を持ちます。アクセスを制限するか、または詳細なアクセス権を割り当てるには、<emphasis/>「アクセス制御リスト」(ACL)を使用できます。
   </para>
@@ -15,14 +17,16 @@ Please see LICENSE.txt for this document's license.
   <para>
    アクセス制御リストは、順序付けされたアクセスルールセットで構成されています。各ルールにより、クラスタ設定の一部への読み込みまたは書き込みアクセスの許可、またはアクセスの拒否が行われます。ルールは通常、組み合わせて特定の役割を生成し、ユーザを自分のタスクに一致する役割に割り当てることができます。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  
  <note>
   <title>CIB検証バージョンとACLとの違い</title>
   <para>このACLマニュアルは、<literal>pacemaker-2.0</literal>以上のCIB構文バージョンでCIBを検証する場合にのみ適用します。この検証方法およびCIBバージョンのアップグレード方法の詳細については、<xref linkend="note-ha-cib-upgrade"/>を参照してください。 </para>
-  <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3からアップグレードする一方で、それまで使用してきたCIBバージョンを保持している場合は、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』の「<citetitle>アクセス制御リスト</citetitle>」の章を参照してください。<ulink url="http://www.suse.com/documentation/"/>から入手できます。</para>
+  <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3からアップグレードする一方で、それまで使用してきたCIBバージョンを保持している場合は、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』の「<citetitle>アクセス制御リスト</citetitle>」の章を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。</para>
  </note>
- <sect1 id="sec-ha-acl-require">
+ <section xml:id="sec-ha-acl-require">
   <title>要件と前提条件</title>
 
   <para>
@@ -74,10 +78,10 @@ Please see LICENSE.txt for this document's license.
   </important>
 
   <para>
-   ACLを使用するには、XPathに関するいくらかの知識が必要になります。XPathはXMLドキュメントでノードを選択するための言語です。<ulink url="http://en.wikipedia.org/wiki/XPath"/>を参照するか、<ulink url="http://www.w3.org/TR/xpath/"/>の仕様を確認してください。
+   ACLを使用するには、XPathに関するいくらかの知識が必要になります。XPathはXMLドキュメントでノードを選択するための言語です。<link xlink:href="http://en.wikipedia.org/wiki/XPath"/>を参照するか、<link xlink:href="http://www.w3.org/TR/xpath/"/>の仕様を確認してください。
   </para>
- </sect1>
- <sect1 id="sec-ha-acl-enable">
+ </section>
+ <section xml:id="sec-ha-acl-enable">
   <title>クラスタでのACLの使用の有効化</title>
 
   <para>
@@ -90,31 +94,31 @@ Please see LICENSE.txt for this document's license.
    または、<xref linkend="pro-ha-acl-enable-hawk"/>で説明するように、Hawkを使用します。
   </para>
 
-  <procedure id="pro-ha-acl-enable-hawk">
+  <procedure xml:id="pro-ha-acl-enable-hawk">
    <title>HawkでのACLの使用の有効化</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタのプロパティ</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>CRMの環境設定</guimenu>グループで、空のドロップダウンボックスから<guimenu>enable-acl</guimenu>属性を選択し、プラスアイコンをクリックして追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <literal>enable-acl=true</literal>を設定するには、<literal>enable-acl</literal>の隣のチェックボックスをオンにして、変更内容を確認します。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-basics">
+ </section>
+ <section xml:id="sec-ha-acl-basics">
   <title>ACLの基\'96\'7b事項</title>
 
   <para>
@@ -151,14 +155,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <sect2 id="sec-ha-acl-config-xpath">
+  <section xml:id="sec-ha-acl-config-xpath">
    <title>XPath式によるACLルールの設定</title>
    <para>
     XPathによってACLルールを管理するには、その記述言語であるXMLの構造を理解している必要があります。XMLでクラスタ設定を表示する次のコマンドで構造を取得します(<xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>を参照)。
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure show xml</screen>
    
-   <example id="ex-ha-acl-excerpt">
+   <example xml:id="ex-ha-acl-excerpt">
     <title>XML内のクラスタ設定の例</title>
 <screen>&lt;num_updates="59" 
       dc-uuid="175704363"
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     一例として、<xref linkend="tab-ha-acl-operator"/>は、<quote>オペレータ</quote>の役割を作成するためのパラメータ(アクセスタイプおよびXPath式)を示しています。この役割を持つユーザは、2番目の列で説明されるタスクのみ実行することができ、リソースを再構成することはできません(たとえば、パラメータや操作の変更など)。また、コロケーションや順序の制約の設定を変更することもできません。
    </para>
-   <table id="tab-ha-acl-operator">
+   <table xml:id="tab-ha-acl-operator">
     <title>オペレータ役割 - アクセスタイプおよびXPath式</title>
     <tgroup cols="2">
      <thead>
@@ -305,10 +309,10 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
   
-   <sect2 id="sec-ha-acl-config-tag">
+   <section xml:id="sec-ha-acl-config-tag">
    <title>短縮によるACLルールの設定</title>
    <para>
     XML構造を扱いたくないユーザ向には、より簡単な方法があります。 
@@ -331,51 +335,51 @@ Please see LICENSE.txt for this document's license.
     短縮構文はcrmshおよびHawkで使用できます。CIBデーモンは一致するオブジェクトにACLルールを適用する方法を認識しています。
    </para>
    
-   </sect2>
-  </sect1>
- <sect1 id="sec-ha-acl-config-hbgui">
+   </section>
+  </section>
+ <section xml:id="sec-ha-acl-config-hbgui">
   <title>Pacemaker GUIによるACLの構成</title>
 
   <para> 次の手順は、<literal>monitor</literal>役割を定義し、それをユーザに割り当てることで、クラスタ設定への読み込み専用アクセスを設定する方法を示しています。または、<xref linkend="sec-ha-acl-config-hawk"/>と<xref linkend="pro-ha-acl-crm"/>で説明されているように、Hawkあるいはcrmshを使用してこの操作を実行することもできます。 </para>
 
-  <procedure id="pro-ha-acl-hbgui">
+  <procedure xml:id="pro-ha-acl-hbgui">
    <title>Pacemaker GUIを使用して、監視の役割を追加し、ユーザを割り当てる</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>設定</guimenu>ツリー内の<guimenu>ACL</guimenu>エントリをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>追加</guimenu>をクリックします。ダイアログボックスが表示されます。<guimenu>ACL Target (ACLターゲット)</guimenu>または<guimenu>ACLの役割</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ACLの役割を定義するには、次のとおり実行します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu> ACLの役割</guimenu>を選択します。設定オプションを追加するウィンドウが開きます。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-id" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-id">
       <para>
        <guimenu>ID</guimenu>テキストフィールド内に固有の識別子を追加します(例［<literal>監視</literal>］)。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-add" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-add">
       <para>
        <guimenu>追加</guimenu>をクリックして、権利(<guimenu>読み込み</guimenu>、<guimenu>書き込み</guimenu>、または<guimenu>拒否</guimenu>)を選択します。ここの例では<guimenu>読み込み</guimenu>を選択します。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-xpath" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-xpath">
       <para>
        XPath式<literal>/cib</literal>を<guimenu>Xpath</guimenu>テキストフィールドに入力します。<guimenu>OK</guimenu>をクリックして、続行します。
       </para>
@@ -383,34 +387,34 @@ Please see LICENSE.txt for this document's license.
        傍注: リソースや制約がある場合、<xref linkend="sec-ha-acl-config-tag"/>で説明したように、短縮構文も使用できます。 
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        その他の条件がある場合、手順(<xref linkend="st-ha-acl-config-hbgui-add"/>および<xref linkend="st-ha-acl-config-hbgui-xpath"/>)を繰り返します。この例ではあてはまらないため、役割は完了し、<guimenu>OK</guimenu>をクリックしてウィンドウを閉じることができます。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次のようにユーザに役割を割り当てます
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>追加</guimenu>ボタンをクリックします。<guimenu>ACL Target (ACLターゲット)</guimenu>または<guimenu>ACLの役割</guimenu>を選択するダイアログボックスが表示されます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ACL Target (ACLターゲット)</guimenu>を選択します。設定オプションを追加するウィンドウが開きます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ID</guimenu>テキストフィールドにユーザ名を入力します。このユーザが<systemitem class="groupname">haclient</systemitem>グループに属することを確認します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="st-ha-acl-config-hbgui-id"/>で指定されている役割名をクリックして使用します。
       </para>
@@ -418,47 +422,47 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-config-hawk">
+ </section>
+ <section xml:id="sec-ha-acl-config-hawk">
   <title>HawkによるACLの設定</title>
   
   <para>
    次の手順は、<literal>monitor</literal>役割を定義し、それをユーザに割り当てることで、クラスタ設定への読み込み専用アクセスを設定する方法を示しています。または、<xref linkend="pro-ha-acl-crm"/>で説明されているように、crmshを使用してこの操作を実行することもできます。
   </para>
   
-  <procedure id="pro-ha-acl-hawk">
+  <procedure xml:id="pro-ha-acl-hawk">
    <title>監視の役割を追加して、Hawkを持つユーザに割り当てる</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>アクセス制御リスト</guimenu>を選択します。このビューには、すでに定義済みの<guimenu>役割</guimenu>と<guimenu>ユーザ</guimenu>が表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ACLの役割を定義するには、次のとおり実行します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>役割</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        固有な<guimenu>役割ID</guimenu>として、<literal>monitor</literal>などを入力します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <literal>monitor</literal>役割を定義する例として、<guimenu>右</guimenu>ドロップダウンボックスから<literal>read</literal>を選択します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>Xpath</guimenu>テキストボックスに、Xpath式<literal>/cib</literal>を入力し、<guimenu>役割の作成</guimenu>をクリックします。
       </para>
@@ -466,19 +470,19 @@ Please see LICENSE.txt for this document's license.
        この操作は、<literal>monitor</literal>の名前を持つ新しい役割を作成して、<literal>read</literal>の権利を設定し、XPath式<literal>/cib</literal>を使用してCIB内のすべての要素に適用します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        必要に応じて、プラスアイコンをクリックして各パラメータを指定し、さらにアクセス権およびXPath引数を追加できます。変更内容を確認します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次のようにユーザに役割を割り当てます。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ユーザ</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
       </para>
@@ -486,12 +490,12 @@ Please see LICENSE.txt for this document's license.
        <guimenu>ユーザの作成</guimenu>ビューに使用可能な役割が表示されます。このビューにはそのユーザの個別ACLルールを設定するための追加の行も含まれます。このビューでは、ユーザに1つまたは複数の役割を割り当てたり、ユーザに1つ以上の個別ルールを定義することもできます。<emphasis/>役割を選択すると、個別ルールの行が非表示となり、その逆も同様になります。役割と個別ルールを割り当てることはできません。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        固有な<guimenu>ユーザID</guimenu>として、<literal>tux</literal>などを入力します。このユーザが<systemitem class="groupname">haclient</systemitem>グループに属することを確認します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        ユーザに役割を割り当てるには、<guimenu>役割</guimenu>から各エントリを選択します。例では、作成した<literal>monitor</literal>役割を選択します。
       </para>
@@ -510,12 +514,12 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </figure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        代わりに個別ルールを定義する場合は、<guimenu>右</guimenu>を選択し、ルールに対する各Xpathパラメータを入力します。追加のルールを定義するには、プラスアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選択内容を確認し、<guimenu>ユーザの作成</guimenu>をクリックしてユーザに役割またはルールを割り当てます。
       </para>
@@ -527,35 +531,35 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースや制約に対するアクセス権を設定するには、<xref linkend="sec-ha-acl-config-tag"/>で説明したように、短縮構文も使用できます。 
   </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-acl-config-crm">
+ <section xml:id="sec-ha-acl-config-crm">
   <title>crmshによるACLの設定</title>
 
   <para>
    次の手順は、<literal>monitor</literal>役割を定義し、それをユーザに割り当てることで、クラスタ設定への読み込み専用アクセスを設定する方法を示しています。
   </para>
 
-  <procedure id="pro-ha-acl-crm">
+  <procedure xml:id="pro-ha-acl-crm">
    <title>監視の役割を追加して、crmshを持つユーザに割り当てる</title>
-   <step performance="required">
+   <step>
     <para>
      <systemitem class="username">root</systemitem>としてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      crmshの対話モードを開始します。
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure
 <prompt role="custom">crm(live)configure# </prompt></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ACLの役割を次のとおり定義します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <command>role</command>コマンドを使用して、新しい役割を定義します。
       </para>
@@ -564,26 +568,26 @@ Please see LICENSE.txt for this document's license.
        前のコマンドは、<literal>monitor</literal>の名前を持つ新しい役割を作成して、<literal>read</literal>の権利を設定し、XPath式<literal>/cib</literal>を使用してCIB内のすべての要素に適用します。必要な場合は、アクセス権およびXPath引数をさらに追加できます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        必要に応じてさらに役割を追加します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      役割を1つ以上のACLターゲットに割り当てます。このACLターゲットは、該当のシステムユーザです。これらのシステムユーザが<systemitem class="groupname">haclient</systemitem>グループに属していることを確認します。
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>acl_target</command> tux monitor</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更を確認します:
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更をコミットします:
     </para>
@@ -594,6 +598,6 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースや制約に対するアクセス権を設定するには、<xref linkend="sec-ha-acl-config-tag"/>で説明したように、短縮構文も使用できます。 
   </para>
- </sect1>
+ </section>
  
 </chapter>

--- a/ja/xml/ha_agents.xml
+++ b/ja/xml/ha_agents.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_agents.xml" id="cha-ha-agents">
- <title>リソースエージェントの追加または変更</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_agents.xml" xml:id="cha-ha-agents"><title>リソースエージェントの追加または変更</title><info><abstract>
   <para>
    クラスタによる管理が必要なすべての作業は、リソースとして使用できなければなりません。主要なグループとして、リソースエージェントとSTONITHエージェントの2つがあります。両方のカテゴリで、エージェントの追加や所有が可能で、クラスタ機能を各自のニーズに合わせて拡張することができます。
   </para>
- </abstract>
- <sect1 id="sec-ha-stonithagents">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-stonithagents">
   <title>STONITHエージェント</title>
 
   <para>
@@ -33,8 +37,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    今のところ、STONITHエージェントの作成に関するマニュアルはありません。新しいSTONITHエージェントを作成する場合は、<systemitem class="resource">cluster-glue</systemitem>パッケージのソースに提供されている例を参照してください。
   </para>
- </sect1>
- <sect1 id="sec-ha-writingresourceagents">
+ </section>
+ <section xml:id="sec-ha-writingresourceagents">
   <title>OCFリソースエージェントの作成</title>
 
   <para>
@@ -103,18 +107,18 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      テンプレートとして、<filename>/usr/lib/ocf/resource.d/pacemaker/Dummy</filename>ファイルをロードします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しいリソースエージェントごとに新しいサブディレクトリを作成して、名前が競合しないようにします。たとえばリソースグループ<literal>kitchen</literal>にリソース<literal>coffee_machine</literal>がある場合、このリソースを<filename>/usr/lib/ocf/resource.d/kitchen/</filename>ディレクトリに追加します。このRAにアクセスするには、コマンド<command>crm</command>を実行します。
     </para>
 <screen><command>configure</command><command>primitive</command> coffee_1 <emphasis>ocf:coffee_machine:kitchen</emphasis> ...</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      異なるシェル関数を実装し、異なる名前でファイルを保存します。
     </para>
@@ -122,8 +126,8 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
   <para>
-   OCFリソースエージェントの作成についての詳細は、<ulink url="http://linux-ha.org/wiki/Resource_Agents"/>を参照してください。コンセプトの特別な情報については、<xref linkend="cha-ha-concepts"/>を参照してください。
+   OCFリソースエージェントの作成についての詳細は、<link xlink:href="http://linux-ha.org/wiki/Resource_Agents"/>を参照してください。コンセプトの特別な情報については、<xref linkend="cha-ha-concepts"/>を参照してください。
   </para>
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_error_codes.xml" parse="xml"/>
+ </section>
+ <xi:include href="ha_error_codes.xml" parse="xml"/>
 </chapter>

--- a/ja/xml/ha_authors.xml
+++ b/ja/xml/ha_authors.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE authorgroup PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE authorgroup>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<authorgroup xml:base="ha_authors.xml">
- <author><firstname>Tanja</firstname><surname>Roth</surname>
- </author>
- <author><firstname>Thomas</firstname><surname>Schraitle</surname>
- </author>
+<authorgroup xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="ha_authors.xml">
+ <author><personname version="5.1"><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+ <author><personname version="5.1"><firstname>Thomas</firstname><surname>Schraitle</surname></personname></author>
 </authorgroup>

--- a/ja/xml/ha_clvm.xml
+++ b/ja/xml/ha_clvm.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_clvm.xml" id="cha-ha-clvm">
- <title>Cluster Logical Volume Manager(cLVM)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_clvm.xml" xml:id="cha-ha-clvm"><title>Cluster Logical Volume Manager(cLVM)</title><info><abstract>
   <para>
    クラスタ上の共有ストレージを管理する場合、ストレージサブシステムに行った変更を各ノードに伝える必要があります。Linux Volume Manager 2 (LVM2)はローカルストレージの管理に多用されており、クラスタ全体のボリュームグループのトランスペアレントな管理をサポートするために拡張されています。クラスタ化されたボリュームグループを、ローカルストレージと同じコマンドで管理できます。
   </para>
- </abstract>
- <sect1 id="sec-ha-clvm-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-clvm-overview">
   <title>概念の概要</title>
 
 
@@ -47,8 +51,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-clvm-config">
+ </section>
+ <section xml:id="sec-ha-clvm-config">
   <title>cLVMの環境設定</title>
 
   <para>
@@ -117,7 +121,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect2 id="sec-ha-clvm-config-cmirrord">
+  <section xml:id="sec-ha-clvm-config-cmirrord">
    <title>cmirrordの構成</title>
 
    <para>
@@ -127,12 +131,12 @@ Please see LICENSE.txt for this document's license.
     ここでは、<filename>/dev/sda</filename>と<filename>/dev/sdb</filename>が共有ストレージデバイスだとします。必要な場合は、これらを独自のデバイス名に置き換えます。次の手順に従います。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       2つ以上のノードを使用してクラスタを作成します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>dlm</command>、<command>clvmd</command>、およびSTONITHを実行するために、クラスタを構成します。
      </para>
@@ -150,12 +154,12 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>clone</command> base-clone base-group \
         meta interleave="true"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>exit</command>でcrmshを終了し、変更内容をコミットします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ化されたボリュームグループ (VG) を作成します。
 
@@ -163,45 +167,45 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> -cy vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ミラーログの論理ボリューム (LV) をクラスタ内に作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> -nlv -m1 -l10%VG vg --mirrorlog mirrored</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>lvs</command>を使用して進捗状況を表示します。パーセンテージの数値が100%に到達したら、ミラーディスクは正しく同期化されたということです。
      </para>
     </step>
-    <step id="st-ha-clvm-config-cmirrord-test" performance="required">
+    <step xml:id="st-ha-clvm-config-cmirrord-test">
      <para>
       クラスタ化されたボリューム<filename>/dev/vg/lv</filename>をテストするには、次の手順に従います。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <filename>/dev/vg/lv</filename>を読み込むか、ここに書き込みます。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <command>lvchange</command> <option>-an</option>でLVを非アクティブ化します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <command>lvchange</command> <option>-ay</option>でLVをアクティブ化します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <command>lvconvert</command>を使用してミラーログをディスクログに変換します。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       別のクラスタVGにミラーログのLVを作成します。これは前のものとは別のボリュームグループです。
      </para>
@@ -216,20 +220,20 @@ Please see LICENSE.txt for this document's license.
    </para>
    <procedure>
 
-    <step performance="required">
+    <step>
      <para>
       ボリュームグループ (VG) を作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ファイル<filename>/etc/lvm/lvm.conf</filename>を開き、<literal>allocation</literal>セクションに移動します。次の行を設定して、ファイルを保存します。
      </para>
 <screen>mirror_legs_require_separate_pvs = 1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       PVにタグを追加します。
      </para>
@@ -239,7 +243,7 @@ Please see LICENSE.txt for this document's license.
       タグは、ストレージオブジェクトのメタデータに割り当てられる順序付けのないキーワードまたは用語です。タグを使用すると、順序付けのないタグのリストをLVMストレージオブジェクトのメタデータに添付することによって、それらのオブジェクトのコレクションを有用になるように分類できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       タグを一覧します。
      </para>
@@ -253,11 +257,11 @@ Please see LICENSE.txt for this document's license.
     </step>
    </procedure>
    <para>
-    LVMに関する詳細情報が必要な場合は、『SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>ストレージ管理ガイド</citetitle>』の「<citetitle/>LVM設定」の章を参照してください。<ulink url="http://www.suse.com/documentation/"/>から入手できます。
+    LVMに関する詳細情報が必要な場合は、『SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>ストレージ管理ガイド</citetitle>』の「<citetitle/>LVM設定」の章を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-config-resources">
+  <section xml:id="sec-ha-clvm-config-resources">
    <title>クラスタリソースの作成</title>
    <para>
     cLVMを使用するためのクラスタ準備には次の基本的な手順が含まれます。
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-clvm-dlmresource">
+   <procedure xml:id="pro-ha-clvm-dlmresource">
     <title>DLMリソースを作成する</title>
 
     <note>
@@ -283,22 +287,22 @@ Please see LICENSE.txt for this document's license.
        cLVMおよびOCFS2は両方とも、クラスタ内のすべてのノード上で実行するDLMリソースを必要とするため、通常はクローンとして設定されます。OCFS2およびcLVMの両方を含むセットアップがある場合、OCFS2およびcLVMの両方に<emphasis>1つの</emphasis>DLMリソースを設定することで十分です。
      </para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       シェルを起動して、<systemitem class="username">root</systemitem>としてログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      <command>crm <option>configure</option></command>を実行します。
+      <command>crm</command> <option>configure</option>を実行します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>show</command>でクラスタリソースの現在の設定を確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すでにDLMリソース(および対応するベースグループおよびベースクローン)を設定済みである場合、<xref linkend="pro-ha-clvm-lvmresources"/>で継続します。
      </para>
@@ -306,25 +310,25 @@ Please see LICENSE.txt for this document's license.
       そうでない場合は、<xref linkend="pro-ocfs2-resources"/>で説明されているように、DLMリソース、および対応するベースグループとベースクローンを設定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       crmライブ設定を<command>exit</command>で終了します。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-clvm-lvmresources">
+   <procedure xml:id="pro-ha-clvm-lvmresources">
     <title>LVMおよびcLVMリソースの作成</title>
-    <step performance="required">
+    <step>
      <para>
       シェルを起動して、<systemitem class="username">root</systemitem>としてログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      <command>crm <option>configure</option></command>を実行します。
+      <command>crm</command> <option>configure</option>を実行します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のとおり、cLVMリソースを設定します。
      </para>
@@ -333,7 +337,7 @@ Please see LICENSE.txt for this document's license.
 
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のとおり、ボリュームグループのLVMリソースを設定します。
      </para>
@@ -341,7 +345,7 @@ Please see LICENSE.txt for this document's license.
       params volgrpname="cluster-vg" \
       op monitor interval="60" timeout="60"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ボリュームグループを<emphasis>1つ</emphasis>のノード上で単独にアクティブ化する場合、以下で説明されるようにLVMリソースを設定し、<xref linkend="step-ha-clvm-lvmresources-group"/>を省略します。
      </para>
@@ -352,18 +356,18 @@ Please see LICENSE.txt for this document's license.
       この場合、cLVMは、非クラスタ化アプリケーション用の追加保護手段として、VG内のすべての論理ボリュームが複数のノード上でアクティブ化されないよう保護します。
      </para>
     </step>
-    <step id="step-ha-clvm-lvmresources-group" performance="required">
+    <step xml:id="step-ha-clvm-lvmresources-group">
      <para>
       cLVMおよびLVMリソースがクラスタ全体でアクティブ化されていることを確認するには、<xref linkend="pro-ocfs2-resources"/>で作成したベースグループに両方のプリミティブを追加します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         入力
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>edit</command> base-group</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         Viエディタが開いたら、そこに次のようにグループを変更し、変更を保存します。
        </para>
@@ -377,25 +381,25 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>show</command>で変更内容をレビューします。必要なリソースをすべて設定したことを確認するには、<xref linkend="cha-ha-config-example"/>も参照してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべて正しければ、<command>commit</command>で変更を送信し、<command>exit</command>でcrmライブ設定を終了します。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-scenario-iscsi">
+  <section xml:id="sec-ha-clvm-scenario-iscsi">
    <title>シナリオ - SAN上でiSCSIを使用するｃLVM</title>
    <para>
     次のシナリオでは、iSCSIターゲットをいくつかのクライアントにエクスポートする2つのSANボックスを使用します。一般的なアイデアが、<xref linkend="fig-ha-clvm-scenario-iscsi"/>で説明されています。
    </para>
-   <figure id="fig-ha-clvm-scenario-iscsi">
+   <figure xml:id="fig-ha-clvm-scenario-iscsi">
     <title>ｃLVMによるiSCSIのセットアップ</title>
     <mediaobject>
      <imageobject role="fo">
@@ -416,80 +420,80 @@ Please see LICENSE.txt for this document's license.
     まず、1つのSANボックスだけ設定します。各SANボックスは、そのiSCSIターゲットをエクスポートする必要があります。次の手順に従います。
    </para>
 
-   <procedure id="pro-ha-clvm-scenario-iscsi-targets">
+   <procedure xml:id="pro-ha-clvm-scenario-iscsi-targets">
     <title>iSCSIターゲット(SAN上)を設定する</title>
-    <step performance="required">
+    <step>
      <para>
       YaSTを実行し、<menuchoice><guimenu>ネットワークサービス</guimenu><guimenu>iSCSIターゲット</guimenu></menuchoice>の順にクリックしてiSCSIサーバモジュールを起動します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       コンピュータがブートするたびにiSCSIターゲットを起動したい場合は、<guimenu>ブート時</guimenu>を選択し、そうでない場合は、<guimenu>手動</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ファイアウォールが実行中の場合は、<guimenu>ファイアウォールでポートを開く</guimenu>を有効にします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>グローバル</guimenu>タブに切り替えます。認証が必要な場合は、受信または送信(あるいはその両方の)認証を有効にします。この例では、<guimenu>認証なし</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しいiSCSIターゲットを追加します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <guimenu>ターゲット</guimenu>タブに切り替えます。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>追加</guimenu>をクリックします。
        </para>
       </step>
-      <step id="st-ha-clvm-iscsi-iqn" performance="required">
+      <step xml:id="st-ha-clvm-iscsi-iqn">
        <para>
         ターゲットの名前を入力します。名前は、次のようにフォーマットされます。
        </para>
 <screen>iqn.<replaceable>DATE</replaceable>.<replaceable>DOMAIN</replaceable></screen>
        <para>
-        フォーマットに関する詳細は、セクション3.2.6.3.1のタイプ「iqn」<citetitle/>(iSCSI修飾名)(<ulink url="http://www.ietf.org/rfc/rfc3720.txt"/>)を参照してください。
+        フォーマットに関する詳細は、セクション3.2.6.3.1のタイプ「iqn」<citetitle/>(iSCSI修飾名)(<link xlink:href="http://www.ietf.org/rfc/rfc3720.txt"/>)を参照してください。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         より説明的な名前にしたい場合は、さまざまなターゲットで一意であれば、識別子を変更できます。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>追加</guimenu>をクリックします。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>パス</guimenu>にデバイス名を入力し、<guimenu>Scsiid</guimenu>を使用します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>次へ</guimenu>を2回クリックします。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       警告ボックスで<guimenu>はい</guimenu>を選択して確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       環境設定ファイル<filename>/etc/iscsi/iscsi.conf</filename>を開き、パラメータ<literal>node.startup</literal>を<literal>automatic</literal>に変更します。
      </para>
@@ -498,71 +502,71 @@ Please see LICENSE.txt for this document's license.
    <para>
     次の手順に従って、iSCSIイニシエータを設定します。
    </para>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-initiator">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-initiator">
     <title>iSCSIイニシエータを設定する</title>
-    <step performance="required">
+    <step>
      <para>
       YaSTを実行し、<menuchoice><guimenu>ネットワークサービス</guimenu><guimenu>iSCSIイニシエータ</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       コンピュータがブートするたびに、iSCSIイニシエータを起動したい場合は、<guimenu>ブート時</guimenu>を選択し、そうでない場合は、<guimenu>手動</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>検出</guimenu>タブに切り替え、<guimenu>検出</guimenu>ボタンをクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       自分のIPアドレスとiSCSIターゲットのポートを追加します(<xref linkend="pro-ha-clvm-scenario-iscsi-targets"/>参照)。通常は、ポートを既定のままにし、デフォルト値を使用できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       認証を使用する場合は、受信および送信用のユーザ名およびパスワードを挿入します。そうでない場合は、<guimenu>認証なし</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>次へ</guimenu>を選択します。検出された接続が一覧されます。
      </para>
     </step>
     
-    <step performance="required">
+    <step>
      <para>iSCSIイニシエータが正常に起動しているかかどうかをテストするには、表示されたターゲットのいずれかを選択して<guimenu>ログイン</guimenu>をクリックします。</para>
     </step>
 
    </procedure>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-lvm">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-lvm">
     <title>LVMボリュームグループを作成する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-clvm-scenarios-iscsi-initiator"/>のiSCSIイニシエータを実行したノードの1つで、<systemitem class="username">root</systemitem>シェルを開きます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ディスク<filename>/dev/sdd</filename>および<filename>/dev/sde</filename>でコマンド<command>pvcreate</command>を使用して、LVM用に物理ボリュームを準備します。
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sdd
 <prompt role="root">root # </prompt><command>pvcreate</command> /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       両方のディスク上でクラスタ対応のボリュームグループを作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y clustervg /dev/sdd /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要に応じて、論理ボリュームを作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> --name clusterlv --size 500M clustervg</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       物理ボリュームを<command>pvdisplay</command>で確認します。
      </para>
@@ -588,7 +592,7 @@ Please see LICENSE.txt for this document's license.
       Allocated PE          0
       PV UUID               Ouj3Xm-AI58-lxB1-mWm2-xn51-agM2-0UuHFC</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ボリュームグループを<command>vgdisplay</command>で確認します。
      </para>
@@ -621,28 +625,28 @@ Please see LICENSE.txt for this document's license.
    </para>
 
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-clvm-scenario-drbd">
+  <section xml:id="sec-ha-clvm-scenario-drbd">
    <title>シナリオ - DRBDを使用するｃLVM</title>
    <para>
     市、国、または大陸の各所にデータセンターが分散している場合は、次のシナリオを使用できます。
    </para>
-   <procedure id="pro-ha-clvm-withdrbd">
+   <procedure xml:id="pro-ha-clvm-withdrbd">
     <title>DRBDでクラスタ対応ボリュームグループを作成する</title>
-    <step performance="required">
+    <step>
      <para>
       プライマリ/プライマリDRBDリソースを作成する
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         まず、<xref linkend="step-drbd-configure"/>の説明に従って、DRBDデバイスをプライマリ/セカンダリとしてセットアップします。ディスクの状態が両方のノードで<literal>up-to-date</literal>であることを確認します。これは、<command>cat</command> <option>/proc/drbd</option>または<command>rcdrbd</command> <option>status</option>で確認します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         次のオプションを環境設定ファイル(通常は、<filename>/etc/drbd.d/r0.res</filename>)に追加します。
        </para>
@@ -657,13 +661,13 @@ Please see LICENSE.txt for this document's license.
   ...
 }</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         変更した設定ファイルをもう一方のノードにコピーします。たとえば、次のように指定します。
        </para>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.d/r0.res venus:/etc/drbd.d/</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <emphasis>両方</emphasis>のノードで、次のコマンドを実行します。
        </para>
@@ -671,7 +675,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="root">root # </prompt><command>drbdadm</command> connect r0
 <prompt role="root">root # </prompt><command>drbdadm</command> primary r0</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         ノードのステータスをチェックします。
        </para>
@@ -681,24 +685,24 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       clvmdリソースをペースメーカーの環境設定でクローンとして保存し、DLMクローンリソースに依存させます。詳細については、<xref linkend="pro-ha-clvm-dlmresource"/>を参照してください。次に進む前に、クラスタでこれらのリソースが正しく機動していることを確認してください。<command>crm_mon</command>またはWebインタフェースを使用して、実行中のサービスを確認できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>pvcreate</command>コマンドで、LVM用に物理ボリュームを準備します。たとえば、<filename>/dev/drbd_r0</filename>デバイスでは、コマンドは次のようになります。
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ対応のボリュームグループを作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y myclusterfs /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要に応じて、論理ボリュームを作成します。論理ボリュームのサイズは変更できます。たとえば、次のコマンドで、4GBの論理ボリュームを作成します。
      </para>
@@ -706,7 +710,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       
       VG内の論理ボリュームは、ファイルシステムのマウントまたはraw用として使用できるようになりました。論理ボリュームを使用しているサービスにコロケーションのための正しい依存性があることを確認し、VGをアクティブ化したら論理ボリュームの順序付けを行います。
@@ -716,9 +720,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     このような設定手順を終了すると、LVM2の環境設定は他のスタンドアロンワークステーションと同様に行えます。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-clvm-drbd">
+  </section>
+ </section>
+ <section xml:id="sec-ha-clvm-drbd">
   <title>有効なLVM2デバイスの明示的な設定</title>
 
   <para>
@@ -734,17 +738,17 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      ファイル<filename>/etc/lvm/lvm.conf</filename>を編集し、<literal>filter</literal>から始まる行を検索します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      そこに記載されているパターンは正規表現として処理されます。冒頭の<quote>a</quote>は走査にデバイスパターンを受け入れることを、冒頭の<quote>r</quote>はそのデバイスパターンのデバイスを拒否することを意味します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <filename>/dev/sdb1</filename>という名前のデバイスを削除するには、次の表現をフィルタルールに追加します。
     </para>
@@ -759,22 +763,22 @@ Please see LICENSE.txt for this document's license.
 <screen>filter = [ "a|/dev/drbd.*|", "a|/dev/.*/by-id/dm-uuid-mpath-.*|", "r/.*/" ]</screen>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      環境設定ファイルを書き込み、すべてのクラスタノードにコピーします。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-clvm-more">
+ </section>
+ <section xml:id="sec-ha-clvm-more">
   <title>詳細</title>
 
   <para>
-   詳細な情報は、<ulink url="http://www.clusterlabs.org/wiki/Help:Contents"/>にあるPacemakerメーリングリストから取得できます。
+   詳細な情報は、<link xlink:href="http://www.clusterlabs.org/wiki/Help:Contents"/>にあるPacemakerメーリングリストから取得できます。
   </para>
 
   <para>
-   cLVMのFAQのオフィシャルサイトは<ulink url="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/>です。
+   cLVMのFAQのオフィシャルサイトは<link xlink:href="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/>です。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_concepts.xml
+++ b/ja/xml/ha_concepts.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_concepts.xml" id="cha-ha-concepts">
- <title>製品の概要</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_concepts.xml" xml:id="cha-ha-concepts"><title>製品の概要</title><info><abstract>
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>は、オープンソースクラスタ化技術の統合スイートで、可用性の高い物理Linuxクラスタと仮想Linuxクラスタを実装し、SPOF (シングルポイント障害)をなくします。データ、アプリケーション、サービスなどの重要なネットワークリソースの高度な可用性と管理のしやすさを実現します。その結果、ミッションクリティカルなLinuxワークロードに対してビジネスの継続性維持、データ整合性の保護、予期せぬダウンタイムの削減を行います。
   </para>
@@ -23,21 +25,23 @@ Please see LICENSE.txt for this document's license.
   <para>
    High Availabilityクラスタのコンテキストでよく使用される用語については、<xref linkend="gl-heartb"/>を参照してください。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-availability">
+ 
+ 
+ <section xml:id="sec-ha-availability">
   <title>アドオン/拡張としての可用性</title>
   <para>High Availability Extensionは、SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>に対するアドオンとして入手できます。Geo Clustering for SUSE Linux Enterprise High Availability Extensionという、High Availability Extensionの個別の拡張として、地理的に離れたクラスタ(Geoクラスタ)に対するサポートが提供されています。 </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-features">
+ <section xml:id="sec-ha-features">
   <title>主な機能</title>
 
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>では、ネットワークリソースの可用性を確保し、管理することができます。以降のセクションでは、いくつかの主要機能に焦点を合わせて説明します。
   </para>
 
-  <sect2 id="sec-ha-features-scenarios">
+  <section xml:id="sec-ha-features-scenarios">
    <title>広範なクラスタリングシナリオ</title>
    <para>
     High Availability Extensionは次のシナリオをサポートしています。
@@ -77,30 +81,30 @@ Please see LICENSE.txt for this document's license.
    <para>
     クラスタには、最大32のLinuxサーバを含めることができます。クラスタ内のどのサーバも、クラスタ内の障害が発生したサーバのリソース(アプリケーション、サービス、IPアドレス、およびファイルシステム)を再起動することができます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-flexibility">
+  <section xml:id="sec-ha-features-flexibility">
    <title>柔軟性</title>
    <para>
     High Availability Extensionには、Corosync/OpenAISメッセージングおよびメンバーシップ層のほか、Pacemakerクラスタリソースマネージャが標準装備されています。Pacemakerの使用によって、管理者は継続的にリソースのヘルスとステータスを監視し、依存関係を管理し、柔軟に設定できるルールとポリシーに基づいてサービスを自動的に開始および停止できます。High Availability Extensionでは、ユーザの組織に適した特定のアプリケーションおよびハードウェアインフラストラクチャに合わせて、クラスタのカスタマイズが可能です。時間依存設定を使用して、サービスを特定の時刻に修復済みのノードに自動的にフェールバック(マイグレート)させることができます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-storage">
+  <section xml:id="sec-ha-features-storage">
    <title>ストレージとデータレプリケーション</title>
    <para>
     High Availability Extensionでは必要に応じてサーバストレージを自動的に割り当て、再割り当てすることができます。ファイバチャネルまたはiSCSIストレージエリアネットワーク(SAN)をサポートしています。共有ディスクもサポートされていますが、必要要件ではありません。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>には、クラスタ対応のファイルシステムとボリュームマネージャ(OCFS2)、cLVM (clustered Logical Volume Manager)も含まれています。データのレプリケーションでは、DRBD*を使用して、High Availabilityサービスのデータをクラスタのアクティブノードからスタンバイノードへミラーリングできます。さらに、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>では、Sambaクラスタリング技術であるCTDB (Clustered Trivial Database)もサポートしています。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-virtualized">
+  <section xml:id="sec-ha-features-virtualized">
    <title>仮想化環境のサポート</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>は、物理Linuxサーバと仮想Linuxサーバの混合クラスタリングをサポートしています。SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>は、オープンソース仮想化ハイパーバイザであるXenと、ハードウェア仮想化拡張機能に基づく、Linuxの仮想化ソフトウェアであるKVM (Kernel-based Virtual Machine)を標準装備しています。High Availability Extension内のクラスタリソースマネージャは、仮想サーバで実行中のサービスと物理サーバで実行中のサービスを認識、監視、および管理できます。ゲストシステムは、クラスタにサービスとして管理されます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-geo">
+  <section xml:id="sec-ha-features-geo">
    <title>ローカル、メトロ、およびGeoクラスタのサポート</title>
    <para> <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>は、様々な地理的なシナリオをサポートするように拡張されています。Geo Clustering for SUSE Linux Enterprise High Availability Extensionという、High Availability Extensionの個別の拡張として、地理的に離れたクラスタ(Geoクラスタ)に対するサポートが提供されています。 </para>
    <variablelist>
@@ -132,16 +136,16 @@ Please see LICENSE.txt for this document's license.
    <para>
     個々のクラスタノード間の地理的距離が大きいほど、クラスタが提供するサービスの高可用性を妨げる可能性のある要因が多くなります。ネットワークの遅延時間、限られた帯域幅およびストレージへのアクセス が長距離クラスタの課題として残ります。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-ra">
+  <section xml:id="sec-ha-features-ra">
    <title>リソースエージェント</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>には、Apache、IPv4、IPv6、その他多数のリソースを管理するための膨大な数のリソースエージェントが含まれています。またIBM WebSphere Application Serverなどの一般的なサードパーティアプリケーション用のリソースエージェントも含まれています。ご利用の製品に含まれているOpen Cluster Framework (OCF)リソースエージェントの概要は、<xref linkend="sec-ha-manual-config-ocf"/>で説明される<command>crm ra</command>コマンドを使用してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-tools">
+  <section xml:id="sec-ha-features-tools">
    <title>ユーザフレンドリな管理ツール</title>
    <para>
     High Availability Extensionは、クラスタの基本的なインストールとセットアップのほか、効果的な設定および管理に使用できる強力なツールセットを標準装備しています。
@@ -198,9 +202,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-benefits">
+  </section>
+ </section>
+ <section xml:id="sec-ha-benefits">
   <title>利点</title>
 
   <para>
@@ -358,8 +362,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    たとえば、WebサイトAまたはWebサイトBをWebサーバ1からクラスタ内の他のサーバに手動で移動することができます。これは、Webサーバ1のアップグレードや定期メンテナンスを実施する場合、また、Webサイトのパフォーマンスやアクセスを向上させる場合に有効な機能です。
   </para>
- </sect1>
- <sect1 id="sec-ha-clusterconfig">
+ </section>
+ <section xml:id="sec-ha-clusterconfig">
   <title>クラスタ設定: ストレージ</title>
 
   <para>
@@ -420,20 +424,20 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect1>
- <sect1 id="sec-ha-architecture">
+ </section>
+ <section xml:id="sec-ha-architecture">
   <title>アーキテクチャ</title>
 
   <para>
    このセクションでは、High Availability Extensionアーキテクチャの概要を説明します。アーキテクチャコンポーネントと、その相互運用方法について説明します。
   </para>
 
-  <sect2 id="sec-ha-architecture-layers">
+  <section xml:id="sec-ha-architecture-layers">
    <title>アーキテクチャ層</title>
    <para>
     High Availability Extensionのアーキテクチャは層化されています。<xref linkend="fig-ha-architecture" xrefstyle="FigureXRef"/>に異なる層と関連するコンポーネントを示します。
    </para>
-   <figure id="fig-ha-architecture">
+   <figure xml:id="fig-ha-architecture">
     <title>アーキテクチャ</title>
     <mediaobject>
      <imageobject role="fo">
@@ -444,19 +448,19 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-   <sect3 id="sec-ha-architecture-layers-messaging">
+   <section xml:id="sec-ha-architecture-layers-messaging">
     <title>メッセージングおよびインフラストラクチャ層</title>
     <para>
      プライマリまたは最初の層は、メッセージングおよびインフラストラクチャの層で、Corosync/OpenAIS層とも呼ばれます。この層には、<quote>I'm alive</quote>信号やその他の情報を含むメッセージを送信するコンポーネントが含まれます。High Availability Extensionのプログラムはメッセージングおよびインフラストラクチャ層に常駐しています。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-allocation">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-allocation">
     <title>リソース割り当て層</title>
     <para>
      次の層はリソース割り当て層です。この層は最も複雑で、次のコンポーネントから設定されていいます。
     </para>
     <variablelist>
-     <varlistentry id="vle-crm">
+     <varlistentry xml:id="vle-crm">
       <term>CRM (クラスターリソースマネージャ)</term>
       <listitem>
        <para>
@@ -464,7 +468,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-cib">
+     <varlistentry xml:id="vle-cib">
       <term>CIB (クラスタ情報ベース)</term>
       <listitem>
        <para>
@@ -472,7 +476,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-dc">
+     <varlistentry xml:id="vle-dc">
       <term>指定コーディネータ(DC)</term>
       <listitem>
        <para>
@@ -480,7 +484,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-pe-and-te">
+     <varlistentry xml:id="vle-pe-and-te">
       <term>PE (ポリシーエンジン)</term>
       <listitem>
        <para>
@@ -488,7 +492,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-lrm">
+     <varlistentry xml:id="vle-lrm">
       <term>LRM(ローカルリソースマネージャ)</term>
       <listitem>
        <para>
@@ -498,16 +502,16 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-resources">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-resources">
     <title>リソース層</title>
     <para>
      最も上位の層はリソース層です。リソース層には1つ以上のリソースエージェント(RA)が含まれます。リソースエージェントは、一定の種類のサービス(リソース)を開始、停止、監視するために作成されたプログラム(通常はシェルスクリプト)です。リソースエージェントの呼び出しはLRMだけが行います。サードパーティはファイルシステム内の定義された場所に独自のエージェントを配置して、自社ソフトウェア用に、すぐに使えるクラスタ統合機能を提供することができます。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-architecture-processflow">
+  <section xml:id="sec-ha-architecture-processflow">
    <title>プロセスフロー</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>は、PacemakerをCRMとして使用します。 CRMは各クラスタノード上にインスタンスを持つデーモン(<literal>crmd</literal>)として実装されます。Pacemakerは、マスタとして動作するcrmdインスタンスを１つ選択することにより、クラスタのすべての意思決定を一元化します。選択したcrmdプロセス(またはその下のノード)で障害が発生したら、新しいcrmdプロセスが確立されます。
@@ -530,6 +534,6 @@ Please see LICENSE.txt for this document's license.
    <para>
     場合によっては、共有データの保護や完全なリソース復旧のためにノードの電源を切らなければならないことがあります。このPacemakerにはフェンシングサブシステムとしてstonithdが内蔵されています。STONITHは<quote>Shoot The Other Node In The Head</quote>(他のノードの即時強制終了)の略語で、通常はリモート電源スイッチを使用して実装されます。Pacemakerでは、STONITHデバイスは、その障害を簡単に監視できるように、リソースとしてモデル化(そしてCIB内で設定)されます。ただし、STONITHトポロジの把握はstonithdが担当し、そのクライアントはノードのフェンシングを要求するだけであり、残りの作業はstonithdが実行します。
    </para>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/ja/xml/ha_config_basics.xml
+++ b/ja/xml/ha_config_basics.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_basics.xml" id="cha-ha-config-basics">
- <title>設定および管理の基本事項</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_basics.xml" xml:id="cha-ha-config-basics"><title>設定および管理の基本事項</title><info><abstract>
   <para>
    HAクラスタの主な目的はユーザサービスの管理です。ユーザサービスの典型的な例は、Apache Webサーバまたはデータベースです。サービスとは、ユーザの観点からすると、指示に基づいて特別な何かを行うことを意味していますが、クラスタにとっては開始や停止できるリソースにすぎません。サービスの性質はクラスタには無関係なのです。
   </para>
@@ -15,18 +17,20 @@ Please see LICENSE.txt for this document's license.
   <para>
    この章では、リソースを設定しクラスタを管理する場合に知っておく必要のある基本概念を紹介します。後続の章では、High Availability Extensionが提供する各管理ツールを使用して、主要な設定および管理タスクを行う方法を説明します。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-basics-global">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-basics-global">
   <title>グローバルクラスタオプション</title>
 
   <para>
    グローバルクラスタオプションは、一定の状況下でのクラスタの動作を制御します。それらは、セットにグループ化され、Hawkや<command>crm</command>シェルなどのクラスタ管理ツールで表示したり、変更することができます。
   </para>
 
-  <sect2 id="sec-ha-config-basics-global-all">
+  <section xml:id="sec-ha-config-basics-global-all">
    <title>概要</title>
    <para>
-    すべてのグローバルクラスタオプションとそのデフォルト値の概要については、『<citetitle>Pacemaker Explained</citetitle>』(<ulink url="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Available Cluster Options</citetitle>」のセクションを参照してください。
+    すべてのグローバルクラスタオプションとそのデフォルト値の概要については、『<citetitle>Pacemaker Explained</citetitle>』(<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Available Cluster Options</citetitle>」のセクションを参照してください。
    </para>
    <para>
     事前に定義されている値は、通常は、そのまま保持できます。ただし、クラスタの主要機能を正しく機能させるには、クラスタの基本的なセットアップ後に、次のパラメータを調整する必要があります。
@@ -65,9 +69,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
-  <sect2 id="sec-ha-config-basics-global-quorum">
+  <section xml:id="sec-ha-config-basics-global-quorum">
    <title>オプション<literal>no-quorum-policy</literal></title>
    <para>
     このグローバルオプションは、クラスタパーティションにクォーラムがない(ノードの過半数がパーティションに含まれない)場合どうするかを定義します。
@@ -133,9 +137,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-global-stonith">
+  <section xml:id="sec-ha-config-basics-global-stonith">
    <title>オプション<literal>stonith-enabled</literal></title>
    <para>
     このグローバルオプションは、フェンシングを適用して、STONITHデバイスによる、障害ノードや停止できないリソースを持つノードのダウンを許可するかどうか定義します。通常のクラスタ操作には、STONITHデバイスの使用が必要なので、このグローバルオプションは、デフォルトで<literal>true</literal>に設定されています。デフォルト値では、クラスタは、STONITHリソースが定義されていない場合にはリソースの開始を拒否します。
@@ -150,16 +154,16 @@ Please see LICENSE.txt for this document's license.
      STONITHがないクラスタはサポートされません。
     </para>
    </important>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-resources">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-resources">
   <title>クラスタリソース</title>
 
   <para>
    クラスタの管理者は、クラスタ内のサーバ上の各リソースや、サーバ上で実行する各アプリケーションに対してクラスタリソースを作成する必要があります。クラスタリソースには、Webサイト、電子メールサーバ、データベース、ファイルシステム、仮想マシン、およびユーザが常時使用できるようにする他のサーバベースのアプリケーションまたはサービスなどが含まれます。
   </para>
 
-  <sect2 id="sec-ha-config-basics-resources-management">
+  <section xml:id="sec-ha-config-basics-resources-management">
    <title>リソース管理</title>
 
    <para>
@@ -197,9 +201,9 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-raclasses">
+  <section xml:id="sec-ha-config-basics-raclasses">
    <title>サポートされるリソースエージェントクラス</title>
    <para>
     追加するクラスタリソースごとに、リソースエージェントが準拠する基準を定義する必要があります。リソースエージェントは、提供するサービスを抽象化して正確なステータスをクラスタに渡すので、クラスタは管理するリソースについてコミットする必要がありません。クラスタは、リソースエージェントに依存して、start、stop、またはmonitorのコマンドの発行に適宜対応します。
@@ -212,18 +216,18 @@ Please see LICENSE.txt for this document's license.
      <term>Linux Standards Base (LSB)スクリプト</term>
      <listitem>
       <para>
-       LSBリソースエージェントは一般にオペレーティングシステム/配布パッケージによって提供され、<filename>/etc/init.d</filename>にあります。リソースエージェントをクラスタで使用するには、それらのエージェントがLSB iniスクリプトの仕様に準拠している必要があります。たとえば、リソースエージェントには、いくつかのアクションが実装されている必要があります。それらのアクションとして、少なくとも<literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal>、<literal>status</literal>があります。詳細については、<ulink url="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>を参照してください。
+       LSBリソースエージェントは一般にオペレーティングシステム/配布パッケージによって提供され、<filename>/etc/init.d</filename>にあります。リソースエージェントをクラスタで使用するには、それらのエージェントがLSB iniスクリプトの仕様に準拠している必要があります。たとえば、リソースエージェントには、いくつかのアクションが実装されている必要があります。それらのアクションとして、少なくとも<literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal>、<literal>status</literal>があります。詳細については、<link xlink:href="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>を参照してください。
       </para>
       <para>
        これらのサービスの構成は標準化されていません。High AvailabilityでLSBスクリプトを使用する場合は、該当のスクリプトの設定方法を理解する必要があります。これに関する情報は、多くの場合、<filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>内の該当パッケージのマニュアルに記載されています。
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-resources-ocf-ra">
+    <varlistentry xml:id="vle-ha-resources-ocf-ra">
      <term>Open Cluster Framework (OCF)リソースエージェント</term>
      <listitem>
       <para>
-       OCF RAエージェントは、High Availabilityでの使用に最適であり、特に、マルチステートリソースまたは特殊なモニタリング機能を必要とする場合に適しています。それらのエージェントは、通常、<filename>/usr/lib/ocf/resource.d/<replaceable>provider</replaceable></filename>にあります。この機能はLSBスクリプトの機能と同様です。ただし、環境設定では、常に、パラメータの受け入れと処理を容易にする環境変数が使用されます。OCF仕様は<ulink url="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/>で参照できます(リソースエージェントに関連するため)。OCF仕様には、アクション終了コードの厳密な定義があります。<xref linkend="sec-ha-errorcodes"/>を参照してください。クラスタは、それらの仕様に正確に準拠します。 
+       OCF RAエージェントは、High Availabilityでの使用に最適であり、特に、マルチステートリソースまたは特殊なモニタリング機能を必要とする場合に適しています。それらのエージェントは、通常、<filename>/usr/lib/ocf/resource.d/<replaceable>provider</replaceable></filename>にあります。この機能はLSBスクリプトの機能と同様です。ただし、環境設定では、常に、パラメータの受け入れと処理を容易にする環境変数が使用されます。OCF仕様は<link xlink:href="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/>で参照できます(リソースエージェントに関連するため)。OCF仕様には、アクション終了コードの厳密な定義があります。<xref linkend="sec-ha-errorcodes"/>を参照してください。クラスタは、それらの仕様に正確に準拠します。 
       </para>
 
 
@@ -251,9 +255,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     High Availability Extensionで提供されるエージェントは、OCF仕様に従って作成されています。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-types">
+  <section xml:id="sec-ha-config-basics-resources-types">
    <title>リソースのタイプ</title>
    <para>
     次のリソースタイプを作成できます。
@@ -312,9 +316,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-templates">
+  <section xml:id="sec-ha-config-basics-resources-templates">
    <title>リソーステンプレート</title>
    <para>
     類似した設定のリソースを多く作成する最も簡単な方法は、リソーステンプレートを定義することです。定義された後でテンプレートは、プリミティブ内で参照したり、<xref linkend="sec-ha-config-basics-constraints-templates"/>で説明するように、特定のタイプの制約内で参照することができます。
@@ -338,19 +342,19 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-advanced">
+  <section xml:id="sec-ha-config-basics-resources-advanced">
    <title>高度なリソースタイプ</title>
    <para>
     プリミティブは、最も単純なタイプのリソースなので、設定が容易ですが、クラスタ設定には、より高度なリソースタイプ(グループ、クローン、マルチステートリソースなど)が必要になることがあります。
    </para>
-   <sect3 id="sec-ha-config-basics-resources-advanced-groups">
+   <section xml:id="sec-ha-config-basics-resources-advanced-groups">
     <title>グループ</title>
     <para>
      クラスタリソースの中には、他のコンポーネントやリソースに依存しているものもあります。それぞれのコンポーネントやリソースが決められた順序で開始され、依存しているリソースと同じサーバ上で同時に実行していなければならない場合があります。この設定を簡素化するには、クラスタリソースグループを使用できます。
     </para>
-    <example id="ex-ha-config-resource-group">
+    <example xml:id="ex-ha-config-resource-group">
      <title>Webサーバのリソースグループ</title>
      <para>
       リソースグループの1例として、IPアドレスとファイルシステムを必要とするWebサーバがあります。この場合、各コンポーネントは、個々のリソースであり、それらが組み合わされてクラスタリソースグループを構成します。リソースグループは、1つ以上のサーバで実行されます。ソフトウェアまたはハードウェアが機能しない場合には、個々のクラスタリソースと同様に、グループはクラスタ内の別のサーバにフェールオーバーします。
@@ -442,8 +446,8 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-clones">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-clones">
     <title>クローン</title>
     <para>
      クラスタ内の複数のノードで特定のリソースを同時に実行することができます。このためには、リソースをクローンとして設定する必要があります。クローンとして設定するリソースの1例として、STONITHや、OCFS2などのクラスタファイルシステムが挙げられます。提供されているどのリソースも、クローンとして設定できます。これは、リソースのリソースエージェントによってサポートされます。クローンリソースは、ホスティングされているノードによって異なる設定をすることもできます。
@@ -481,7 +485,7 @@ Please see LICENSE.txt for this document's license.
      クローンは、グループまたは通常リソースを1つだけ含む必要があります。
     </para>
     <para>
-     リソースのモニタリングまたは制約を設定する場合、クローンには、単純なリソースとは異なる要件があります。詳細については、『<citetitle>Pacemaker Explained</citetitle>』(<ulink url="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Clones - Resources That Get Active on Multiple Hosts</citetitle>」のセクションを参照してください。
+     リソースのモニタリングまたは制約を設定する場合、クローンには、単純なリソースとは異なる要件があります。詳細については、『<citetitle>Pacemaker Explained</citetitle>』(<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Clones - Resources That Get Active on Multiple Hosts</citetitle>」のセクションを参照してください。
     </para>
     <para>
      選択したクラスタ管理ツールでクローンを作成する方法については、次を参照してください。
@@ -503,24 +507,24 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-masters">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-masters">
     <title>マルチステートリソース</title>
     <para>
      マルチステートリソースは、クローンが得意とするところです。これにより、インスタンスを2つの動作モード(<literal>master</literal>または<literal>slave</literal>と呼ばれているが、任意の名前を割り当てることができる)のいずれかに設定できます。マルチステートリソースは、グループまたは通常リソースを1つだけ含む必要があります。
     </para>
     <para>
-     リソースの監視または制約を設定する場合、マルチステートリソースには、単純なリソースとは異なる要件があります。詳細については、『<citetitle>Pacemaker Explained</citetitle>』(<ulink url="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Multi-state - Resources That Have Multiple Modes</citetitle>」のセクションを参照してください。
+     リソースの監視または制約を設定する場合、マルチステートリソースには、単純なリソースとは異なる要件があります。詳細については、『<citetitle>Pacemaker Explained</citetitle>』(<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手可)を参照してください。特に、「<citetitle>Multi-state - Resources That Have Multiple Modes</citetitle>」のセクションを参照してください。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-meta-attr">
+  <section xml:id="sec-ha-config-basics-meta-attr">
    <title>リソースオプション(メタ属性)</title>
    <para>
     追加した各リソースについて、オプションを定義できます。クラスタはオプションを使用して、リソースの動作方法を決定します。CRMに特定のリソースの処理方法を通知します。リソースオプションは、<command>crm_resource --meta</command>コマンドまたはPacemaker GUIを使用して設定できます(<xref linkend="pro-ha-config-gui-parameters"/>参照)。または、Hawkを使用してください(<xref linkend="pro-ha-config-hawk-primitives"/>参照)。
    </para>
-   <table id="tab-ha-basics-meta">
+   <table xml:id="tab-ha-basics-meta">
     <title>プリミティブリソースのオプション</title>
     <tgroup cols="3">
      <thead>
@@ -775,9 +779,9 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-inst-attr">
+  <section xml:id="sec-ha-config-basics-inst-attr">
    <title>インスタンス属性(パラメータ)</title>
 
 
@@ -869,9 +873,9 @@ monitor_0     interval=5s timeout=20s</screen>
      グループ、クローン、およびマルチステートリソースには、インスタンス属性がないので注意してください。ただし、インスタンス属性のセットは、グループ、クローン、またはマルチステートリソースの子によって継承されます。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-operations">
+  <section xml:id="sec-ha-config-basics-operations">
    <title>リソース操作</title>
    <para>
     デフォルトで、クラスタはリソースが良好な状態であることを保証しません。クラスタにこれを行わせるには、リソースの定義に監視操作を追加する必要があります。監視操作は、すべてのクラスまたはリソースエージェントに追加できます。詳細については、<xref linkend="sec-ha-config-basics-monitoring"/>を参照してください。
@@ -1050,9 +1054,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-timeouts">
+  <section xml:id="sec-ha-config-basics-timeouts">
    <title>タイムアウト値</title>
    <para>
     リソースのタイムアウト値は次の3つのパラメータの影響を受けることがあります。
@@ -1112,38 +1116,38 @@ monitor_0     interval=5s timeout=20s</screen>
    </para>
    <procedure>
     <title>タイムアウト値の決定</title>
-    <step performance="required">
+    <step>
      <para>
       負荷の下でリソースが開始および停止するためにかかる時間を確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要に応じて <varname>op_defaults</varname> パラメータを追加し、それに応じて(デフォルト)タイムアウト値を設定します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         たとえば、<literal>op_defaults</literal>を<literal>60</literal>秒に設定します。
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt> op_defaults timeout=60</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         さらに長い時間を必要とするリソースについては、個別の値を定義します。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       あるリソースに対して操作を設定する場合には、個別の<literal>start</literal>および<literal>stop</literal>操作を追加します。Hawkを使用して設定する場合、これらの操作に適したタイムアウト値候補が表示されます。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitoring">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitoring">
   <title>リソース監視</title>
 
   <para>
@@ -1211,15 +1215,15 @@ monitor_0     interval=5s timeout=20s</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-config-basics-constraints">
+ </section>
+ <section xml:id="sec-ha-config-basics-constraints">
   <title>リソースの制約</title>
 
   <para>
    すべてのリソースを設定する以外にも、多くの作業が必要です。クラスタが必要なすべてのリソースを認識しても、正しく処理できるとは限りません。リソースの制約を指定して、リソースを実行可能なクラスタノード、リソースのロード順序、特定のリソースが依存している他のリソースを指定することができます。
   </para>
 
-  <sect2 id="sec-ha-config-basics-constraints-types">
+  <section xml:id="sec-ha-config-basics-constraints-types">
    <title>制約のタイプ</title>
    <para>
     使用可能な制約には3種類あります。
@@ -1251,16 +1255,16 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-   <sect3 id="sec-ha-config-basics-constraints-rscset">
+   <section xml:id="sec-ha-config-basics-constraints-rscset">
     <title>リソースセット</title>
 
     <para/>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints">
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints">
      <title>制約を定義するためにリソースセットを使用する</title>
      <para>
       場所、コロケーション、または順序の制約を定義するための別のフォーマットとして、<literal>resource sets</literal>を使用することができます。リソースセットでは、プリミティブが1つのセットでグループ化されます。以前は、これはリソースグループを定義するか(デザインを正確に表現できない場合もあった)、個々の制約として各関係を定義することでこの操作が可能でした。個々の制約として定義した場合、多数のリソースとの組み合わせが増えるにつれて、制約が飛躍的に増加しました。リソースセットを介した設定で、冗長性が常に低減されるわけではありませんが、次の例が示すように、定義内容の把握と管理がより容易になります。
      </para>
-     <example id="ex-config-basic-resourceset-loc">
+     <example xml:id="ex-config-basic-resourceset-loc">
       <title>場所制約のリソースセット</title>
       <para>
        たとえば、crmshでリソースセット(<varname>loc-alice</varname>)の次の設定を使用して、2つの仮想IP (<varname>vip1</varname> および <varname>vip2</varname>)を同じノード、 <varname>aliceに配置できます</varname>。
@@ -1323,8 +1327,8 @@ monitor_0     interval=5s timeout=20s</screen>
      <para>
       これらのセットは、順序付けされている(<literal>sequential=true</literal>)場合もあれば、順序付けされていない場合(<literal>sequential=false</literal>)場合もあります。また、<literal>require-all</literal>属性を使用して、<literal>AND</literal>および<literal>OR</literal>ロジック間を切り替えることができます。
      </para>
-    </sect4>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints-dep">
+    </section>
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints-dep">
      <title>依存関係のないコロケーション制約のリソースセット</title>
 
      <para>
@@ -1342,9 +1346,9 @@ monitor_0     interval=5s timeout=20s</screen>
        </para>
       </listitem>
      </itemizedlist>
-    </sect4>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-constraints-more">
+    </section>
+   </section>
+   <section xml:id="sec-ha-config-basics-constraints-more">
     <title>その他の情報</title>
     <para>
      様々な種類の制約を追加する方法については、選択したクラスタ管理ツールに応じて次のいずれかを参照してください。
@@ -1362,7 +1366,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </itemizedlist>
     <para>
-     制約の設定の詳細や、順序付けおよびコロケーションの基本的な概念についての詳しいバックグラウンド情報は次のドキュメントを参照してください。これらのドキュメントは、<ulink url="http://www.clusterlabs.org/doc/"/>で入手できます。
+     制約の設定の詳細や、順序付けおよびコロケーションの基本的な概念についての詳しいバックグラウンド情報は次のドキュメントを参照してください。これらのドキュメントは、<link xlink:href="http://www.clusterlabs.org/doc/"/>で入手できます。
     </para>
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
@@ -1381,10 +1385,10 @@ monitor_0     interval=5s timeout=20s</screen>
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-scores">
+  <section xml:id="sec-ha-config-basics-constraints-scores">
    <title>スコアと無限大</title>
    <para>
     制約を定義する際は、スコアも扱う必要があります。あらゆる種類のスコアはクラスタの動作方法と密接に関連しています。スコアの操作によって、リソースのマイグレーションから、速度が低下したクラスタで停止するリソースの決定まで、あらゆる作業を実行できます。スコアはリソースごとに計算され、リソースに対して負のスコアが付けられているノードは、そのリソースを実行できません。リソースのスコアを計算した後、クラスタはスコアが最も高いノードを選択します。
@@ -1412,9 +1416,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     リソース制約を定義する際は、各制約のスコアを指定します。スコアはこのリソース制約に割り当てる値を示します。スコアの高い制約は、それよりもスコアが低い制約より先に適用されます。1つのリソースに対して場所の制約を複数作成し、それぞれに異なるスコアを指定することで、リソースがフェールオーバーするノードの順序を指定できます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-templates">
+  <section xml:id="sec-ha-config-basics-constraints-templates">
    <title>リソーステンプレートと制約</title>
    <para>
     リソーステンプレートを定義したら(<xref linkend="sec-ha-config-basics-resources-templates"/>を参照)、次のタイプの制約で参照できます。
@@ -1443,9 +1447,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     制約内で参照されたリソーステンプレートは、そのテンプレートから派生するすべてのプリミティブを表します。これは、そのリソーステンプレートを参照しているすべてのプリミティブリソースに、この制約が適用されることを意味します。制約内でリソーステンプレートを参照すれば、リソースセットの代替となり、クラスタ設定をかなりの程度単純化することができます。リソースセットの詳細については、<xref linkend="pro-ha-config-hawk-constraints-sets"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failover">
+  <section xml:id="sec-ha-config-basics-failover">
    <title>フェールオーバーノード</title>
    <para>
     リソースに障害が発生すると、自動的に再起動されます。現在のノードで再起動できない場合、または現在のノードで<literal>N</literal>回失敗した場合は、別のノードへのフェールオーバーが試行されます。リソースが失敗するたびに、その失敗回数が増加します。新しいノードへのマイグレートを行う基準(<literal>migration-threshold</literal>)となるリソースの失敗数を定義できます。クラスタ内に3つ以上ノードがある場合、特定のリソースのフェールオーバー先のノードはHigh Availabilityソフトウェアが選択します。
@@ -1473,7 +1477,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-   <example id="ex-ha-config-basics-failover">
+   <example xml:id="ex-ha-config-basics-failover">
     <title>マイグレーションしきい値 - プロセスフロー</title>
     <para>
      たとえば、リソース「<literal>rsc1</literal>」に場所の制約を設定し、このリソースを「<literal>alice</literal>」で優先的に実行するように指定したと仮定します。そのノードで実行できなかった場合は、「<literal>migration-threshold</literal>」を確認して失敗回数と比較します。失敗回数 &gt;= マイグレーションしきい値の場合は、リソースは次の優先実行先として指定されているノードにマイグレートされます。
@@ -1523,9 +1527,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failback">
+  <section xml:id="sec-ha-config-basics-failback">
    <title>フェールバックノード</title>
    <para>
     ノードがオンライン状態に戻り、クラスタ内にある場合は、リソースが元のノードにフェールバックすることがあります。リソースを実行していたノードにリソースをフェールバックさせたくない場合や、リソースのフェールバック先として別のノードを指定する場合は、リソースの<literal>resource stickiness</literal>値を変更します。リソースの固着性は、リソースの作成時でも、その後でも指定できます。
@@ -1575,9 +1579,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-utilization">
+  <section xml:id="sec-ha-config-basics-utilization">
    <title>負荷インパクトに基づくリソースの配置</title>
    <para>
     すべてのリソースが同等ではありません。Xenゲストなどの一部のリソースでは、そのホストであるノードがリソースの容量要件を満たす必要があります。リソースの組み合わされたニーズが提供された容量より大きくなるようにリソースが配置されると、リソースのパフォーマンスが低下します(あるいは失敗することさえあります)。
@@ -1696,7 +1700,7 @@ monitor_0     interval=5s timeout=20s</screen>
      使用できる配置ストラテジは、最善策であり、まだ、複雑なヒューリスティックソルバで、常に最適な割り当て結果を得るには至っていません。リソースの優先度を正しく設定して、最重要なリソースが最初にスケジュールされるようにしてください。
     </para>
    </note>
-   <example id="ex-ha-config-basics-utilization">
+   <example xml:id="ex-ha-config-basics-utilization">
     <title>負荷分散型配置の設定例</title>
     <para>
      次の例は、同等のノードから成る3ノードクラスタと4つの仮想マシンを示しています。
@@ -1724,9 +1728,9 @@ property placement-strategy="minimal"</screen>
      1つのノードに障害が発生した場合、残りのノード上で利用できるメモリ合計が少なすぎて、これらのリソースすべてはホストできません。<literal>xenA</literal>は確実に割り当てられ、<literal>xenD</literal>も同様です。ただし、残りのリソース<literal>xenB</literal>と<literal>xenC</literal>は、そのどちらかしか割り当てられません。xenBとxenCの優先度は同等なので、結果はまだ決められません。これを解決するためにも、どちらかに高い優先度を設定する必要があります。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-tags">
+  <section xml:id="sec-ha-config-basics-tags">
    <title>タグの使用によるリソースのグループ化</title>
 
    <para>
@@ -1747,9 +1751,9 @@ property placement-strategy="minimal"</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-remote">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-remote">
   <title>リモートホストでのサービスの管理</title>
 
 
@@ -1758,7 +1762,7 @@ property placement-strategy="minimal"</screen>
    リモートホストでサービスを監視および管理できることが、ここ数年の間にますます重要になってきています。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3では、監視プラグインを介したリモートホスト上のサービスの詳細な監視機能を提供してきました。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>では、最近追加された<literal>pacemaker_remote</literal>サービスを使用すると、リモートマシンにクラスタスタックをインストールしていなくても、実際のクラスタノードと同様にリモートホスト上のリソースを全面的に管理および監視できます。
   </para>
 
-  <sect2 id="sec-ha-config-basics-remote-nagios">
+  <section xml:id="sec-ha-config-basics-remote-nagios">
    <title>Nagiosプラグインを使用したリモートホストでのサービスの監視</title>
    <para>
     仮想マシンの監視はVMエージェント(ハイパーバイザにゲストが出現する場合のみチェックを行う)を使用して行うか、VirtualDomainまたはXenエージェントから呼び出される外部スクリプトによって行うことができます。これまでは、精度の高い監視を行うには、仮想マシン内にHigh Availabilityスタックを完全にセットアップするしか方法がありませんでした。
@@ -1790,7 +1794,7 @@ property placement-strategy="minimal"</screen>
    <para>
     一般的な使用例としては、1つのリソースコンテナに属するリソースとしてNagiosプラグインを設定します。このリソースコンテナは通常はVMです。いずれかのリソースに障害が発生したら、このコンテナが再起動されます。設定例については、<xref linkend="ex-ha-nagios-config"/>を参照してください。または、Nagiosリソースエージェントを使用してネットワーク経由でホストまたはサービスを監視する場合、このエージェントを通常のリソースとして設定することもできます。
    </para>
-   <example id="ex-ha-nagios-config">
+   <example xml:id="ex-ha-nagios-config">
     <title>Nagiosプラグインのリソースの設定</title>
 <screen>primitive vm1 ocf:heartbeat:VirtualDomain \
   params hypervisor="qemu:///system" config="/etc/libvirt/qemu/vm1.xml" \
@@ -1798,11 +1802,11 @@ property placement-strategy="minimal"</screen>
      op stop interval="0" timeout="90" \
      op monitor interval="10" timeout="30"
   primitive vm1-sshd nagios:check_tcp \
-     params hostname="vm1" port="22" \<co id="co-nagios-hostname"/>
-     op start interval="0" timeout="120" \<co id="co-nagios-startinterval"/>
+     params hostname="vm1" port="22" \<co xml:id="co-nagios-hostname"/>
+     op start interval="0" timeout="120" \<co xml:id="co-nagios-startinterval"/>
      op monitor interval="10"
   group g-vm1-and-services vm1 vm1-sshd \
-     meta container="vm1"<co id="co-nagios-container"/></screen>
+     meta container="vm1"<co xml:id="co-nagios-container"/></screen>
     <calloutlist>
      <callout arearefs="co-nagios-hostname">
       <para>
@@ -1836,9 +1840,9 @@ property placement-strategy="minimal"</screen>
      VMのマイグレーションしきい値を検討する場合は、サービスの障害発生回数が考慮されます。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-remote-pace-remote">
+  <section xml:id="sec-ha-config-basics-remote-pace-remote">
    <title><literal>pacemaker_remote</literal>を使用したリモートノードでのサービスの管理</title>
    <para>
     <literal>pacemaker_remote</literal>サービスを使用すると、High Availabilityクラスタを仮想ノードまたはリモートベアメタルマシンに拡張することができます。クラスタスタックを実行して、クラスタのメンバーになる必要はありません。
@@ -1887,11 +1891,11 @@ property placement-strategy="minimal"</screen>
     </listitem>
    </itemizedlist>
    <para>
-    <literal>remote_pacemaker</literal>サービスに関する詳細については(詳細な設定手順からなる複数の使用例を含む)、『<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>』を参照してください(<ulink url="http://www.clusterlabs.org/doc/"/>から入手可能)。
+    <literal>remote_pacemaker</literal>サービスに関する詳細については(詳細な設定手順からなる複数の使用例を含む)、『<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>』を参照してください(<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手可能)。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitor-health">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitor-health">
   <title>システムヘルスの監視</title>
 
 
@@ -1909,19 +1913,19 @@ property placement-strategy="minimal"</screen>
 
 
 
-  <procedure id="pro-ha-health-monitor">
+  <procedure xml:id="pro-ha-health-monitor">
    <title>システムヘルスの監視設定</title>
    <para>
     ノードがディスク容量を使い尽くした場合に、リソースを自動的にノードから移動させるには、次の手順に従います。
    </para>
-   <step performance="required">
+   <step>
     <para>
      <systemitem>ocf:pacemaker:SysInfo</systemitem>リソースを設定します。
     </para>
 <screen><?dbsuse-fo font-size="0.71em"?>
 
 primitive sysinfo ocf:pacemaker:SysInfo \ 
-     params disks="/tmp /var"<co id="co-disks"/> min_disk_free="100M"<co id="co-min-disk-free"/> disk_unit="M"<co id="co-disk-unit"/> \ 
+     params disks="/tmp /var"<co xml:id="co-disks"/> min_disk_free="100M"<co xml:id="co-min-disk-free"/> disk_unit="M"<co xml:id="co-disk-unit"/> \ 
      op monitor interval="15s"</screen>
     <calloutlist>
      <callout arearefs="co-disks">
@@ -1948,12 +1952,12 @@ primitive sysinfo ocf:pacemaker:SysInfo \
 
     </calloutlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソース設定を完了するには、<systemitem>ocf:pacemaker:SysInfo</systemitem>のクローンを作成し、各クラスタノードでそれを起動します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <systemitem>node-health-strategy</systemitem>を<literal>migrate-on-red</literal>に設定します。
     </para>
@@ -1991,8 +1995,8 @@ primitive sysinfo ocf:pacemaker:SysInfo \
   <para>
    ノードがサービスに復帰し、再びリソースを実行できるようになります。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-basics-maint-mode">
+ </section>
+ <section xml:id="sec-ha-config-basics-maint-mode">
   <title>メンテナンスモード</title>
 
 
@@ -2057,14 +2061,14 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-basics-more">
+ <section xml:id="sec-ha-config-basics-more">
   <title>その他の情報</title>
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/"/>
+    <term><link xlink:href="http://crmsh.github.io/"/>
     </term>
     <listitem>
      <para>
@@ -2073,16 +2077,16 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/documentation"/>
+    <term><link xlink:href="http://crmsh.github.io/documentation"/>
     </term>
     <listitem>
      <para>
-      crmshを使用した基本的なクラスタ設定の『<citetitle>Getting Started</citetitle>』チュートリアルとcrmシェルの包括的なマニュアル<citetitle/>を含む、crmシェルに関するいくつかのドキュメント。マニュアルは<ulink url="http://crmsh.github.io/man-2.0/"/>で入手できます。チュートリアルは<ulink url="http://crmsh.github.io/start-guide/"/>に用意されています。
+      crmshを使用した基本的なクラスタ設定の『<citetitle>Getting Started</citetitle>』チュートリアルとcrmシェルの包括的なマニュアル<citetitle/>を含む、crmシェルに関するいくつかのドキュメント。マニュアルは<link xlink:href="http://crmsh.github.io/man-2.0/"/>で入手できます。チュートリアルは<link xlink:href="http://crmsh.github.io/start-guide/"/>に用意されています。
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://clusterlabs.org/"/>
+    <term><link xlink:href="http://clusterlabs.org/"/>
     </term>
     <listitem>
      <para>
@@ -2091,7 +2095,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/> 
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/> 
     </term>
     <listitem>
      <para>
@@ -2122,7 +2126,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://linux-ha.org"/>
+    <term><link xlink:href="http://linux-ha.org"/>
     </term>
     <listitem>
      <para>
@@ -2131,5 +2135,5 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_config_cli.xml
+++ b/ja/xml/ha_config_cli.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_cli.xml" id="cha-ha-manual-config">
- <title>クラスタリソースの設定と管理(コマンドライン)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_cli.xml" xml:id="cha-ha-manual-config"><title>クラスタリソースの設定と管理(コマンドライン)</title><info><abstract>
   <para>
    クラスタリソースを設定および管理するには、グラフィカルユーザインタフェース(Pacemaker GUI)または<command>crm</command>コマンドラインユーティリティのいずれかを使用します。GUIを使用する方法については、<xref linkend="cha-ha-configuration-gui"/>を参照してください。
   </para>
@@ -15,7 +17,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    この章では、<command>crm</command>コマンドラインツールを紹介し、このツールの概要、テンプレートの使用方法、そして、主にクラスタリソースの設定と管理(基本的なリソースと高度なリソース(グループとクローン)の作成、制約の設定、フェールオーバーノードとフェールバックノードの指定、リソース監視の設定、リソースの開始、クリーンアップ、または削除、および手動によるリソースの移行について説明します。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <note>
   <title>ユーザの権限</title>
   <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    <filename>/etc/sudoers</filename>を設定しておいて、<command>sudo</command>がパスワードを要求しないようにしておく必要があることに注意してください。
   </para>
  </note>
- <sect1 id="sec-ha-manual-config-crm">
+ <section xml:id="sec-ha-manual-config-crm">
   <title>crmsh - 概要</title>
 
   <para>
@@ -61,7 +65,7 @@ Please see LICENSE.txt for this document's license.
    </itemizedlist>
   </tip>
 
-  <sect2 id="sec-ha-manual-config-crm-help">
+  <section xml:id="sec-ha-manual-config-crm-help">
    <title>ヘルプの表示</title>
    <para>
     ヘルプには複数の方法でアクセスできます。
@@ -105,15 +109,15 @@ Please see LICENSE.txt for this document's license.
    <para>
     <command>help</command>サブコマンド(<option>--help</option>オプションと混同しないこと)のほとんどすべての出力によって、テキストビューアが開きます。このテキストビューアは上下にスクロール可能で、ヘルプテキストが読みやすくなっています。テキストビューアを閉じるには、<keycap>Q</keycap>キーを押します。
    </para>
-   <tip id="tip-crm-tabcompletion">
+   <tip xml:id="tip-crm-tabcompletion">
     <title>バッシュおよび対話型シェルでタブ補完機能を使用</title>
     <para>
      crmshは、対話型シェルに対してだけではなく、バッシュでの直接的で完全なタブ補完機能をサポートしています。たとえば、<literal>crm help config</literal><keycap function="tab"/>と入力すると、対話型シェルと同様に単語が補完されます。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-crm-run">
+  <section xml:id="sec-ha-manual-config-crm-run">
    <title>crmshのサブコマンドの実行</title>
    <para>
     <command>crm</command>コマンドそのものは、次のように使用できます。
@@ -177,9 +181,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以降のサブセクションでは、<command>crm</command>ツールの重要な側面について、その概要を示します。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-ocf">
+  <section xml:id="sec-ha-manual-config-ocf">
    <title>OCFリソースエージェントに関する情報の表示</title>
    <para>
     リソースエージェントはクラスタ設定で常に操作する必要があるため、<command>crm</command>ツールには、<command>ra</command>コマンドが含まれています。このコマンドを使用して、リソースエージェントの情報を表示し、リソースエージェントを管理します(詳細は<xref linkend="sec-ha-config-basics-raclasses"/>も参照)。
@@ -242,9 +246,9 @@ Operations' defaults (advisory minimum):
      前の例では、<command>crm</command>コマンドの内部シェルを使用しました。ただし、必ずしも、それを使用する必要はありません。該当するサブコマンドを<command>crm</command>に追加すれば、同じ結果が得られます。たとえば、すべてのOCFリソースエージェントを一覧するには、シェルに「<command>crm</command> <option>ra list ocf</option>」を入力すれば済みます。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-template">
+  <section xml:id="sec-ha-manual-config-template">
    <title>設定テンプレートの使用</title>
 
    <para>
@@ -256,32 +260,32 @@ Operations' defaults (advisory minimum):
    <para>
     次の手順は、簡単ですが機能的なApache設定を作成する方法を示しています。
    </para>
-   <procedure id="pro-ha-manual-config-template">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-template">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       設定テンプレートから新しい設定を作成します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <command>template</command>サブコマンドに切り替えます。
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>template</command></screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用可能な設定テンプレートを一覧します。
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command> templates
 gfs2-base   filesystem  virtual-ip  apache   clvm     ocfs2    gfs2</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         必要な設定テンプレートを決めます。Apache設定が必要なので、<literal>apache</literal>テンプレートを選択し、<literal>g-intranet</literal>と名付けます。
        </para>
@@ -291,19 +295,19 @@ INFO: pulling in template virtual-ip</screen>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       パラメータを定義します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         作成した設定を一覧表示します。
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command>
 g-intranet</screen>
       </step>
-      <step id="st-config-cli-show" performance="required">
+      <step xml:id="st-config-cli-show">
        <para>
         入力を必要とする最小限の変更項目を表示します。
        </para>
@@ -312,7 +316,7 @@ ERROR: 23: required parameter ip not set
 ERROR: 61: required parameter id not set
 ERROR: 65: required parameter configfile not set</screen>
       </step>
-      <step id="st-config-cli-edit" performance="required">
+      <step xml:id="st-config-cli-edit">
        <para>
         好みのテキストエディタを起動し、<xref linkend="st-config-cli-show"/>でエラーとして表示されたすべての行に入力します。
        </para>
@@ -321,7 +325,7 @@ ERROR: 65: required parameter configfile not set</screen>
 
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       設定を表示し、設定が有効かどうか確認します(太字のテキストは、<xref linkend="st-config-cli-edit" xrefstyle="select:label"/>で入力した設定によって異なります)。
      </para>
@@ -334,7 +338,7 @@ primitive apache ocf:heartbeat:apache \
 group <emphasis role="strong">g-intranet</emphasis> \
     apache virtual-ip</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       設定を適用します。
      </para>
@@ -342,7 +346,7 @@ group <emphasis role="strong">g-intranet</emphasis> \
 <prompt role="custom">crm(live)configure# </prompt><command>cd ..</command>
 <prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       変更内容をCIBに送信します。
      </para>
@@ -363,9 +367,9 @@ group <emphasis role="strong">g-intranet</emphasis> \
    <para>
     ただし、このコマンドは、設定テンプレートから設定を作成するだけです。設定をCIBに適用したり、コミットすることはありません。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-shadowconfig">
+  <section xml:id="sec-ha-manual-config-shadowconfig">
    <title>シャドーイング設定のテスト</title>
    <para>
     シャドーイング設定は、異なる設定シナリオのテストに使用されます。複数のシャドウ設定を作成した場合は、1つ1つテストして変更を加えた影響を確認できます。
@@ -374,13 +378,13 @@ group <emphasis role="strong">g-intranet</emphasis> \
     通常の処理は次のようになります。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しいシャドウ設定を作成します。
      </para>
@@ -390,7 +394,7 @@ INFO: myNewConfig shadow CIB created</screen>
       シャドウCIBの名前を省略する場合は、一時名の<literal>@tmp@</literal>が作成されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       現在のライブ設定をシャドウ設定にコピーする場合は、次のコマンドを使用します。コピーしない場合は、このステップをスキップします。
      </para>
@@ -399,13 +403,13 @@ INFO: myNewConfig shadow CIB created</screen>
       このコマンドを使用すると、既存のリソースを後から編集する場合に、簡単に編集できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       通常どおり変更を行います。シャドウ設定の作成後は、すべての変更がシャドウ設定に適用されます。すべての変更を保存するには、次のコマンドを使用します。
      </para>
 <screen>crm(myNewConfig)# <command>commit</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ライブクラスタ設定が再び必要な場合は、次のコマンドでライブ設定に戻ります。
      </para>
@@ -413,9 +417,9 @@ INFO: myNewConfig shadow CIB created</screen>
 <prompt role="custom">crm(live)# </prompt></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-debugging">
+  <section xml:id="sec-ha-manual-config-debugging">
    <title>設定の変更のデバッグ</title>
    <para>
     設定の変更をクラスタにロードする前に、変更内容を<command>ptest</command>でレビューすることを推奨します。<command>ptest</command>コマンドを指定すると、変更のコミットによって生じるアクションのダイアグラムを表示できます。ダイアグラムを表示するには、<systemitem>graphviz</systemitem>パッケージが必要です。次の例は監視操作を追加するスクリプトです。
@@ -431,9 +435,9 @@ primitive fence-bob stonith:apcsmart \
         op monitor interval="120m" timeout="60s"
 <prompt role="custom">crm(live)configure# </prompt><emphasis role="strong">ptest</emphasis>
 <prompt role="custom">crm(live)configure# </prompt>commit</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-diagram">
+  <section xml:id="sec-ha-manual-config-diagram">
    <title>クラスタダイアグラム</title>
    <para>
     <xref linkend="fig-ha-cluster-diagram"/>に示すようなクラスタダイアグラムを出力するには、コマンド<command>crm</command> <command>configure graph</command>を使用します。これにより現在の設定が現在のウィンドウに表示されるので、X11が必要になります。
@@ -442,10 +446,10 @@ primitive fence-bob stonith:apcsmart \
     SVG (Scalable Vector Graphics)を使用する場合は、次のコマンドを使用します。
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure graph dot config.svg svg</screen>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 
- <sect1 id="sec-ha-config-crm-global">
+ <section xml:id="sec-ha-config-crm-global">
   <title>グローバルクラスタオプションの設定</title>
 
   <para>
@@ -454,13 +458,13 @@ primitive fence-bob stonith:apcsmart \
 
   <procedure>
    <title><command>crm</command>でグローバルクラスタオプションを変更する</title>
-   <step performance="required">
+   <step>
     <para>
      <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>ツールを開始します。
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次のコマンドを使用して、2ノードクラスタだけのオプションを設定します。
     </para>
@@ -473,7 +477,7 @@ primitive fence-bob stonith:apcsmart \
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更内容を表示します。
     </para>
@@ -485,7 +489,7 @@ property $id="cib-bootstrap-options" \
    no-quorum-policy="ignore" \
    stonith-enabled="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更内容をコミットして終了します。
     </para>
@@ -493,8 +497,8 @@ property $id="cib-bootstrap-options" \
 <prompt role="custom">crm(live)configure# </prompt><command>exit</command></screen>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-config-crm-resources">
+ </section>
+ <section xml:id="sec-ha-config-crm-resources">
   <title>クラスタリソースの設定</title>
 
   <para>
@@ -505,19 +509,19 @@ property $id="cib-bootstrap-options" \
    作成できるリソースタイプの概要については、<xref linkend="sec-ha-config-basics-resources-types"/>を参照してください。
   </para>
 
-  <sect2 id="sec-ha-manual-config-create">
+  <section xml:id="sec-ha-manual-config-create">
    <title>クラスタリソースの作成</title>
    <para>
     クラスタで使用できるRA(リソースエージェント)には3種類あります(背景情報については<xref linkend="sec-ha-config-basics-raclasses"/>を参照)。新しいリソースをクラスタに追加するには、次の手順に従います。
    </para>
-   <procedure id="pro-ha-manual-config-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-create">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>ツールを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       プリミティブIPアドレスを設定ます。
      </para>
@@ -527,13 +531,13 @@ property $id="cib-bootstrap-options" \
       前のコマンドは<quote>プリミティブ</quote>に名前<literal>myIP</literal>を設定します。クラス(ここでは<literal>ocf</literal>)、プロバイダ(<literal>heartbeat</literal>)、およびタイプ(<literal>IPaddr</literal>)を選択する必要があります。さらに、このプリミティブでは、IPアドレスなどのパラメータが必要です。自分の設定に合わせてアドレスを変更してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       行った変更を表示して確認します。
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       変更をコミットして反映させます。
      </para>
@@ -541,11 +545,11 @@ property $id="cib-bootstrap-options" \
     </step>
    </procedure>
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-config-rsc-template">
+  <section xml:id="sec-ha-manual-config-rsc-template">
    <title>リソーステンプレートの作成</title>
    <para>
     類似した設定で複数のリソースを作成する場合、リソーステンプレートを使用すれば作業が簡単になります。基本的なバックグラウンド情報については、<xref linkend="sec-ha-config-basics-constraints-templates"/>を参照してください。これらを、<quote>通常の</quote>テンプレート(<xref linkend="sec-ha-manual-config-template"/>で説明したもの)と混同しないでください。次の構文を知るには、<command>rsc_template</command>コマンドを使用してください。
@@ -588,23 +592,23 @@ usage: rsc_template &lt;name&gt; [&lt;class&gt;:[&lt;provider&gt;:]]&lt;type&gt;
    <para>
     リソーステンプレートは、そのテンプレートから派生するすべてのプリミティブを表すものとして、制約で参照することができます。これにより、クラスタ設定をいっそう簡潔かつクリアに行うことができます。リソーステンプレートは、場所の制約を除くすべての制約から参照することができます。コロケーション制約には、複数のテンプレート参照を含めることはできません。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-create-stonith">
+  <section xml:id="sec-ha-manual-create-stonith">
    <title>STONITHリソースの作成</title>
    <para>
     <command>crm</command>からは、STONITHデバイスは単なる1つのリソースと認識されます。STONITHリソースを作成するには、次の手順に従います。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のコマンドで、すべてのSTONITHタイプのリストを取得します。
      </para>
@@ -622,7 +626,7 @@ ipmilan                    meatware                   nw_rpc100s
 rcd_serial                 rps10                      suicide
 wti_mpc                    wti_nps</screen>
     </step>
-    <step id="st-ha-manual-create-stonith-type" performance="required">
+    <step xml:id="st-ha-manual-create-stonith-type">
      <para>
       上記のリストからSTONITHタイプを選択し、利用できるオプションのリストを表示します。次のコマンドを実行します。
      </para>
@@ -641,7 +645,7 @@ hostname (string): Hostname
     The name of the host to be managed by this STONITH device.
 ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <literal>stonith</literal>クラス、<xref linkend="st-ha-manual-create-stonith-type" xrefstyle="select:label nopage"/>で選択したタイプ、および必要に応じて該当するパラメータを使用して、STONITHリソースを作成します。たとえば、次のコマンドを使用します。
      </para>
@@ -653,9 +657,9 @@ hostname (string): Hostname
     op monitor interval=60m timeout=120s  </screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-constraints">
+  <section xml:id="sec-ha-manual-config-constraints">
    <title>リソース制約の設定</title>
    <para>
     すべてのリソースを設定することは、ジョブのほんの一部分です。クラスタが必要なすべてのリソースを認識しても、正しく処理できるとは限りません。たとえば、DRBDのスレーブノードにファイルシステムをマウントしないようにしてください(実際、DRBDでは失敗します)。このような情報をクラスタが利用できるように、制約を定義します。
@@ -663,7 +667,7 @@ hostname (string): Hostname
    <para>
     制約の詳細については、<xref linkend="sec-ha-config-basics-constraints"/>を参照してください。
    </para>
-   <sect3 id="sec-ha-manual-config-constraints-locational">
+   <section xml:id="sec-ha-manual-config-constraints-locational">
     <title>場所の制約</title>
     <para>
      <command>location</command>コマンドは、リソースを実行できるノード、できないノード、または実行に適したノードを定義するものです。
@@ -696,8 +700,8 @@ hostname (string): Hostname
      ある場合には、<command>location</command>コマンドでリソースパターンを使用すると、より効率的で便利です。リソースパターンは、2つのスラッシュ間の正規表現です。たとえば、前に示した仮想IPアドレスは、次とすべて一致させることができます。
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>location</command>  loc-alice /vip.*/ inf: alice</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-collocational">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-collocational">
     <title>コロケーション制約</title>
     <para>
      <command>colocation</command>コマンドは、同じホストまたは別のホストで実行するべきリソースを定義するために使用します。
@@ -713,8 +717,8 @@ hostname (string): Hostname
     <para>
      マスタスレーブ構成では、現在のノートがマスタかどうかと、リソースをローカルに実行しているかどうかを把握することが必要です。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-weak-bond">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-weak-bond">
     <title>依存性なしのリソースセットのコロケーション</title>
 
     <para>
@@ -727,8 +731,8 @@ hostname (string): Hostname
     <para>
      <command>weak-bond</command>の実装により、指定されたリソースを持つダミーリソースとコロケーション制約が自動的に作成されます。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-ordering">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-ordering">
     <title>順序の制約</title>
     <para>
      <command>order</command>コマンドは、アクションのシーケンスを定義します。
@@ -741,8 +745,8 @@ hostname (string): Hostname
     </para>
 
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> nfs_after_filesystem mandatory: filesystem_resource nfs_group</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-example">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-example">
     <title>サンプル設定のための制約</title>
     <para>
      このセクションで使用される例は、制約を追加しないと機能しません。すべてのリソースは、必ず、マスタであるDRBDリソースと同じマシンで実行される必要があります。DRBDリソースは、他のリソースが開始する前にマスタにする必要があります。マスタでないときに、drbdデバイスをマウントしようとすると失敗します。次の制約を満たす必要があります。
@@ -777,10 +781,10 @@ hostname (string): Hostname
     drbd_resource:promote filesystem_resource:start</screen>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failover">
+  <section xml:id="sec-ha-manual-config-failover">
    <title>リソースフェールオーバーノードの指定</title>
    <para>
     リソースフェールオーバーを判定するには、メタ属性migration-thresholdを使用します。すべてのノードで失敗回数がmigration-thresholdを超えている場合には、リソースは停止したままになります。例:
@@ -796,9 +800,9 @@ hostname (string): Hostname
    <para>
     概要については、<xref linkend="sec-ha-config-basics-failover"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failback">
+  <section xml:id="sec-ha-manual-config-failback">
    <title>リソースフェールバックノードの指定(リソースの固着性)</title>
      <para>
     ノードがオンライン状態に戻り、クラスタ内にある場合は、リソースが元のノードにフェールバックすることがあります。リソースを実行していたノードにリソースをフェールバックさせたくない場合や、リソースのフェールバック先として別のノードを指定する場合は、リソースの<literal>resource stickiness</literal>値を変更します。リソースの固着性は、リソースの作成時でも、その後でも指定できます。
@@ -806,9 +810,9 @@ hostname (string): Hostname
    <para>
     概要については、<xref linkend="sec-ha-config-basics-failback"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-utilization">
+  <section xml:id="sec-ha-manual-config-utilization">
    <title>負荷インパクトに基づくリソース配置の設定</title>
    <para>
     一部のリソースは、メモリの最小量など、特定の容量要件を持っています。要件が満たされていない場合、リソースは全く開始しないか、またはパフォーマンスを下げた状態で実行されます。
@@ -846,13 +850,13 @@ hostname (string): Hostname
    </para>
    <procedure>
     <title><command>crm</command>で使用属性を追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ノードが<emphasis>提供する</emphasis>容量を指定するには、次のコマンドを使用し、プレースホルダ<replaceable>NODE_1</replaceable>をノードの名前に置き換えます。
      </para>
@@ -862,7 +866,7 @@ hostname (string): Hostname
       これらの値によって、<replaceable>NODE_1</replaceable>は16GBのメモリと8つのCPUコアをリソースに提供すると想定されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースが<emphasis>要求する</emphasis>容量を指定するには、次のコマンドを使用します。
      </para>
@@ -872,7 +876,7 @@ hostname (string): Hostname
       これによって、リソースはnodeAからの4096のメモリ単位と4つのCPUユニットを使用します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>property</command>コマンドを使用して、配置ストラテジを設定します。
      </para>
@@ -924,7 +928,7 @@ hostname (string): Hostname
     </para>
    </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       変更をコミットしてから、crmshを終了します。
      </para>
@@ -956,9 +960,9 @@ hostname (string): Hostname
    <para>
     1つのノードに障害が発生した場合、残りのノード上で利用できるメモリ合計が少なすぎて、これらのリソースすべてはホストできません。xenAは確実に割り当てられ、xenDも同様です。ただし、xenBとxenCは、そのどちらか1つしか割り当てられません。xenBとxenCの優先度は同等なので、結果はまだ未定義です。これを解決するためにも、どちらかに高い優先度を設定する必要があります。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-monitor">
+  <section xml:id="sec-ha-manual-config-monitor">
    <title>リソース監視の設定</title>
 
    <para>
@@ -976,21 +980,21 @@ hostname (string): Hostname
    <para>
     概要については、<xref linkend="sec-ha-config-basics-monitoring"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-group">
+  <section xml:id="sec-ha-manual-config-group">
    <title>クラスタリソースグループの構成</title>
 
    <para>
     クラスタの一般的な要素の1つは、一緒の場所で見つける必要のあるリソースのセットです。連続的に開始し、逆の順序で停止します。この設定を簡単にするため、グループのコンセプトをサポートしています。次の例では、2つのプリミティブ(IPアドレスと電子メールリソース)を作成します。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <command>crm</command>コマンドをシステム管理者として実行します。プロンプトが<literal>crm(live)</literal>に変化します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       プリミティブを設定します。
      </para>
@@ -1000,7 +1004,7 @@ hostname (string): Hostname
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Email lsb:exim \
    params id=p.lsb-exim</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       該当するIDを使用して、正しい順序で、プリミティブをグループ化します。
      </para>
@@ -1019,9 +1023,9 @@ hostname (string): Hostname
    <para>
     概要については、<xref linkend="sec-ha-config-basics-resources-advanced-groups"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-clone">
+  <section xml:id="sec-ha-manual-config-clone">
    <title>クローンリソースの設定</title>
 
    <para>
@@ -1031,46 +1035,46 @@ hostname (string): Hostname
    <para>
     クローンリソースの詳細については、<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>を参照してください。
    </para>
-   <sect3 id="sec-ha-manual-config-clone-anonymous">
+   <section xml:id="sec-ha-manual-config-clone-anonymous">
     <title>匿名クローンリソースの作成</title>
     <para>
      匿名クローンリソースを作成するには、まずプリミティブリソースを作成して、それを<command>clone</command>コマンドで指定することです。次の操作を実行してください:
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        次のように、プリミティブを設定します。
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Apache lsb:apache</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        プリミティブをクローンします。
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>clone</command> cl-apache Apache </screen>
      </step>
     </procedure>
-   </sect3>
+   </section>
 
-   <sect3 id="sec-ha-manual-config-clone-stateful">
+   <section xml:id="sec-ha-manual-config-clone-stateful">
     <title>ステートフル/マルチステートクローンリソースの作成</title>
     <para>
      ステートフルクローンリソースを作成するには、まずプリミティブリソースを作成してから、マルチステートリソースを作成します。マルチステートリソースは少なくとも、昇格および降格操作をサポートしている必要があります。
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        プリミティブを作成します。必要に応じて間隔を変更します。
       </para>
@@ -1078,62 +1082,62 @@ hostname (string): Hostname
     op monitor interval=60 \
     op monitor interval=61 role=Master</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        マルチステートリソースを作成します。
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>ms</command> ms-rsc my-rsc</screen>
      </step>
     </procedure>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-crm">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-crm">
   <title>クラスタリソースの管理</title>
 
   <para>
    <command>crm</command>ツールでは、クラスタリソースの設定が可能なだけでなく、既存リソースを管理することもできます。移行のサブセクションで概要を示します。
   </para>
 
-  <sect2 id="sec-ha-manual-config-start">
+  <section xml:id="sec-ha-manual-config-start">
    <title>新しいクラスタリソースの開始</title>
    <para>
     新しいクラスタリソースを開始するには、そのIDが必要です。次の手順に従います。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースレベルに切り替えます。
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>resource</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>start</command>でリソースを開始し、<keycap function="tab"/>キーを押してすべての既知のリソースを表示します。
      </para>
 <screen><prompt role="custom">crm(live)resource# </prompt><command>start</command> <replaceable>ID</replaceable></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cleanup">
+  <section xml:id="sec-ha-manual-config-cleanup">
    <title>リソースのクリーンアップ</title>
    <para>
     リソースは、失敗した場合は自動的に再起動しますが、失敗のたびにリソースの失敗回数が増加します。<literal>migration-threshold</literal>がそのリソースに設定されている場合は、失敗の数が移行しきい値に達するとただちに、そのリソースはノードで実行できなくなります。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       シェルを開いて、<systemitem class="username">root</systemitem>ユーザとしてログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのリソースのリストを取得します。
      </para>
@@ -1144,28 +1148,28 @@ Resource Group: dlm-clvm:1
          clvm:1 (ocf::lvm2:clvmd) Started
          cmirrord:1     (ocf::lvm2:cmirrord) Started</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソース<literal>dlm</literal>をクリーンアップするには、たとえば、以下の手順を実行します:
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource cleanup dlm</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-remove">
+  <section xml:id="sec-ha-manual-config-remove">
    <title>クラスタリソースの削除</title>
    <para>
     次の手順に従って、クラスタリソースを削除します。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="username">root</systemitem>としてログインし、<command>crm</command>対話型シェルを開始します。
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のコマンドを実行して、リソースのリストを取得します。
      </para>
@@ -1175,22 +1179,22 @@ Resource Group: dlm-clvm:1
      </para>
 <screen>myIP    (ocf::IPaddr:heartbeat) ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       該当するIDを持つリソースを削除します(これは、<command>commit</command>も含意します)。
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> delete <replaceable>YOUR_ID</replaceable></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       変更をコミットします。
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-migrate">
+  <section xml:id="sec-ha-manual-config-migrate">
    <title>クラスタリソースのマイグレーション</title>
    <para>
     リソースは、ハードウェアまたはソフトウェアに障害が発生した場合、クラスタ内の他のノードに自動的にフェールオーバー(つまり移行)するよう設定されていますが、Pacemaker GUIまたはコマンドラインを使用して、手動でリソースをクラスタ内の別のノードに移動することもできます。
@@ -1200,9 +1204,9 @@ Resource Group: dlm-clvm:1
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource
 <prompt role="custom">crm(live)resource# </prompt><command>migrate</command> ipaddress1 bob</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-tag">
+  <section xml:id="sec-ha-manual-config-tag">
    <title>リソースのグループ化/タグ付け</title>
 
    <para>
@@ -1223,9 +1227,9 @@ Resource Group: dlm-clvm:1
     <para>リソースをグループ化するタグと一部のACLの機能は、<literal>pacemaker-2.0</literal>以上のCIB構文バージョンでのみ動作します。この点に該当するタグやACLであるかどうかを確認して、CIBバージョンをアップグレードする方法の詳細については、『<citetitle>High Availability Guide</citetitle> for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>』のセクション「<citetitle>SLE HA 11 SP3からSLE HA 11 SP4へのアップグレード</citetitle>」を参照してください。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cli-maint-mode">
+  <section xml:id="sec-ha-manual-config-cli-maint-mode">
    <title>保守モードの使用</title>
 
    
@@ -1287,10 +1291,10 @@ Resource Group: dlm-clvm:1
    <para>
     保守モード中にリソースおよびクラスタで何が発生するかの詳細については、<xref linkend="sec-ha-config-basics-maint-mode"/>を参照してください。
    </para>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
- <sect1 id="sec-ha-config-crm-setpwd">
+ <section xml:id="sec-ha-config-crm-setpwd">
   <title><filename>cib.xml</filename>から独立したパスワードの設定</title>
 
   <para>
@@ -1322,9 +1326,9 @@ linux</screen>
   <para>
    パラメータは、ノード間で同期する必要があることに注意してください。<command>crm resource secret</command>コマンドを使用すれば、この処理が実行されます。秘密のパラメータを管理する場合には、このコマンドを使用することを強く推奨します。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-crm-history">
+ <section xml:id="sec-ha-config-crm-history">
   <title>履歴情報の取得</title>
 
   <para>
@@ -1381,7 +1385,7 @@ linux</screen>
 
 
   <para>
-   その他の例とタイムフレームの作成方法については、<ulink url="http://labix.org/python-dateutil"/>を参照してください。
+   その他の例とタイムフレームの作成方法については、<link xlink:href="http://labix.org/python-dateutil"/>を参照してください。
   </para>
 
   <para>
@@ -1429,8 +1433,8 @@ INFO: fetching new logs, please wait ...</screen>
   </para>
 
 <screen><prompt role="custom">crm(live)history# </prompt><command>transition</command> -1 nograph</screen>
- </sect1>
- <sect1 id="sec-ha-config-crm-more">
+ </section>
+ <section xml:id="sec-ha-config-crm-more">
   <title>詳細</title>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -1441,7 +1445,7 @@ INFO: fetching new logs, please wait ...</screen>
    </listitem>
    <listitem>
     <para>
-     アップストリームプロジェクトマニュアルにアクセスします(<ulink url="http://crmsh.github.io/documentation"/>)。
+     アップストリームプロジェクトマニュアルにアクセスします(<link xlink:href="http://crmsh.github.io/documentation"/>)。
     </para>
    </listitem>
    <listitem>
@@ -1450,5 +1454,5 @@ INFO: fetching new logs, please wait ...</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_config_example.xml
+++ b/ja/xml/ha_config_example.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_config_example.xml" id="cha-ha-config-example">
- <title>OCFS2およびcLVMの設定例</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_example.xml" xml:id="cha-ha-config-example"><title>OCFS2およびcLVMの設定例</title><info/>
+ 
  <para>
   次の設定例は、OCFS2、cLVM、または両方を使用するためのリソースを設定するのに役立ちます。下の設定は完全なクラスタ設定を表すものではなく、抽出のみで、OCFS2およびcLVMに必要なすべてのリソースを含み、その他必要な可能性のあるリソースは無視しています。属性および属性の値は個々のセットアップに合わせて調整する必要がある場合があります。
  </para>
- <example id="ex-ha-config-ocfs2-clvm">
+ <example xml:id="ex-ha-config-ocfs2-clvm">
   <title>CFS2およびcLVMのクラスタ設定</title>
 
 <screen>primitive clvm ocf:lvm2:clvmd \

--- a/ja/xml/ha_config_gui.xml
+++ b/ja/xml/ha_config_gui.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_gui.xml" id="cha-ha-configuration-gui">
- <title>クラスタリソースの設定と管理(GUI)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_gui.xml" xml:id="cha-ha-configuration-gui"><?dbfo-need height="20em"?><?dbfo-need height="20em"?><title>クラスタリソースの設定と管理(GUI)</title><info><abstract>
   <para>
    この章では、Pacemaker GUIを紹介し、グローバルクラスタオプションの変更、基本的なリソースと高度なリソース(グループとクローン)の作成、制約の設定、フェールオーバーノードとフェールバックノードの指定、リソースモニタリングの設定、リソースの始動、クリーンアップ、または削除、および手動によるリソースの移行など、クラスタリソースの設定と管理に必要な基本的な作業について説明します。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <para>
   GUIのサポートは、2つのパッケージで提供されます。<systemitem class="resource">pacemaker-mgmt</systemitem>パッケージには、GUIのバックエンド(<systemitem class="daemon">mgmtd</systemitem>デーモン)が含まれています。このパッケージは、GUIで接続するすべてのクラスタノードにインストールする必要があります。GUIを実行するコンピュータには、<systemitem class="resource">pacemaker-mgmt-client</systemitem>パッケージをインストールします。
  </para>
@@ -27,17 +31,17 @@ Please see LICENSE.txt for this document's license.
    Pacemaker GUIを使用して、接続先の各ノードでこれを実行します。
   </para>
  </note>
-<?dbfo-need height="20em"?>
 
 
- <sect1 id="sec-ha-configuration-gui-intro">
+
+ <section xml:id="sec-ha-configuration-gui-intro">
   <title>Pacemaker GUI - 概要</title>
 
   <para>
    Pacemaker GUIを開始するには、コマンドラインに「<command>crm_gui</command>」と入力します。設定と管理のオプションにアクセスするには、クラスタにログインする必要があります。
   </para>
 
-  <sect2 id="sec-ha-configuration-gui-intro-connect">
+  <section xml:id="sec-ha-configuration-gui-intro-connect">
    <title>クラスタにログインする</title>
    <para>
     クラスタに接続するには、<menuchoice><guimenu>接続</guimenu><guimenu>ログイン</guimenu></menuchoice>の順に選択します。デフォルトでは、<guimenu>サーバ</guimenu>フィールドにローカルホストのIPアドレスと<systemitem>hacluster</systemitem>が<guimenu>ユーザ名</guimenu>として表示されています。ユーザのパスワードを入力して続行します。
@@ -56,13 +60,13 @@ Please see LICENSE.txt for this document's license.
    <para>
     Pacemaker GUIをリモートで実行している場合は、クラスタノードのIPアドレスを<guimenu>サーバ</guimenu>として入力します。<guimenu>ユーザ名</guimenu>に、<systemitem>haclient</systemitem>グループに属する他の任意のユーザ使用して、クラスタに接続することもできます。
    </para>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-gui-intro-main">
+  <section xml:id="sec-ha-configuration-gui-intro-main">
    <title>メインウィンドウ</title>
    <para>
     接続後、メインウィンドウが開きます。
@@ -134,9 +138,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以降のセクションでは、クラスタオプションとリソースの設定時に必要な主要作業について説明し、Pacemaker GUIでリソースを管理する方法を示します。特に説明されない限り、ステップバイステップの説明は、簡易モードで実行される手順を反映しています。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-global">
   <title>グローバルクラスタオプションの設定</title>
 
   <para>
@@ -156,29 +160,29 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-gui-global">
+  <procedure xml:id="pro-ha-config-gui-global">
    <title>グローバルクラスタオプションを変更する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <menuchoice><guimenu>表示</guimenu><guimenu>簡易モード</guimenu></menuchoice>の順に選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左ペインで、<guimenu>CRM Config</guimenu>を選択して、グローバルクラスタオプションとそれらの現在の値を表示します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタ要件に応じて、<guimenu>クォーラムなしポリシー</guimenu>を適切な値に設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      なんらかの理由でフェンシングを無効にする必要がある場合は、<guimenu>stonith-enabled</guimenu>の選択を解除します。
     </para>
@@ -189,7 +193,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>適用</guimenu>をクリックして、変更を確認します。
     </para>
@@ -199,11 +203,11 @@ Please see LICENSE.txt for this document's license.
   <para>
    左ペインの<guimenu>CRM Config</guimenu>を選択して<guimenu>デフォルト</guimenu>をクリックすると、すべてのオプションを、いつでもデフォルト値に戻すことができます。
   </para>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-config-gui-resources">
+
+ <section xml:id="sec-ha-config-gui-resources">
   <title>クラスタリソースの設定</title>
 
   <para>
@@ -214,44 +218,44 @@ Please see LICENSE.txt for this document's license.
    作成できるリソースタイプの概要については、<xref linkend="sec-ha-config-basics-resources-types"/>を参照してください。
   </para>
 
-  <sect2 id="sec-ha-configuration-create">
+  <section xml:id="sec-ha-configuration-create">
    <title>単純なクラスタリソースの作成</title>
    <para>
     最も基本的なタイプのリソースを作成するには、次の手順に従います。
    </para>
-   <procedure id="pro-ha-config-gui-primitives">
+   <procedure xml:id="pro-ha-config-gui-primitives">
     <title>プリミティブリソースを追加する</title>
-    <step id="st-ha-configuration-create-start" performance="required">
+    <step xml:id="st-ha-configuration-create-start">
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで、<guimenu>リソース</guimenu>を選択し、<menuchoice> <guimenu>追加</guimenu><guimenu>プリミティブ</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のダイアログで、リソースに次のようなパラメータを設定します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         リソースに固有の<guimenu>ID</guimenu>を入力します。
        </para>
       </step>
-      <step id="step-ha-config-gui-primitives-start" performance="required">
+      <step xml:id="step-ha-config-gui-primitives-start">
        <para>
         <guimenu>クラス</guimenu>リストから、そのリソースに使用するリソースエージェントクラスを選択します。<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>service</guimenu>、または<guimenu>stonith</guimenu>を選択できます。 詳細については、<xref linkend="sec-ha-config-basics-raclasses"/>を参照してください。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>ocf</guimenu>をクラスとして選択した場合、OCFリソースエージェントの<guimenu>プロバイダ</guimenu>も指定します。OCFの指定によって、複数のベンダが同じリソースエージェントを提供できるようになります。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>タイプ</guimenu>リストから、使用するリソースエージェントを選択します(たとえば<guimenu>IPaddr</guimenu>または<guimenu>Filesystem</guimenu>)。このリソースエージェントの簡単な説明を次に表示します。
        </para>
@@ -259,12 +263,12 @@ Please see LICENSE.txt for this document's license.
         <guimenu>タイプ</guimenu>リストに表示される選択肢は、選択した<guimenu>クラス</guimenu>(OCFリソースの場合は、<guimenu>プロバイダ</guimenu>も)によって異なります。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>オプション</guimenu>の下で、<guimenu>Initial state of resource (リソースの当初の状態)</guimenu>を設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         リソースのヘルスが維持されているかどうかをクラスタに監視させる場合は、<guimenu>Add monitor operation(モニタ操作の追加)</guimenu>を有効にします。
        </para>
@@ -281,12 +285,12 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>進む</guimenu>をクリックします。次のウィンドウには、そのリソースに定義したパラメータのサマリが表示されます。そのリソースに必要なすべての<guimenu>Instance Attributes (インスタンス属性)</guimenu>が一覧が表示されます。適切な値に設定するには、編集する必要があります。展開や設定によっては、属性の追加が必要な場合もあります。詳細については<xref linkend="pro-ha-config-gui-parameters"/>を参照してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>適用</guimenu>をクリックして、そのリソースの設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに新しく追加されたリソースが表示されます。
      </para>
@@ -312,14 +316,14 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-config-gui-parameters">
+   <procedure xml:id="pro-ha-config-gui-parameters">
     <title>メタ属性およびインスタンス属性を追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       Pacemaker GUIのメインウィンドウの左側のペインで、<guimenu>リソース</guimenu>をクリックして、そのクラスタに設定されているリソースを表示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右側のペインで、変更するリソースを選択し、<guimenu>編集</guimenu>をクリックします(またはリソースをダブルクリックします)。次のウィンドウには、そのリソースに定義された基本的なリソースパラメータと<guimenu>メタ属性</guimenu>、<guimenu>インスタンス属性</guimenu>、または<guimenu>操作</guimenu>が表示されます。
      </para>
@@ -334,27 +338,27 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しいメタ属性またはインスタンス属性を追加するには、該当するタブを選択して<guimenu>追加</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       追加する属性の<guimenu>名前</guimenu>を選択します。短い<guimenu>説明</guimenu>が表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要に応じて、属性の<guimenu>値</guimenu>を指定します。指定しなければ、その属性のデフォルト値が使用されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>OK</guimenu>をクリックして変更を確認します。新しく追加または変更された属性がタブに表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>OK</guimenu>をクリックして、そのリソースの設定を完了します。環境設定ダイアログが閉じ、メインウィンドウに変更済みのリソースが表示されます。
      </para>
@@ -372,9 +376,9 @@ Please see LICENSE.txt for this document's license.
      XMLコードを表示しているエディタで、XML要素を<guimenu>インポート</guimenu>または<guimenu>エクスポート</guimenu>、あるいは手動でXMLコードを編集することができます。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-stonith">
+  <section xml:id="sec-ha-configuration-stonith">
    <title>STONITHリソースの作成</title>
    <important>
     <title>STONITHがない場合はサポートなし</title>
@@ -385,56 +389,56 @@ Please see LICENSE.txt for this document's license.
    <para>
     デフォルトでは、グローバルクラスタオプション<literal>stonith-enabled</literal>は<literal>true</literal>に設定されています。STONITHリソースが定義されていない場合、クラスタはどのリソースの開始も拒否します。STONITHのセットアップを完了するには、1つ以上のSTONITHリソースを構成する必要があります。STONITHは他のリソースと同様に設定しますが、その動作はいくつかの点で異なっています。詳細については、<xref linkend="sec-ha-fencing-config"/>を参照してください。
    </para>
-   <procedure id="pro-ha-config-gui-stonith">
+   <procedure xml:id="pro-ha-config-gui-stonith">
     <title>STONITHリソースの追加</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで、<guimenu>リソース</guimenu>を選択し、<menuchoice> <guimenu>追加</guimenu><guimenu>プリミティブ</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のダイアログで、リソースに次のようなパラメータを設定します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         リソースに固有の<guimenu>ID</guimenu>を入力します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>クラス</guimenu>リストで、リソースエージェントクラスとして<guimenu>stonith</guimenu>を選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>タイプ</guimenu>リストから、使用しているSTONITHデバイスのSTONITHプラグインを選択します。このプラグインの簡単な説明が下に表示されます。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>オプション</guimenu>の下で、<guimenu>Initial state of resource (リソースの当初の状態)</guimenu>を設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         クラスタにフェンシングデバイスの監視を行わせたい場合は、<guimenu>Add monitor operation (監視操 の追加)</guimenu>を起動します。詳細については、<xref linkend="sec-ha-fencing-monitor"/>を参照してください。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>進む</guimenu>をクリックします。次のウィンドウには、そのリソースに定義したパラメータのサマリが表示されます。選択したSTONITHプラグインに必要なすべての<guimenu>インスタンス属性</guimenu>が一覧に表示されます。適切な値に設定するには、編集する必要があります。展開と設定によっては、監視操作のための属性を追加しなければならない場合もあります。詳細については、<xref linkend="pro-ha-config-gui-parameters"/>および<xref linkend="sec-ha-configuration-monitor"/>を参照してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>適用</guimenu>をクリックして、そのリソースの設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに新しく追加されたリソースが表示されます。
      </para>
@@ -443,90 +447,90 @@ Please see LICENSE.txt for this document's license.
    <para>
     フェンシングを設定するには、制約の追加とクローンの使用のいずれか、またはその両方を行います。詳細については、<xref linkend="cha-ha-fencing"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-gui-templates">
+  <section xml:id="sec-ha-config-gui-templates">
    <title>リソーステンプレートの使用</title>
    <para>
     類似した設定のリソースを複数作成する最も簡単な方法は、リソーステンプレートを定義することです。リソーステンプレートを定義しておくと、プリミティブの中や、特定のタイプの制約で参照できるようになります。リソーステンプレートの機能と使用方法の詳細については、<xref linkend="sec-ha-config-basics-constraints-templates"/>を参照してください。
    </para>
-   <procedure id="pro-ha-config-gui-templates-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-templates-create">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで、<guimenu>リソース</guimenu>を選択し、<menuchoice> <guimenu>追加</guimenu><guimenu>テンプレート</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       テンプレートに固有の<guimenu>ID</guimenu>を入力します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       プリミティブを指定するリソーステンプレートを指定します。<xref linkend="pro-ha-config-gui-primitives" xrefstyle="select:label title nopage"/>に従って、<xref linkend="step-ha-config-gui-primitives-start" xrefstyle="select:label"/>を開始します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>適用</guimenu>をクリックしてリソーステンプレートの設定を完了します環境設定ダイアログが閉じて、メインウィンドウに新しく追加されたリソーステンプレートが表示されます。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-templates-use">
+   <procedure xml:id="pro-ha-config-gui-templates-use">
     <title>リソーステンプレートの参照</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しく作成したリソーステンプレートをプリミティブで参照するには、次の手順に従います。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         左側のペインで、<guimenu>リソース</guimenu>を選択し、<menuchoice> <guimenu>追加</guimenu><guimenu>プリミティブ</guimenu></menuchoice>の順にクリックします。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         固有の<guimenu>ID</guimenu>を入力して、<guimenu>クラス</guimenu>、<guimenu>プロバイダ</guimenu>、および<guimenu>タイプ</guimenu>を指定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         参照する<guimenu>テンプレート</guimenu>を選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         テンプレートのものとは異なる特定のインスタンス属性、操作またはメタ属性を設定する場合には、<xref linkend="pro-ha-config-gui-primitives"/>で説明した方法で、リソースの設定を継続します。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しく作成したリソーステンプレートをコロケーションまたは順序の制約で参照するには
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         制約を<xref linkend="pro-ha-config-gui-constraints-collocation"/>または<xref linkend="pro-ha-config-gui-constraints-order"/>でそれぞれ説明した方法で設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         コロケーション制約の場合には、<guimenu>リソース</guimenu>ドロップダウンリストに、設定されたすべてのリソースとリソーステンプレートのIDが表示されます。参照するテンプレートを選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         同様に、順序の制約の場合には、<guimenu>最初</guimenu>および<guimenu>次</guimenu>ドロップダウンリストに、リソースとリソーステンプレートの両方が表示されます。参照するテンプレートを選択します。
        </para>
@@ -534,9 +538,9 @@ Please see LICENSE.txt for this document's license.
      </substeps>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-constraints">
+  <section xml:id="sec-ha-configuration-constraints">
    <title>リソース制約の設定</title>
    <para>
     すべてのリソースを設定する以外にも、多くの作業が必要です。クラスタが必要なすべてのリソースを認識しても、正しく処理できるとは限りません。リソースの制約を指定して、リソースを実行可能なクラスタノード、リソースのロード順序、特定のリソースが依存している他のリソースを指定することができます。
@@ -550,45 +554,45 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-constraints-location">
+   <procedure xml:id="pro-ha-config-gui-constraints-location">
     <title>場所の制約を追加または変更する</title>
-    <step id="step-ha-configuration-constraints-start" performance="required">
+    <step xml:id="step-ha-configuration-constraints-start">
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Pacemaker GUIのメインウィンドウの左側のペインで、<guimenu>制約</guimenu>をクリックして、そのクラスタに設定されている制約を表示します。
      </para>
     </step>
-    <step id="step-ha-configuration-constraints-stop" performance="required">
+    <step xml:id="step-ha-configuration-constraints-stop">
      <para>
       左側のペインで<guimenu>制約</guimenu>を選択し、<guimenu>追加</guimenu>をクリックします。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Resource Location (リソース位置)</guimenu>を選択し、<guimenu>OK</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約に固有の<guimenu>ID</guimenu>を入力します。既存の制約を変更する場合、IDはすでに定義されているため、環境設定ダイアログに表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約を設定する<guimenu>リソース</guimenu>を選択します。リストには、そのクラスタに設定されているすべてのリソースのIDが表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約の<guimenu>Score (スコア)</guimenu>を設定します。正の値は、下で指定した<guimenu>ノード</guimenu>でリソースを実行できることを示します。負の値は、リソースをこのノードで実行すべきではないことを示します。スコアを<literal>INFINITY</literal>に設定すれば、リソースはこのノードで実行されるように強制されます。<literal>-INFINITY</literal>に設定すれば、リソースはそのノードで実行してはならないことになります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約を設定する<guimenu>ノード</guimenu>を選択します。
      </para>
@@ -603,47 +607,47 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       <guimenu>ノード</guimenu>および<guimenu>Score (スコア)</guimenu>フィールドを空のままにしておくと、<menuchoice><guimenu>追加</guimenu><guimenu>ルール</guimenu></menuchoice>の順にクリックしてルールを追加することもできます。有効期間を追加するには、<menuchoice><guimenu>追加</guimenu><guimenu>有効期間</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおり設定されたら、<guimenu>OK</guimenu>をクリックして、制約の設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに新しく追加または変更された制約が表示されます。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-collocation">
+   <procedure xml:id="pro-ha-config-gui-constraints-collocation">
     <title>コロケーション制約を追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Pacemaker GUIのメインウィンドウの左側のペインで、<guimenu>制約</guimenu>をクリックして、そのクラスタに設定されている制約を表示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで<guimenu>制約</guimenu>を選択し、<guimenu>追加</guimenu>をクリックします。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Resource Colocation (リソースのコロケーション)</guimenu>を選択し、<guimenu>OK</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約に固有の<guimenu>ID</guimenu>を入力します。既存の制約を変更する場合、IDはすでに定義されているため、環境設定ダイアログに表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       コロケーションソースとなる<guimenu>リソース</guimenu>を選択します。リストには、そのクラスタに設定されているすべてのリソースとリソーステンプレートのIDが表示されます。
      </para>
@@ -651,23 +655,23 @@ Please see LICENSE.txt for this document's license.
       制約が満たされないと、クラスタはリソースがまったく実行しないようにすることがあります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       <guimenu>リソース</guimenu>と<guimenu>With Resource (対象リソース)</guimenu>フィールドを両方とも空のままにしておくと、<menuchoice><guimenu>追加</guimenu><guimenu>リソースセット</guimenu></menuchoice>の順にクリックしてリソースを追加することもできます。有効期間を追加するには、<menuchoice><guimenu>追加</guimenu><guimenu>有効期間</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>With Resource (対象リソース)</guimenu>には、コロケーション先を定義します。クラスタはこのリソースの配置先を最初に決定し、次に<guimenu>リソース</guimenu>フィールドのリソースを配置する場所を決定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Score (スコア)</guimenu>を定義して、両方のリソース間の位置関係を決定します。正の値は、リソースを同じノードで実行するべきであることを示します。負の値は、リソースを同じノードで実行するべきではないことを示します。スコアを<literal>INFINITY</literal>に設定すれば、リソースは同じノードで実行されるように強制されます。<literal>-INFINITY</literal>に設定すれば、リソースは同じノードで実行してはならないことになります。スコアと他の要因との組み合わせによって、ノードの配置先が決定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要に応じて、<guimenu>Resource Role (リソース役割)</guimenu>などの追加のパラメータも指定します。
      </para>
@@ -675,46 +679,46 @@ Please see LICENSE.txt for this document's license.
       選択したパラメータとオプションに応じて、短い<guimenu>説明</guimenu>が表示され、設定しているコロケーション制約の効果を確認できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおり設定されたら、<guimenu>OK</guimenu>をクリックして、制約の設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに新しく追加または変更された制約が表示されます。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-order">
+   <procedure xml:id="pro-ha-config-gui-constraints-order">
     <title>順序の制約を追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Pacemaker GUIのメインウィンドウの左側のペインで、<guimenu>制約</guimenu>をクリックして、そのクラスタに設定されている制約を表示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで<guimenu>制約</guimenu>を選択し、<guimenu>追加</guimenu>をクリックします。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Resource Order (リソース順序)</guimenu>を選択し、<guimenu>OK</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       制約に固有の<guimenu>ID</guimenu>を入力します。既存の制約を変更する場合、IDはすでに定義されているため、環境設定ダイアログに表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>最初</guimenu>では、<guimenu>次</guimenu>で指定するリソースの開始前に開始するリソースを定義します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>次</guimenu>では、<guimenu>最初</guimenu>のリソースより後に開始するリソースを定義します。
      </para>
@@ -722,24 +726,24 @@ Please see LICENSE.txt for this document's license.
       選択したパラメータとオプションに応じて、短い<guimenu>説明</guimenu>が表示され、設定している順序の制約の効果を確認できます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要な場合は、さらにパラメータを定義します。たとえば、次のように定義します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <guimenu>スコア</guimenu>でスコアを指定します。制約は、ゼロより大きい場合は必須になりますが、そうでない場合はアドバイスにすぎません。デフォルト値は、<literal>INFINITY</literal>です。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>シンメトリック</guimenu>の値を指定します。<literal>true</literal>を指定した場合は、リソースが逆の順序で停止されます。デフォルト値は、<literal>true</literal>です。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおり設定されたら、<guimenu>OK</guimenu>をクリックして、制約の設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに新しく追加または変更された制約が表示されます。
      </para>
@@ -759,9 +763,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failover">
+  <section xml:id="sec-ha-configuration-failover">
    <title>リソースフェールオーバーノードの指定</title>
    <para>
     リソースに障害が発生すると、自動的に再起動されます。現在のノードで再起動できない場合、または現在のノードでN回失敗した場合は、別のノードへのフェールオーバーが試行されます。新しいノードへのマイグレートを行う基準(<literal>migration-threshold</literal>)となるリソースの失敗数を定義できます。クラスタ内に3つ以上ノードがある場合、特定のリソースのフェールオーバー先のノードはHigh Availabilityソフトウェアが選択します。
@@ -769,24 +773,24 @@ Please see LICENSE.txt for this document's license.
    <para>
     ただし、次の手順を実行すると、リソースのフェールオーバー先のノードを指定できます。
    </para>
-   <procedure id="pro-ha-config-gui-failover">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-failover">
+    <step>
      <para>
       <xref linkend="pro-ha-config-gui-constraints-location"/>に記載の手順に従って、そのリソースの場所の制約を設定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-config-gui-parameters"/>に記載の手順に従って、<literal>migration-threshold</literal>メタ属性をそのリソースに追加し、マイグレーションしきい値の<guimenu>値</guimenu>を入力します。INFINITY未満の正の値を指定する必要があります。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースの失敗回数を自動的に失効させる場合は、<xref linkend="pro-ha-config-gui-parameters"/>に記載の手順に従って<literal>failure-timeout</literal>メタ属性をそのリソースに追加し、失敗タイムアウトの<guimenu>値</guimenu>を入力します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースの初期設定として、追加のフェールオーバーノードを指定する場合は、追加の場所の制約を作成します。
      </para>
@@ -798,9 +802,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     リソースの失敗回数は、自動的に期限切れにする代わりに、いつでも、手動でクリーンアップすることもできます。詳細については、<xref linkend="sec-ha-configuration-cleanup"/>を参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failback">
+  <section xml:id="sec-ha-configuration-failback">
    <title>リソースフェールバックノードの指定(リソースの固着性)</title>
    <para>
     ノードがオンライン状態に戻り、クラスタ内にある場合は、リソースが元のノードにフェールバックすることがあります。フェールオーバー前にリソースを実行していたノードにリソースをフェールバックさせたくない場合や、リソースのフェールバック先として別のノードを指定する場合は、リソースの固着性の値を変更する必要があります。リソースの固着性は、リソースの作成時でも、その後でも指定できます。
@@ -811,9 +815,9 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-stickiness">
+   <procedure xml:id="pro-ha-config-gui-stickiness">
     <title>リソースの固着性を指定する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-config-gui-parameters"/>に従って、<literal>resource-stickiness</literal>メタ属性をリソースに追加します。
      </para>
@@ -828,15 +832,15 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       resource-stickinessの<guimenu>値</guimenu>として、<literal>-INFINITY</literal>から<literal>INFINITY</literal>の範囲の値を指定します。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-utilization">
+  <section xml:id="sec-ha-configuration-utilization">
    <title>負荷インパクトに基づくリソース配置の設定</title>
    <para>
     すべてのリソースが同等ではありません。Xenゲストなどの一部のリソースでは、そのホストであるノードがリソースの容量要件を満たす必要があります。リソースの組み合わされたニーズが提供された容量より大きくなるようにリソースが配置されると、リソースのパフォーマンスが低下します(あるいは失敗することさえあります)。
@@ -867,66 +871,66 @@ Please see LICENSE.txt for this document's license.
    <para>
     リソースの要件とノードが提供する容量を手動で設定するには、<xref linkend="pro-ha-config-gui-capacity"/>の手順に従ってください。使用属性に任意の名前を付け、設定に必要なだけ名前/値のペアを定義します。
    </para>
-   <procedure id="pro-ha-config-gui-capacity">
+   <procedure xml:id="pro-ha-config-gui-capacity">
     <title>使用属性を追加または変更する</title>
     <para>
      次の例では、クラスタのノードとリソースの基本設定がすでに完了しているところへ、さらに、一定のノードが提供する容量と一定のリソースが必要とする容量の設定を行う場合を想定しています。使用属性の追加手順は、基本的に同じであり、異なるのは<xref linkend="step-ha-config-gui-capacity-node"/>と<xref linkend="step-ha-config-gui-capacity-resource"/>だけです。
     </para>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-node" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-node">
      <para>
       ノードが<emphasis>提供する</emphasis>容量を指定するには、次の手順に従います。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         左ペインで、<guimenu>ノード</guimenu>をクリックします。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         右ペインで、容量を設定するノードを選択し、<guimenu>編集</guimenu>をクリックします。
        </para>
       </step>
      </substeps>
     </step>
-    <step id="step-ha-config-gui-capacity-resource" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-resource">
      <para>
       リソースが<emphasis>要求する</emphasis>容量を指定するには、次の手順に従います。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         左ペインで、<guimenu>リソース</guimenu>をクリックします。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         右ペインで、容量を設定するリソースを選択して、<guimenu>編集</guimenu>をクリックします。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>使用</guimenu>タブを選択し、<guimenu>追加</guimenu>をクリックして使用属性を追加します。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-name" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-name">
      <para>
       新しい属性の<guimenu>名前</guimenu>を入力します。使用属性には、好きな名前を付けることができます。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-value" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-value">
      <para>
       属性の<guimenu>値</guimenu>を入力し、<guimenu>OK</guimenu>をクリックします。属性値は整数にする必要があります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用属性をさらに追加する場合は、<xref linkend="step-ha-config-gui-capacity-attr-name"/>から<xref linkend="step-ha-config-gui-capacity-attr-value"/>まで繰り返します。
      </para>
@@ -934,7 +938,7 @@ Please see LICENSE.txt for this document's license.
       <guimenu>使用</guimenu>タブに、そのノードまたはリソースに定義した使用属性の要約が表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが望みどおりに設定されたら、<guimenu>OK</guimenu>をクリックして、設定ダイアログを閉じます。
      </para>
@@ -943,7 +947,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     <xref linkend="fig-ha-config-gui-capacit-node"/>は、8つのCPUユニットと16GBのメモリを、そのノードで実行中のリソースに提供するノードの設定を示しています。
    </para>
-   <figure id="fig-ha-config-gui-capacit-node">
+   <figure xml:id="fig-ha-config-gui-capacit-node">
     <title>ノード容量の設定例</title>
     <mediaobject>
      <imageobject role="fo">
@@ -957,7 +961,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     たとえば、ノードの4096メモリ単位と4つのCPUユニットを必要とするリソースの設定例は、次のようになります。
    </para>
-   <figure id="fig-ha-config-gui-capacit-resource">
+   <figure xml:id="fig-ha-config-gui-capacit-resource">
     <title>リソース容量の設定例</title>
     <mediaobject>
      <imageobject role="fo">
@@ -971,68 +975,68 @@ Please see LICENSE.txt for this document's license.
    <para>
     ノードが提供する容量とリソースが要求する容量を(手動または自動で)設定した後、グローバルクラスタオプションで配置ストラテジを設定する必要があります。これを設定しないと、容量の設定は有効になりません。負荷のスケジュールに使用できるストラテジがいくつかあります。たとえば、負荷をできるだけ少ない数のノードに集中したり、使用可能なすべてのノードに均等に分散できます。詳細については、<xref linkend="sec-ha-config-basics-utilization"/>を参照してください。
    </para>
-   <procedure id="pro-ha-config-gui-placement">
+   <procedure xml:id="pro-ha-config-gui-placement">
     <title>配置ストラテジを設定する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <menuchoice><guimenu>表示</guimenu><guimenu>簡易モード</guimenu></menuchoice>の順に選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>CRM Config</guimenu>を選択して、グローバルクラスタオプションとそれらの現在の値を表示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要件に応じて、<guimenu>配置ストラテジ</guimenu>を適切な値に設定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       何らかの理由でフェンシングを無効にする必要がある場合は、<literal>Stonith Enabled</literal>の選択を解除します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>適用</guimenu>をクリックして、変更を確認します。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-monitor">
+  <section xml:id="sec-ha-configuration-monitor">
    <title>リソース監視の設定</title>
    <para>
     High Availability Extensionはノード障害を検出できますが、ノード上の個々のリソースで障害が発生した場合にも検出することができます。リソースが実行中であるかどうか確認するには、そのリソースにリソースの監視を設定しておく必要があります。リソース監視は、タイムアウト、開始遅延のいずれか、または両方と、間隔を指定することで設定できます。間隔の指定によって、CRMにリソースステータスの確認頻度を指示します。<literal>start</literal>または<literal>stop</literal>操作に対する<literal>Timeout</literal>など、特定のパラメータも設定できます。
    </para>
-   <procedure id="pro-ha-config-gui-operations">
+   <procedure xml:id="pro-ha-config-gui-operations">
     <title>監視操作を追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Pacemaker GUIのメインウィンドウの左側のペインで、<guimenu>リソース</guimenu>をクリックして、そのクラスタに設定されているリソースを表示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右側のペインで、変更するリソースを選択して<guimenu>編集</guimenu>をクリックします。次のウィンドウには、そのリソースに定義された基本的なリソースパラメータとメタ属性、インスタンス属性、および操作が表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しい監視操作を追加するには、該当するタブを選択して<guimenu>追加</guimenu>をクリックします。
      </para>
@@ -1042,7 +1046,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       <guimenu>名前</guimenu>で、<literal>monitor</literal>、<literal>start</literal>、<guimenu>stop</guimenu>など、実行するアクションを選択します。
      </para>
@@ -1060,17 +1064,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>タイムアウト</guimenu>フィールドに、値を秒単位で入力します。指定したタイムアウトを過ぎると、操作は<literal>failed</literal>と見なされます。PEは何を行うか、あるいは監視操作の<guimenu>On Fail (障害発生時の動作)</guimenu>フィールドで指定した内容を実行するかどうかを判断します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要な場合は、<guimenu>オプション</guimenu>セクションを開いて、<guimenu>失敗の場合</guimenu>(このアクションが失敗した場合の処理)または<guimenu>必要</guimenu>(このアクションを発生する前に満たす必要がある条件)などのパラメータを追加します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>OK</guimenu>をクリックして、そのリソースの設定を完了します。設定ダイアログが閉じて、メインウィンドウに変更されたリソースが表示されます。
      </para>
@@ -1093,9 +1097,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-group">
+  <section xml:id="sec-ha-configuration-group">
    <title>クラスタリソースグループの構成</title>
    <para>
     クラスタリソースの中には、他のコンポーネントやリソースに依存しており、各コンポーネントや各リソースを特定の順序で開始したり、同じサーバ上で一緒に実行しなければならないものもあります。この構成を簡単にするため、グループのコンセプトをサポートしています。
@@ -1109,39 +1113,39 @@ Please see LICENSE.txt for this document's license.
      グループには1つ以上のリソースを含む必要があります。空の場合は設定は無効になります。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-group">
+   <procedure xml:id="pro-ha-config-gui-group">
     <title>リソースグループを追加する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで<guimenu>リソース</guimenu>を選択し、<menuchoice><guimenu>追加</guimenu><guimenu>グループ</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       グループに固有の<guimenu>ID</guimenu>を入力します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>オプション</guimenu>の下で、<guimenu>Initial state of resource (リソースの当初の状態)</guimenu>を設定し、<guimenu>転送</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のステップでは、グループのサブリソースとしてプリミティブを追加できます。プリミティブは<xref linkend="pro-ha-config-gui-primitives"/>と類似の方法で作成します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>適用</guimenu>をクリックして、プリミティブの設定を完了します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のウィンドウでは、再度<guimenu>プリミティブ</guimenu>を選択し、<guimenu>OK</guimenu>をクリックすることで、グループのサブリソースの追加を継続できます。
      </para>
@@ -1149,12 +1153,12 @@ Please see LICENSE.txt for this document's license.
       グループに追加するプリミティブがなくなったら、代わりに<guimenu>キャンセル</guimenu>をクリックします。次のウィンドウには、そのグループに定義したパラメータの概要が表示されます。グループの<guimenu>メタ属性</guimenu>および<guimenu>プリミティブ</guimenu>の一覧が表示されます。<guimenu>プリミティブ</guimenu>タブのリソースの場所は、クラスタ内でのリソース開始順序を示します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       グループ内のリソースの順序は重要なので、<guimenu>上へ</guimenu>ボタンと<guimenu>下へ</guimenu>ボタンを使用して、グループ内で<guimenu>プリミティブ</guimenu>をソートします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのパラメータが希望どおりに設定されたら、<guimenu>OK</guimenu>をクリックして、そのグループの設定を完了します。環境設定ダイアログが閉じ、メインウィンドウに新しく作成された、または変更されたグループが表示されます。
      </para>
@@ -1177,76 +1181,76 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-group-modify">
+   <procedure xml:id="pro-ha-config-gui-group-modify">
     <title>既存のグループにリソースを追加する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで<guimenu>リソース</guimenu>ビューに切り替え、右側のペインで、変更するグループを選択して<guimenu>編集</guimenu>をクリックします。次のウィンドウには、そのリソースに定義された基本的なグループパラメータとメタ属性とプリミティブが表示されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>プリミティブ</guimenu>タブをクリックして、<guimenu>追加</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のダイアログで、次のパラメータを設定してIPアドレスをグループのサブリソースとして追加します。
      </para>
      <substeps performance="required">
-      <step id="step-ha-config-gui-group-prim-start" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-start">
        <para>
         一意の<guimenu>ID</guimenu>を入力します(たとえば、<literal>my_ipaddress</literal>)。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>クラス</guimenu>リストで、リソースエージェントクラスとして<guimenu>ocf</guimenu>を選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         OCFリソースエージェントの<guimenu>プロバイダ</guimenu>として、<guimenu>heartbeat</guimenu>を選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>タイプ</guimenu>リストで、リソースエージェントとして<guimenu>IPaddr</guimenu>を選択します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>進む</guimenu>をクリックします。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>Instance Attribute (インスタンス属性)</guimenu>タブで、<guimenu>IP</guimenu>エントリを選択して<guimenu>編集</guimenu>をクリックします(または<guimenu>IP</guimenu>エントリをダブルクリックします)。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>値</guimenu>として、目的のIPアドレスを入力します。たとえば「<literal>192.168.1.180</literal>」と入力します。
        </para>
       </step>
-      <step id="step-ha-config-gui-group-prim-stop" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-stop">
        <para>
         <guimenu>OK</guimenu>、<guimenu>適用</guimenu>の順にクリックします。グループ設定ダイアログには、新しく追加去れたプリミティブが表示されます。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       再度<guimenu>追加</guimenu>をクリックして、次のサブリソース(ファイルシステムとWebサーバ)を追加します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       「<xref linkend="step-ha-config-gui-group-prim-start"/>」から「<xref linkend="step-ha-config-gui-group-prim-stop"/>」のような手順に従って、グループの全サブリソースの設定を終了するまで、各サブリソースの該当するパラメータを設定します。
      </para>
@@ -1264,25 +1268,25 @@ Please see LICENSE.txt for this document's license.
       クラスタ内で開始する順序でサブリソースを設定したので、<guimenu>プリミティブ</guimenu>タブ内の順序はすでに正しいものになっています。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       グループのリソースの順序を変更する必要がある場合は、<guimenu>上へ</guimenu>ボタンと<guimenu>下へ</guimenu>ボタンを使用して、<guimenu>プリミティブ</guimenu>タブのリソースをソートします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       グループからリソースを削除するには、<guimenu>プリミティブ</guimenu>タブのリソースを選択し、<guimenu>削除</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>OK</guimenu>をクリックしてそのグループの設定を完了します。環境設定ダイアログが閉じて、メインウィンドウに変更されたグループが表示されます。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-clone">
+  <section xml:id="sec-ha-configuration-clone">
    <title>クローンリソースの設定</title>
    <para>
     クラスタ内の複数のノードで特定のリソースを同時に実行することができます。このためには、リソースをクローンとして設定する必要があります。クローンとして設定するリソースの1例として、STONITHや、OCFS2などのクラスタファイルシステムが挙げられます。提供されているどのリソースも、クローンとして設定できます。これは、リソースのリソースエージェントによってサポートされます。クローンリソースは、ホスティングされているノードによって異なる設定をすることもできます。
@@ -1290,47 +1294,47 @@ Please see LICENSE.txt for this document's license.
    <para>
     使用できるリソースクローンのタイプの概要については、<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>を参照してください。
    </para>
-   <procedure id="pro-ha-config-gui-clone">
+   <procedure xml:id="pro-ha-config-gui-clone">
     <title>クローンを追加または変更する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左側のペインで<guimenu>リソース</guimenu>を選択し、<menuchoice><guimenu>追加</guimenu><guimenu>クローン</guimenu></menuchoice>の順にクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クローンに固有の<guimenu>ID</guimenu>を入力します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>オプション</guimenu>の下で、<guimenu>Initial state of resource (リソースの当初の状態)</guimenu>を設定します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クローンに設定するオプションを起動し、<guimenu>転送</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のステップでは、<guimenu>プリミティブ</guimenu>または<guimenu>グループ</guimenu>をクローンのサブリソースとして追加することができます。<xref linkend="pro-ha-config-gui-primitives"/>または<xref linkend="pro-ha-config-gui-group"/>で説明している方法のように作成します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クローン設定ダイアログ内のすべてのパラメータが希望どおりに設定されたら、<guimenu>適用</guimenu>をクリックして、クローンの設定を完了します。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-manage">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-manage">
   <title>クラスタリソースの管理</title>
 
   <para>
@@ -1349,7 +1353,7 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <sect2 id="sec-ha-configuration-start">
+  <section xml:id="sec-ha-configuration-start">
    <title>リソースの開始</title>
    <para>
     クラスタリソースは、起動する前に、正しく設定されているようにします。たとえば、Apacheサーバをクラスタリソースとして使用する場合は、まず、Apacheサーバをセットアップし、Apacheの環境設定を完了してから、クラスタで個々のリソースを起動します。
@@ -1369,27 +1373,27 @@ Please see LICENSE.txt for this document's license.
    <para>
     Pacemaker GUIによるリソースの作成時に、リソースの初期状態を<literal>target-role</literal>メタ属性で設定できます。その値を<literal>stopped</literal>に設定した場合、リソースは、その作成後に自動的に起動しません。
    </para>
-   <procedure id="pro-ha-config-gui-start">
+   <procedure xml:id="pro-ha-config-gui-start">
     <title>新しいリソースを起動する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、リソースを右クリックして、コンテキストメニューから<guimenu>開始</guimenu>を選択します(または、ツールバーの<guimenu>リソースの開始</guimenu>アイコンを使用します)。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-cleanup">
+  <section xml:id="sec-ha-configuration-cleanup">
    <title>リソースのクリーンアップ</title>
    <para>
     リソースは、失敗した場合は自動的に再起動しますが、失敗のたびにリソースの失敗回数が増加します。リソースの失敗回数をPacemaker GUIで表示するには、左ペインで<guimenu>管理</guimenu>をクリックしてから、右ペインでリソースを選択します。リソースが失敗している場合は、その<guimenu>失敗回数</guimenu>が右ペインの中ほど(<guimenu>移行しきい値</guimenu>エントリの下)に表示されます。
@@ -1400,33 +1404,33 @@ Please see LICENSE.txt for this document's license.
    <para>
     リソースの失敗回数は、(リソースに<literal>failure-timeout</literal>オプションを設定することにより)自動的にリセットするか、または次に示すように手動でリセットできます。
    </para>
-   <procedure id="pro-ha-config-gui-clean">
+   <procedure xml:id="pro-ha-config-gui-clean">
     <title>リソースをクリーンアップする</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、該当するリソースを右クリックし、コンテキストメニューから<guimenu>リソースのクリーンアップ</guimenu>を選択します(またはツールバーの<guimenu>リソースのクリーンアップ</guimenu>アイコンを使用します)。
      </para>
      <para>
-      これによって指定したノード上の指定したリソースに対して、コマンド<command>crm_resource<option> -C</option></command>および<command>crm_failcount<option> -D</option></command>が実行されます。
+      これによって指定したノード上の指定したリソースに対して、コマンド<command>crm_resource</command> <option> -C</option>および<command>crm_failcount</command> <option> -D</option>が実行されます。
      </para>
     </step>
    </procedure>
    <para>
     詳細は、<command>crm_resource</command>および<command>crm_failcount</command>のマニュアルページを参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-remove">
+  <section xml:id="sec-ha-configuration-remove">
    <title>クラスタリソースの削除</title>
    <para>
     リソースをクラスタから削除する必要がある場合は、次の手順に従って、設定エラーが発生しないようにします。
@@ -1438,59 +1442,59 @@ Please see LICENSE.txt for this document's license.
      何らかの制約によってIDが参照されているクラスタリソースは削除できません。リソースを削除できない場合は、リソースIDが参照されている場所を確認し、最初に制約からリソースを削除します。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-rm">
+   <procedure xml:id="pro-ha-config-gui-rm">
     <title>クラスタリソースの削除</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、該当するリソースを選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-config-gui-clean"/>の説明に従って、すべてのノードでリソースをクリーンアップします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>停止</guimenu>でリソースを停止します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースに関するすべての制約を削除します。これを行わないと、リソースは削除できません。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-migrate">
+  <section xml:id="sec-ha-configuration-migrate">
    <title>クラスタリソースの移行</title>
    <para>
     <xref linkend="sec-ha-configuration-failover"/>で説明したように、ソフトウェアまたはハードウェアの障害時には、クラスタは定義可能な特定のパラメータ(たとえばマイグレーションしきい値やリソースの固着性など)に従って、リソースを自動的にフェールオーバー(マイグレート)させます。それ以外に、クラスタ内の別なノードにリソースを手動でマイグレートさせることもできます。
    </para>
-   <procedure id="pro-ha-config-gui-migrate">
+   <procedure xml:id="pro-ha-config-gui-migrate">
     <title>リソースを手動で移行する</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、該当するリソースを右クリックし、<guimenu>リソースの移行</guimenu>を選択します。
      </para>
@@ -1505,17 +1509,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新規ウィンドウで、<guimenu>To Node (マイグレート先ノード)</guimenu>で、リソースの移動先ノードを選択します。これによって移動先ノードに対して<literal>INFINITY</literal>スコアの場所の制約が作成されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースを一時的にマイグレートするには、<guimenu>Duration (期間)</guimenu>をアクティブにしてリソースが新規ノードにマイグレートされる時間を入力します。指定した時間を経過したら、リソースは元の場所に戻ることが<emphasis>できます</emphasis>。あるいは、現在の場所に残ることもできます(リソースへの固着性による)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       リソースをマイグレートできない場合は(リソースの固着性と制約スコアの合計が現在のノードで<literal>INFINITY</literal>を超えている場合)、<guimenu>強制</guimenu>オプションを有効にします。これによって現在の場所に対するルールと<literal>-INFINITY</literal>のスコアを作成して、リソースを強制的に移動させます。
      </para>
@@ -1525,7 +1529,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>OK</guimenu>をクリックして、マイグレーションを確認します。
      </para>
@@ -1534,55 +1538,55 @@ Please see LICENSE.txt for this document's license.
    <para>
     リソースを再び元に戻すには、次の手順に従います。
    </para>
-   <procedure id="pro-ha-config-gui-migrate-back">
+   <procedure xml:id="pro-ha-config-gui-migrate-back">
     <title>移行制約をクリアする</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、該当するリソースを右クリックし、<guimenu>移行制約のクリア</guimenu>を選択します。
      </para>
      <para>
-      これによって、<command>crm_resource <option>-U</option></command>コマンドが使用されます。リソースは元の場所に戻ることができます<emphasis/>。あるいは現在の場所に残ることもあります(リソースの固着性によって)。
+      これによって、<command>crm_resource </command> <option>-U</option>コマンドが使用されます。リソースは元の場所に戻ることができます<emphasis/>。あるいは現在の場所に残ることもあります(リソースの固着性によって)。
      </para>
     </step>
    </procedure>
    <para>
-    詳細は、<command>crm_resource</command>のマニュアルページ、または<citetitle>Pacemaker Explained</citetitle>を参照してください。<ulink url="http://www.clusterlabs.org/doc/"/>から入手できます。特に、「<citetitle>Resource Migration</citetitle>」のセクションを参照してください。
+    詳細は、<command>crm_resource</command>のマニュアルページ、または<citetitle>Pacemaker Explained</citetitle>を参照してください。<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手できます。特に、「<citetitle>Resource Migration</citetitle>」のセクションを参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-mgmt-mode">
+  <section xml:id="sec-ha-configuration-mgmt-mode">
    <title>リソースの管理モードの変更</title>
    <para>
     リソースがクラスタで管理されているときは、他の方法で(つまり、クラスタ外で)リソースを操作しないでください。個々のリソースの保守する場合は、各リソースを<literal>unmanaged mode</literal>に設定すると、クラスタ外でそのリソースを変更できます。
    </para>
    <procedure>
     <title>リソースの管理モードの変更</title>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       左ペインで、<guimenu>管理</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       右ペインで、該当するリソースを右クリックし、コンテキストメニューから、<guimenu>リソースの管理解除</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       そのリソースの保守作業を完了したら、右ペインで、再び該当するリソースを右クリックして、<guimenu>リソースの管理</guimenu>を選択します。
      </para>
@@ -1591,6 +1595,6 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/ja/xml/ha_config_hawk.xml
+++ b/ja/xml/ha_config_hawk.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_hawk.xml" id="cha-ha-config-hawk">
- <title>クラスタリソースの設定と管理(Webインタフェース)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_hawk.xml" xml:id="cha-ha-config-hawk"><title>クラスタリソースの設定と管理(Webインタフェース)</title><info><abstract>
   <para>
    <command>crm</command>コマンドラインツールとPacemaker GUIの他に、High Availability Extensionには、管理作業用のWebベースのユーザインタフェースであるHA Web Konsole (Hawk)も付属しています。このインタフェースを使用すれば、Linux以外のコンピュータからも、Linuxクラスタを監視し、管理することができます。さらにこれは、ご使用のシステムが最小限のグラフィカルユーザインタフェースしか提供していない場合に最適なソリューションです。
   </para>
@@ -15,15 +17,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    この章では、Hawkを紹介し、グローバルクラスタオプションの変更、基本的なリソースと高度なリソース(グループとクローン)の作成、制約の設定、フェールオーバーノードとフェールバックノードの指定、リソースモニタリングの設定、リソースの始動、クリーンアップ、または削除、および手動によるリソースの移行など、クラスタリソースの設定と管理のための基本的な作業について説明します。Hawkは、クラスタステータスの詳細な分析のために、クラスタレポート(<literal>hb_report</literal>)を生成します。クラスタの履歴を表示できます。また、シミュレータにより、可能性のある障害シナリオを検討することができます。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-hawk-intro">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-hawk-intro">
   <title>Hawk - 概要</title>
 
   <para>
    HawkのWebインタフェースを使用すれば、Linux以外のマシンからも、Linuxクラスタを監視し、管理することができます。さらにこれは、ご使用のシステムが最小限のグラフィカルユーザインタフェースしか提供していない場合に最適なソリューションです。
   </para>
 
-  <sect2 id="sec-ha-config-hawk-intro-connect">
+  <section xml:id="sec-ha-config-hawk-intro-connect">
    <title>Hawkの起動とログイン</title>
    <para>
     このWebインタフェースは、<systemitem class="resource">hawk</systemitem>パッケージに含まれています。これは、Hawkで接続するすべてのクラスタノードにインストールする必要があります。Hawkを使用してクラスタノードにアクセスするマシンに必要なものは、JavaScriptとクッキーを有効にして接続を確立できる(グラフィカル)Webブラウザだけです。
@@ -34,20 +38,20 @@ Please see LICENSE.txt for this document's license.
    <para>
     <systemitem class="resource">sleha-bootstrap</systemitem>パッケージのスクリプトを使用してクラスタをセットアップした場合は、Hawkサービスがすでに開始されています。その場合は、<xref linkend="pro-ha-hawk-service"/>をスキップして<xref linkend="pro-ha-hawk-login"/>に進みます。
    </para>
-   <procedure id="pro-ha-hawk-service">
+   <procedure xml:id="pro-ha-hawk-service">
     <title>Hawkサービスの開始</title>
-    <step performance="required">
+    <step>
      <para>
       接続先にするノードで、シェルを開き、<systemitem class="username">root</systemitem>としてログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のように入力して、サービスのステータスをチェックします。
      </para>
 <screen><prompt role="root">root # </prompt>rchawk status</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       サービスが実行されていない場合は、次のコマンドでサービスを開始します。
      </para>
@@ -70,7 +74,7 @@ Please see LICENSE.txt for this document's license.
      Hawkを使用して接続する各ノードでこれを実行します。
     </para>
    </note>
-   <procedure id="pro-ha-hawk-login">
+   <procedure xml:id="pro-ha-hawk-login">
     <title>Hawk Webインタフェースへのログイン</title>
     <para>
      Hawk Webインタフェースは、HTTPSプロトコルとポート<literal>7630</literal>を使用します。
@@ -80,12 +84,12 @@ Please see LICENSE.txt for this document's license.
      <title>仮想IPによるHawkへのアクセス</title>
      <para>通常接続するクラスタノードがダウンしている場合でもHawkにアクセスできるようにするには、クラスタリソースとしてのHawkに仮想IPアドレス(<literal>IPaddr</literal>または<literal>IPaddr2</literal>)を設定します。そのための特別な設定は不要です。</para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       任意のコンピュータで、Webブラウザを起動し、JavaScriptとクッキーが有効なことを確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       URLとして、Hawk Webサービスを実行するクラスタノードのIPアドレスまたはホスト名を入力します。または、クラスタオペレータがリソースとして設定した可能性のある任意の仮想IPアドレスを入力します:
      </para>
@@ -106,12 +110,12 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Hawkログイン画面で、<systemitem class="username">hacluster</systemitem>ユーザ(または、<systemitem class="groupname">haclient</systemitem>グループのメンバーである他の任意のユーザ)の<guimenu>ユーザ名</guimenu>と<guimenu>パスワード</guimenu>を入力します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>ログイン</guimenu>をクリックします。
      </para>
@@ -120,15 +124,15 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-hawk-intro-main">
+  <section xml:id="sec-ha-config-hawk-intro-main">
    <title>メイン画面: クラスタステータス</title>
    
    <para>
     ログインした後、Hawkは<guimenu>クラスタステータス</guimenu>画面を表示します。重要なグローバルクラスタパラメータと、クラスタノードおよびリソースのステータスを示すサマリが表示されます。ノードとリソースのステータスを表示するのに、次のカラーコードが用いられます。
    </para>
-   <itemizedlist id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
+   <itemizedlist xml:id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
     <title>Hawkのカラーコード</title>
     <listitem>
      <para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
      <para>
       <guimenu>クラスタダイアグラム</guimenu>:ノードのグラフィック表現とCIBで設定されたリソースについては、このエントリを選択します。このダイアグラムには、リソースとノード割り当て(スコア)の間の順序とコロケーションも表示されます。
      </para>
-     <figure id="fig-ha-cluster-diagram" pgwide="0">
+     <figure xml:id="fig-ha-cluster-diagram" pgwide="0">
       <title>Hawk - クラスタダイアグラム</title>
       <mediaobject>
        <imageobject role="fo">
@@ -300,9 +304,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </note>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-hawk-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-hawk-global">
   <title>グローバルクラスタオプションの設定</title>
 
   <para>
@@ -322,14 +326,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-hawk-global">
+  <procedure xml:id="pro-ha-config-hawk-global">
    <title>グローバルクラスタオプションを変更する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタのプロパティ</guimenu>を選択して、グローバルクラスタオプションとそれらの現在の値を表示します。Hawkは、<guimenu>CRM設定</guimenu>、<guimenu>リソースのデフォルト</guimenu>、<guimenu>操作のデフォルト</guimenu>に関する重要なパラメータを表示します。
 
@@ -346,17 +350,17 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタの要件に応じて、<guimenu>CRM Configuration</guimenu>を調整します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>no-quorum-policy</guimenu>を適切な値に設定します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        なんらかの理由でフェンシングを無効にする必要がある場合は、<guimenu>stonith-enabled</guimenu>の選択を解除します。
       </para>
@@ -367,41 +371,41 @@ Please see LICENSE.txt for this document's license.
        </para>
       </important>
      </step>
-     <step performance="required">
+     <step>
       <para>
        CRM設定からプロ化ティを削除するには、プロパティの横のマイナスアイコンをクリックします。プロパティが削除されたら、クラスタはそのプロパティがデフォルト値に設定されているように動作します。デフォルト値の詳細については、<xref linkend="sec-ha-config-basics-meta-attr"/>を参照してください。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        CRM設定に新しいプロパティを追加するには、ドロップダウンボックスからプロパティを1つ選択し、プラスアイコンをクリックします。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>リソースのデフォルト</guimenu>または<guimenu>操作のデフォルト</guimenu>を変更する必要がある場合は、次のような処理を実行します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        すでに表示されているデフォルトの値を変更するには、それぞれの入力フィールドで値を編集します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        新しいリソースのデフォルトまたは操作のデフォルトを追加するには、空のドロップダウンリストから1つ選択し、プラスアイコンをクリックして値を入力します。定義されたデフォルト値が存在する場合は、Hawkから自動的に提示されます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        リソースまたは操作のデフォルトを削除するには、パラメータの横のマイナスアイコンをクリックします。<guimenu>リソースのデフォルト</guimenu>と<guimenu>操作のデフォルト</guimenu>に値が指定されていない場合、クラスタは<xref linkend="sec-ha-config-basics-meta-attr"/>および<xref linkend="sec-ha-config-basics-operations"/>にドキュメントされているデフォルト値を使用します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更内容を確認します。
     </para>
@@ -409,10 +413,10 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
 
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
- <sect1 id="sec-ha-config-hawk-dashboard">
+ </section>
+ <xi:include href="ha_hawk_rsc_config_i.xml" parse="xml"/>
+ <xi:include href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
+ <section xml:id="sec-ha-config-hawk-dashboard">
 
 
   <title>複数のクラスタの監視</title>
@@ -425,7 +429,7 @@ Please see LICENSE.txt for this document's license.
    <guimenu>Cluster Dashboard</guimenu>に表示されているクラスタ情報は、永続クッキーに保存されます。つまり、<guimenu>Cluster Dashboard</guimenu>を表示するHawkインスタンスを決定し、そのインスタンスを常に使用する必要があります。Hawkを実行するマシンは、その目的のためにクラスタの一部である必要はなく、別個の無関係のシステムで構いません。
   </para>
 
-  <procedure id="pro-ha-config-hawk-dashboard">
+  <procedure xml:id="pro-ha-config-hawk-dashboard">
    <title>Hawkによる複数クラスタの監視</title>
    <itemizedlist mark="bullet" spacing="normal">
     <title>前提条件</title>
@@ -445,18 +449,18 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <step performance="required">
+   <step>
     <para>
      複数のクラスタを監視するマシン上で、Hawk Webサービスを開始します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Webブラウザを起動して、Hawkを実行するマシンのIPアドレスまたはホスト名を入力します。
     </para>
 <screen>https://<replaceable>IPaddress</replaceable>:7630/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawkのログイン画面で、右上隅の<guimenu>ダッシュボード</guimenu>リンクをクリックします。
     </para>
@@ -474,12 +478,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>Cluster Dashboard</guimenu>でクラスタを識別するためのカスタムのクラスタ名を<guimenu>クラスタ名</guimenu>に入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタノードのいずれかの<guimenu>ホスト名</guimenu>を入力し、変更内容を確認します。
     </para>
@@ -487,7 +491,7 @@ Please see LICENSE.txt for this document's license.
      <guimenu>クラスタダッシュボード</guimenu>が開き、追加したクラスタのサマリが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ダッシュボードにクラスタをさらに追加するには、プラスアイコンをクリックして、次のクラスタの詳細を入力します。
     </para>
@@ -503,12 +507,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ダッシュボードからクラスタを削除するには、クラスタのサマリの隣の<literal>x</literal>アイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタの詳細を表示するには、ダッシュボード上でクラスタのボックス内の任意の場所をクリックします。
     </para>
@@ -516,7 +520,7 @@ Please see LICENSE.txt for this document's license.
      これにより、新しいブラウザウィンドウまたは新しいブラウザタブが開きます。クラスタに現在ログインしていない場合は、Hawkのログイン画面が開きます。ログインしたら、Hawkのサマリビューに、そのクラスタの<guimenu>クラスタステータス</guimenu>が表示されます。その時点から、Hawkで通常どおりにクラスタを管理できます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>クラスタダッシュボード</guimenu>は独立したブラウザウィンドウまたはタブで開いたままになっているので、ダッシュボードとHawkによる個々のクラスタの管理とは、簡単に切り替えることができます。
     </para>
@@ -528,15 +532,15 @@ Please see LICENSE.txt for this document's license.
   </para>
 
 
- </sect1>
- <sect1 id="sec-ha-config-hawk-geo">
+ </section>
+ <section xml:id="sec-ha-config-hawk-geo">
   <title>GeoクラスタのＨａｗｋ</title>
 
   <para>
    地理的に離れたクラスタ(Geoクラスタ)に関連するHawk機能の詳細については、『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』<citetitle><phrase role="productname"><phrase os="sles"/></phrase></citetitle>を参照してください。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-hawk-trouble">
+ </section>
+ <section xml:id="sec-ha-config-hawk-trouble">
   <title>トラブルシューティング</title>
 
   <variablelist>
@@ -559,7 +563,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-hawk-certificate">
+   <varlistentry xml:id="vle-ha-hawk-certificate">
     <term>自己署名証明書の置き換え</term>
     <listitem>
      <para>
@@ -605,5 +609,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_drbd.xml
+++ b/ja/xml/ha_drbd.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_drbd.xml" id="cha-ha-drbd">
- <title>DRBD</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_drbd.xml" xml:id="cha-ha-drbd"><title>DRBD</title><info><abstract>
   <para>
    <emphasis>分散複製ブロックデバイス</emphasis>(DRBD*)を使用すると、IPネットワーク内の2つの異なるサイトに位置する2つのブロックデバイスのミラーを作成できます。OpenAISと共に使用すると、DRBDは分散高可用性Linuxクラスタをサポートします。この章では、DRBDのインストールとセットアップの方法を示します。
   </para>
- </abstract>
- <sect1 id="sec-ha-drbd-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-drbd-overview">
   <title>概念の概要</title>
 
   <para>
@@ -31,7 +35,7 @@ Please see LICENSE.txt for this document's license.
    DRBDは、Linuxカーネルモジュールであり、下端のI/Oスケジューラと上端のファイルシステムの間に存在しています(<xref linkend="fig-ha-drbd-concept"/>参照)。DRBDと通信するには、高レベルのコマンド<command>drbdadm</command>を使用します。柔軟性を最大にするため、DRBDには、低レベルのツール<command>drbdsetup</command>が付いてきます。
   </para>
 
-  <figure id="fig-ha-drbd-concept">
+  <figure xml:id="fig-ha-drbd-concept">
    <title>Linux内でのDRBDの位置</title>
    <mediaobject>
     <imageobject role="fo">
@@ -85,8 +89,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    たとえば、rawデバイスのサイズが1024MBの場合、DRBDデバイスは、1023MBしかデータ用に使用できません。70KBは隠され、メタデータ用に予約されています。<filename>/dev/drbd<replaceable>N</replaceable></filename>を介した既存のキロバイトへのアクセスは、それがユーザデータ用でないので、すべて失敗します。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-install">
+ </section>
+ <section xml:id="sec-ha-drbd-install">
   <title>DRBDサービスのインストール</title>
 
   <para>
@@ -97,7 +101,7 @@ Please see LICENSE.txt for this document's license.
    クラスタのスタックを完了する必要がなく、DRBDを使用したいだけの場合、<xref linkend="tab-ha-drbd-rpmfiles"/>を参照してください。DRBDのすべてのRPMパッケージのリストが含まれています。<systemitem>drbd</systemitem>パッケージは最近、別々のパッケージに分けられました。
   </para>
 
-  <table id="tab-ha-drbd-rpmfiles">
+  <table xml:id="tab-ha-drbd-rpmfiles">
    <title>DRBD RPMパッケージ</title>
    <tgroup cols="2">
     <thead>
@@ -248,8 +252,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    <systemitem class="username">root</systemitem>用に永続的に使用するには、ファイル<filename>/root/.bashrc</filename>を拡張し、前の行を挿入します。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-configure">
+ </section>
+ <section xml:id="sec-ha-drbd-configure">
   <title>DRBDサービスの設定</title>
 
   <note><title>必要な調整</title>
@@ -268,25 +272,25 @@ Please see LICENSE.txt for this document's license.
    DRBDを手動で設定するには、次の手順に従います。
   </para>
 
-  <procedure id="step-drbd-configure">
+  <procedure xml:id="step-drbd-configure">
    <title>DRBDの手動設定</title>
-   <step performance="required">
+   <step>
      <para>クラスタがすでにDRBDを使用している場合は、クラスタを保守モードにします。</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=true</screen> 
      <para>クラスタがすでにDRBDを使用している場合に、この手順をスキップすると、ライブ設定の構文エラーによってサービスがシャットダウンされます。</para>
      
    </step>
-   <step performance="required">
+   <step>
     <para>
      <systemitem class="username">root</systemitem>ユーザとしてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      DRBDの環境設定ファイルを変更します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        ファイル<filename>/etc/drbd.conf</filename>を開き、次の行を挿入します(これらの行がない場合)。
       </para>
@@ -296,7 +300,7 @@ include "drbd.d/*.res";</screen>
        DRBD 8.3以降、環境設定ファイルは、複数のファイルに分割され、<filename>/etc/drbd.d/</filename>ディレクトリに保存されています。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <filename>/etc/drbd.d/global_common.conf</filename>ファイルを開きます。このファイルには、すでにいくつかの事前定義値が含まれています。<literal>startup</literal>セクションに移動し、次の3行を挿入します。
       </para>
@@ -307,25 +311,25 @@ include "drbd.d/*.res";</screen>
     degr-wfc-timeout 120;
 }</screen>
       <para>
-       これらのオプションは、ブート時のタイムアウトを減らすために使用します。詳細については、<ulink url="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>を参照してください。
+       これらのオプションは、ブート時のタイムアウトを減らすために使用します。詳細については、<link xlink:href="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>を参照してください。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        ファイル<filename>/etc/drbd.d/r0.res</filename>を作成し、状況に合わせて行を変更し、ファイルを保存します。
       </para>
-<screen>resource r0 { <co id="co-drbd-config-r0"/>
-  device /dev/drbd0; <co id="co-drbd-config-device"/>
-  disk /dev/sda1; <co id="co-drbd-config-disk"/>
-  meta-disk internal; <co id="co-drbd-config-meta-disk"/>
-  on alice { <co id="co-drbd-config-resname"/>
-    address  192.168.1.10:7788; <co id="co-drbd-config-address"/>
+<screen>resource r0 { <co xml:id="co-drbd-config-r0"/>
+  device /dev/drbd0; <co xml:id="co-drbd-config-device"/>
+  disk /dev/sda1; <co xml:id="co-drbd-config-disk"/>
+  meta-disk internal; <co xml:id="co-drbd-config-meta-disk"/>
+  on alice { <co xml:id="co-drbd-config-resname"/>
+    address  192.168.1.10:7788; <co xml:id="co-drbd-config-address"/>
   }
   on bob { <xref linkend="co-drbd-config-resname" xrefstyle="selec:nopage"/>
     address 192.168.1.11:7788; <xref linkend="co-drbd-config-address" xrefstyle="selec:nopage"/>
   }
   syncer {
-    rate  7M; <co id="co-drbd-config-syncer-rate"/>
+    rate  7M; <co xml:id="co-drbd-config-syncer-rate"/>
   }
 }</screen>
       <calloutlist>
@@ -353,7 +357,7 @@ include "drbd.d/*.res";</screen>
        </callout>
        <callout arearefs="co-drbd-config-meta-disk">
         <para>
-         meta-diskパラメータには、通常、値<literal>internal</literal>が含まれますが、メタデータを保持する明示的なデバイスを指定することもできです。詳細については、<ulink url="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>を参照してください。
+         meta-diskパラメータには、通常、値<literal>internal</literal>が含まれますが、メタデータを保持する明示的なデバイスを指定することもできです。詳細については、<link xlink:href="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>を参照してください。
         </para>
        </callout>
        <callout arearefs="co-drbd-config-resname">
@@ -375,13 +379,13 @@ include "drbd.d/*.res";</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      環境設定ファイルの構文をチェックします。次のコマンドがエラーを返す場合は、ファイルを検証します。
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> dump all</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Csync2(デフォルト)を設定している場合、DRBD設定ファイルは、同期に必要なファイルのリストにすでに含まれています。同期するには、次のコマンドを使用します。
     </para>
@@ -392,7 +396,7 @@ include "drbd.d/*.res";</screen>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      各ノードで次のコマンドを入力することにより、<emphasis>両方の</emphasis>システムでメタデータを初期化します。
     </para>
@@ -403,7 +407,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
 <screen><prompt role="root">root # </prompt> <command>dd</command> if=/dev/zero of=/dev/sda1 count=16 bs=1M</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次のコマンドを各ノードで入力して、DRBDステータスをチェックします。
     </para>
@@ -416,13 +420,13 @@ m:res  cs         ro                   ds                         p  mounted  fs
 0:r0   Connected  Secondary/Secondary  Inconsistent/Inconsistent  C</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      プライマリにするノード(この場合はalice)で再同期プロセスを開始します。
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> -- --overwrite-data-of-peer primary r0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>rcdrbd status</command>を使用して、再びステータスをチェックすると、次のような結果が得られます。
     </para>
@@ -435,19 +439,19 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      <literal>ds</literal>行のステータス(ディスクステータス)は、両方のノードでUpToDateである必要があります。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      DRBDデバイスの上にファイルシステムを作成します。たとえば、次のように指定します。
     </para>
 <screen><prompt role="root">root # </prompt><command>mkfs.ext3</command> /dev/drbd/by-res/r0/0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ファイルシステムをマウントして使用します。
     </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> /dev/drbd /mnt/</screen>
    </step>
-   <step performance="required">
+   <step>
      <para>クラスタの保守モードフラグをリセットします。</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=false</screen> 
    </step>
@@ -459,20 +463,20 @@ m:res  cs         ro                 ds                 p  mounted  fstype
    または、YaSTを使用してDRBDを設定するには、次の手順を実行します。
   </para>
 
-  <procedure id="pro-drbd-configure-yast">
+  <procedure xml:id="pro-drbd-configure-yast">
    <title>YaSTを使用してDRBDを設定</title>
-   <step performance="required">
+   <step>
     <para>
      YaSTを起動して、設定モジュール<menuchoice><guimenu>高可用性</guimenu><guimenu>DRBD</guimenu></menuchoice>を選択します。すでにDRBDを設定していた場合、YaSTはそのことを警告します。YaSTは設定を変更し、古いDRBD設定ファイルを<filename>*.YaSTsave</filename>として保存します。
     </para>
      <para><menuchoice><guimenu>起動設定</guimenu><guimenu>ブート</guimenu></menuchoice>のブートフラグは、そのままにしてください(デフォルトでは<literal>off</literal>)。Pacemakerがこのサービスを管理するので変更しないでください。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースの実際の設定は、<guimenu>ソース設定</guimenu>で実行されます(<xref linkend="fig-ha-drbd-yast-resconfig"/>を参照)。
     </para>
     
-    <figure id="fig-ha-drbd-yast-resconfig">
+    <figure xml:id="fig-ha-drbd-yast-resconfig">
      <title>リソース設定</title>
      <mediaobject>
       <imageobject role="fo">
@@ -571,7 +575,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      これらのオプションはすべて、<filename>/usr/share/doc/packages/drbd-utils/drbd.conf</filename>ファイルの例と<command>drbd.conf(5)</command>のマニュアルページで説明されています。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Csync2(デフォルト)を設定している場合、DRBD設定ファイルは、同期に必要なファイルのリストにすでに含まれています。同期するには、次のコマンドを使用します。
     </para>
@@ -582,7 +586,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      各ノードで、次のように入力して、DRBDサービスを両方のシステム上で初期化し、起動します。
     </para>
@@ -591,13 +595,13 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> create-md r0
 <prompt role="root">root # </prompt><command>rcdrbrd</command> start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <filename>alice</filename>上で次のコマンドの入力により、<filename>alice</filename>をプライマリノードとして設定します。
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdsetup</command> /dev/drbd0 primary --overwrite-data-of-peer</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      各ノード で、次のコマンドを入力して、DRBDサービスのステータスをチェックします。
     </para>
@@ -606,56 +610,56 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      続行する前に、両方のノード のブロックデバイスが完全に同期されるまで待機します。<command>rcdrbd status</command>コマンドを繰り返して、同期の進捗を追跡します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      両方のノードのブロックデバイスが完全に同期されたら、希望のファイルシステムで、プライマリノード上のDRBDデバイスをフォーマットします。任意のLinuxファイルシステムを使用できます。<filename>/dev/drbd/by-res/<replaceable>RESOURCE</replaceable></filename>名を使用することをお勧めします。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-test">
+ </section>
+ <section xml:id="sec-ha-drbd-test">
   <title>DRBDサービスのテスト</title>
 
   <para>
    インストールと設定のプロシージャが予期どおりの結果となった場合は、DRBD機能の基本的なテストを実行できます。このテストは、DRDBソフトウェアの機能を理解する上でも役立ちます。
   </para>
 
-  <procedure id="pro-drbd-test">
-   <step performance="required">
+  <procedure xml:id="pro-drbd-test">
+   <step>
     <para>
      alice上でDRBDサービスをテストします。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        端末コンソールを開き、<systemitem>root</systemitem>としてログインします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        aliceにマウントポイント(<filename>/srv/r0</filename>など)を作成します。
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <command>drbd</command>デバイスをマウントします。
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd0 /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        プライマリノードからファイルを作成します。
       </para>
 <screen><prompt role="root">root # </prompt><command>touch</command> /srv/r0/from_alice</screen>
      </step>
-      <step performance="required">
+      <step>
         <para>
           aliceでディスクをマウント解除します。
         </para>
         <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
       </step>
-      <step performance="required">
+      <step>
         <para>
           aliceで次のコマンドを入力して、aliceのDRBDサービスを降格します。
         </para>
@@ -663,41 +667,41 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      bob上でDRBDサービスをテストします。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        端末コンソールを開き、bobで<systemitem>root</systemitem>としてログインします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        bobで、DRBDサービスをプライマリに昇格します。
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        bobで、bobがプライマリかどうかチェックします。
       </para>
 <screen><prompt role="root">root # </prompt><command>rcdrbd</command> status</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        bobで、<filename>/srv/r0mount</filename>などのマウントポイントを作成します。
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        bobで、DRBDデバイスをマウントします。
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd_r0 /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        aliceで作成したファイルが存在していることを確認します。
       </para>
@@ -708,35 +712,35 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      サービスが両方のノードで稼動していれば、DRBDの設定は完了です。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      再度、aliceをプライマリとして設定します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        bobで次のコマンドを入力して、bobのディスクをマウント解除します。
       </para>
 <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        bobで次のコマンドを入力して、bobのDRBDサービスを降格します。
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> secondary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        aliceで、DRBDサービスをプライマリに昇格します。
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        aliceで、aliceがプライマリかどうかチェックします。
       </para>
@@ -744,14 +748,14 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      サービスを自動的に起動させ、サーバに問題が発生した場合はフェールオーバーさせるためには、OpenAISでDRBDを高可用性サービスとして設定できます。OpenAIS for SUSE Linux Enterprise 11のインストールと設定については、<xref linkend="part-config"/>を参照してください。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-tuning">
+ </section>
+ <section xml:id="sec-ha-drbd-tuning">
   <title>DRBDのチューニング</title>
 
   <para>
@@ -789,18 +793,18 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
    </listitem>
     <listitem>
-      <para>ワークロードに従って読み込みバランスを有効にします。詳細については、<ulink url="http://blogs.linbit.com/p/256/read-balancing/"/>を参照してください。</para>
+      <para>ワークロードに従って読み込みバランスを有効にします。詳細については、<link xlink:href="http://blogs.linbit.com/p/256/read-balancing/"/>を参照してください。</para>
     </listitem>
   </orderedlist>
- </sect1>
- <sect1 id="sec-ha-drbd-trouble">
+ </section>
+ <section xml:id="sec-ha-drbd-trouble">
   <title>DRBDのトラブルシュート</title>
 
   <para>
    DRBDセットアップには、多数の異なるコンポーネントが使用され、別のソースから問題が発生することがあります。以降のセクションでは、一般的なシナリオをいくつか示し、さまざまなソリューションを推奨します。
   </para>
 
-  <sect2 id="sec-ha-drbd-trouble-config">
+  <section xml:id="sec-ha-drbd-trouble-config">
    <title>環境設定</title>
    <para>
     初期のDRBDセットアップが予期どおりに機能しない場合は、おそらく、環境設定に問題があります。
@@ -809,12 +813,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     環境設定の情報を取得するには:
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       端末コンソールを開き、<systemitem class="username">root</systemitem>としてログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <command>drbdadm</command>に<command>-d</command>オプションを指定して、環境設定ファイルをテストします。入力次のコマンドを入力します。
      </para>
@@ -823,12 +827,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       <command>adjust</command>オプションのドライ実行では、<command>drbdadm</command>は、DRBDリソースの実際の設定を使用中のDRBD環境設定ファイルと比較しますが、コールは実行しません。出力をレビューして、エラーのソースおよび原因を確認してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <filename>/etc/drbd.d/*</filename>ファイルと<filename>drbd.conf</filename>ファイルにエラーがある場合は、そのエラーを修正してから続行してください。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       パーティションと設定が正しい場合は、<command>drbdadm</command>を<command>-d</command>オプションなしで、再度実行します。
      </para>
@@ -838,9 +842,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-hostnames">
+  <section xml:id="sec-ha-drbd-hostnames">
    <title>ホスト名</title>
    <para>
     DRBDの場合、ホスト名の大文字と小文字が区別され(<systemitem>Node0</systemitem>は<systemitem>node0</systemitem>とは異なるホストであるとみなされる)、カーネルに格納されているホスト名と比較されます(<command>uname -n</command>出力を参照)。
@@ -848,16 +852,16 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    <para>
     複数のネットワークデバイスがあり、専用ネットワークデバイスを使用したい場合、おそらく、ホスト名は使用されたIPアドレスに解決されません。この場合は、パラメータ<literal>disable-ip-verification</literal>を使用します。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-port">
+  <section xml:id="sec-ha-drbd-port">
    <title>TCPポート7788</title>
    <para>
     システムがピアに接続できない場合は、ローカルファイアウォールに問題のある可能性があります。DRBDは、デフォルトでは、TCPポート<literal>7788</literal>を使用して、もう一方のノード にアクセスします。このポートを両方のノード からアクセスできるかどうか確認してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-trouble-broken">
+  <section xml:id="sec-ha-drbd-trouble-broken">
    <title>DRBDデバイスが再起動後に破損した</title>
    <para>
     DRBDサブシステムが実際のどのデバイスが最新データを保持しているか認識していない場合、スプリットブレイン受験に変更されます。この場合、それぞれのDRBDサブシステムがセカンダリとして機動され、互いに接続しません。この場合、ログ記録データに、次のメッセージが出力されることがあります。
@@ -873,9 +877,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> connect r0</screen>
     <para>このコマンドは、あるノードのデータをピアのデータで上書きすることによって問題を解決するため、両方のノードで一貫したビューが得られます。</para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-drbd-more">
+  </section>
+ </section>
+ <section xml:id="sec-ha-drbd-more">
   <title>詳細情報</title>
 
   <para>
@@ -885,7 +889,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     プロジェクトホームページ<ulink url="http://www.drbd.org"/>。
+     プロジェクトホームページ<link xlink:href="http://www.drbd.org"/>。
     </para>
    </listitem>
    <listitem>
@@ -895,7 +899,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>(Linux Pacemaker Cluster Stack Projectによる)。
+     <link xlink:href="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>(Linux Pacemaker Cluster Stack Projectによる)。
     </para>
    </listitem>
    <listitem>
@@ -909,8 +913,8 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
    </listitem>
     <listitem>
-      <para>さらに、クラスタ間のストレージ管理を容易にするために、<citetitle/>「DRBD-Manager」(<ulink url="http://blogs.linbit.com/p/666/drbd-manager"/>)に関する最新の通知を参照してください。</para>
+      <para>さらに、クラスタ間のストレージ管理を容易にするために、<citetitle/>「DRBD-Manager」(<link xlink:href="http://blogs.linbit.com/p/666/drbd-manager"/>)に関する最新の通知を参照してください。</para>
     </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_error_codes.xml
+++ b/ja/xml/ha_error_codes.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_error_codes.xml" id="sec-ha-errorcodes">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_error_codes.xml" xml:id="sec-ha-errorcodes">
  <title>OCF戻りコードと障害回復</title>
 
  <para>
@@ -378,4 +382,4 @@ Please see LICENSE.txt for this document's license.
    </tbody>
   </tgroup>
  </table>
-</sect1>
+</section>

--- a/ja/xml/ha_example.xml
+++ b/ja/xml/ha_example.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_example.xml" id="cha-ha-quickstart">
- <title>単純なテストリソースのセットアップ例</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example.xml" xml:id="cha-ha-quickstart"><title>単純なテストリソースのセットアップ例</title><info/>
+ 
  <para>
   この章では、単純なリソース(IPアドレス)を設定する基本的な例を示します。Pacemaker GUIまたは<command>crm</command>コマンドラインツールをのいずれかを使用した、両方の方法を紹介します。
  </para>
@@ -25,6 +29,6 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_gui_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_cli_i.xml" parse="xml"/>
+ <xi:include href="ha_example_gui_i.xml" parse="xml"/>
+ <xi:include href="ha_example_cli_i.xml" parse="xml"/>
 </appendix>

--- a/ja/xml/ha_example_cli_i.xml
+++ b/ja/xml/ha_example_cli_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_cli_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_cli_i.xml">
  <title>リソースの手動設定</title>
 
  <para>
@@ -18,19 +22,19 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <procedure id="proc-ha-quickstart-man">
+ <procedure xml:id="proc-ha-quickstart-man">
   <title>IPアドレスクラスタリソースを作成する</title>
-  <step performance="required">
+  <step>
    <para>
     シェルを開き<systemitem class="username">root</systemitem>になります。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     「<command>crm</command> <option>configure</option>」と入力して、内部シェルを開きます。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     IPアドレスリソースを作成します。
    </para>
@@ -54,16 +58,16 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>リソースを他のノードへマイグレートする</title>
-  <step performance="required">
+  <step>
    <para>
     シェルを起動して<systemitem class="username">root</systemitem>ユーザになります。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     リソース<literal>myip</literal>をノード<systemitem>saturn</systemitem>にマイグレートします。
    </para>
 <screen><command>crm</command> resource <command>migrate</command> myIP saturn</screen>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/ja/xml/ha_example_gui_i.xml
+++ b/ja/xml/ha_example_gui_i.xml
@@ -1,75 +1,79 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_gui_i.xml" id="sec-ha-quickstart-gui">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_gui_i.xml" xml:id="sec-ha-quickstart-gui">
  <title>GUIによるリソースの設定</title>
 
  <para>
   サンプルのクラスタリソースを作成して別のサーバにマイグレートすると、クラスタが正常に機能していることの確認に役立ちます。設定とマイグレートのシンプルなリソースは、IPアドレスです。
  </para>
 
- <procedure id="proc-ha-quickstart-gui">
+ <procedure xml:id="proc-ha-quickstart-gui">
   <title>IPアドレスクラスタリソースを作成する</title>
-  <step performance="required">
+  <step>
    <para>
     <xref linkend="sec-ha-configuration-gui-intro-connect"/>の説明に従い、Pacemaker GUIを起動してクラスタにログインします。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     左側のペインで<guimenu>リソース</guimenu>ビューに切り替え、右側のペインで、変更するグループを選択して<guimenu>編集</guimenu>をクリックします。次のウィンドウには、そのリソースに定義された基本的なグループパラメータとメタ属性とプリミティブが表示されます。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     <guimenu>プリミティブ</guimenu>タブをクリックして、<guimenu>追加</guimenu>をクリックします。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     次のダイアログで、次のパラメータを設定してIPアドレスをグループのサブリソースとして追加します。
    </para>
    <substeps performance="required">
-    <step performance="required">
+    <step>
      <para>
       固有の［<literal>ID</literal>］を入力します。たとえば、「<literal>myIP</literal>」です。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>クラス</guimenu>リストで、リソースエージェントクラスとして<guimenu>ocf</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       OCFリソースエージェントの<guimenu>プロバイダ</guimenu>として、<guimenu>heartbeat</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>タイプ</guimenu>リストで、リソースエージェントとして<guimenu>IPaddr</guimenu>を選択します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>進む</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Instance Attribute (インスタンス属性)</guimenu>タブで、<guimenu>IP</guimenu>エントリを選択して<guimenu>編集</guimenu>をクリックします(または<guimenu>IP</guimenu>エントリをダブルクリックします)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>値</guimenu>として、目的のIPアドレスを入力します。たとえば、「<literal>10.10.0.1</literal>」と入力して、<guimenu>OK</guimenu>をクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新規インスタンス属性を<guimenu>追加</guimenu>して、<literal>nic</literal>を<guimenu>名前</guimenu>に、<literal>eth0</literal>を<guimenu>値</guimenu>に指定して<guimenu>OK</guimenu>をクリックします。
      </para>
@@ -79,7 +83,7 @@ Please see LICENSE.txt for this document's license.
     </step>
    </substeps>
   </step>
-  <step performance="required">
+  <step>
    <para>
     すべてのパラメータを目的どおりに設定したら、<guimenu>OK</guimenu>をクリックして、そのリソースの設定を完了します。設定ダイアログが閉じて、メインウィンドウに変更されたリソースが表示されます。
    </para>
@@ -96,25 +100,25 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>リソースを他のノードへマイグレートする</title>
-  <step performance="required">
+  <step>
    <para>
     左側のペインの<guimenu>管理</guimenu>ビューに切り替え、次に右側のペインのIPアドレスリソースを右クリックして<guimenu>Migrate Resource (リソースのマイグレート)</guimenu>を選択します。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     新規ウィンドウで、<guimenu>To Node (マイグレート先ノード)</guimenu>ドロップダウンリストで<literal>satum</literal>を選択し、選択したリソースをノード<literal>satum</literal>に移動します。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     リソースを一時的にマイグレートするには、<guimenu>Duration (期間)</guimenu>をアクティブにしてリソースが新規ノードにマイグレートされる時間を入力します。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     <guimenu>OK</guimenu>をクリックして、マイグレーションを確認します。
    </para>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/ja/xml/ha_fencing.xml
+++ b/ja/xml/ha_fencing.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_fencing.xml" id="cha-ha-fencing">
- <title>フェンシングとSTONITH</title>
-
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_fencing.xml" xml:id="cha-ha-fencing"><title>フェンシングとSTONITH</title><info><abstract>
   <para>
    フェンシングはHA(High Availability)向けコンピュータクラスタにおいて、非常に重要なコンセプトです。クラスタがノードの1つの誤動作を検出し、そのノードの削除が必要となることがあります。これを<emphasis>フェンシング</emphasis>と呼び、一般にSTONITHリソースで実行されます。フェンシングは、HAクラスタを既知の状態にするための方法として定義できます。
   </para>
@@ -20,9 +21,12 @@ Please see LICENSE.txt for this document's license.
   <para>
    ノードまたはリソースの状態を十分に確定することができない場合には、フェンシングが発生します。クラスタが所定のノードで起こっていることを認識しない場合でも、フェンシングによって、そのノードが重要なリソースを実行しないようにできます。
   </para>
- </abstract>
+ </abstract></info>
  
-   <sect1 id="sec-ha-fencing-classes">
+
+ 
+ 
+   <section xml:id="sec-ha-fencing-classes">
   <title>フェンシングのクラス</title>
 
   <para>
@@ -51,15 +55,15 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-fencing-nodes">
+ </section>
+ <section xml:id="sec-ha-fencing-nodes">
   <title>ノードレベルのフェンシング</title>
 
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>におけるフェンシングの実装が、STONITH (Shoot The Other Node in the Head)です。 これにより、ノードレベルのフェンシングが実行されます。High Availability Extensionには<command>stonith</command>コマンドラインツールが付属し、これはクラスタ上のノードの電源をリモートでオフにする拡張インタフェースです。使用できるオプションの概要については、<command>stonith --help</command>を実行するか、または<command>stonith</command>のマニュアルページで詳細を参照してください。
   </para>
 
-  <sect2 id="sec-ha-fencing-nodes-devices">
+  <section xml:id="sec-ha-fencing-nodes-devices">
    <title>STONITHデバイス</title>
    <para>
     ノードレベルのフェンシングを使用するには、まず、フェンシングデバイスを用意する必要があります。High Availability ExtensionでサポートされているSTONITHデバイスのリストを取得するには、任意のノード上で次のコマンドのいずれかを実行します。
@@ -115,9 +119,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     STONITHデバイスは、予算と使用するハードウェアの種類に応じて選択します。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-fencing-nodes-implementation">
+  <section xml:id="sec-ha-fencing-nodes-implementation">
    <title>STONITHの実装</title>
    <para>
     <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>でのSTONITHの実装は、2つのコンポーネントで構成されています。
@@ -146,9 +150,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-fencing-config">
+  </section>
+ </section>
+ <section xml:id="sec-ha-fencing-config">
   <title>STONITHのリソースと環境設定</title>
 
   <para>
@@ -194,7 +198,7 @@ Please see LICENSE.txt for this document's license.
 
 <screen>stonith -t <replaceable>stonith-device-type</replaceable> -h</screen>
 
-  <sect2 id="sec-ha-fencing-config-examples">
+  <section xml:id="sec-ha-fencing-config-examples">
    <title>STONITHリソースの設定例</title>
    <para>
     以降では、<command>crm</command>コマンドラインツールの構文で作成された設定例を紹介します。これを適用するには、サンプルをテキストファイル(<filename>sample.txt</filename>など)に格納して、実行します。
@@ -229,7 +233,7 @@ commit</screen>
      UPSタイプのフェンシングデバイスの設定は、上記の例と似ています。詳細についてはここでは割愛します。すべてのUPSデバイスは、フェンシングのために、同じ機構を使用します。デバイスへのアクセス方法が異なる方法。古いUPSデバイスにはシリアルポートしかなく、通常、特別のシリアルケーブルを使用して1200ボーで接続していました。新型の多くは、まだシリアルポートがありますが、USBインタフェースまたはEthernetインタフェースも使用します。使用できる接続の種類は、プラグインが何をサポートしているかによります。
     </para>
     <para>
-     たとえば、<literal>apcmaster</literal>を<literal>apcsmart</literal>デバイスと、<command>stonith -t <replaceable>stonith-device-type</replaceable> -n</command>コマンドを使用して比較します。
+     たとえば、<literal>apcmaster</literal>を<literal>apcsmart</literal>デバイスと、<command>stonith -t</command> <replaceable>stonith-device-type</replaceable> -nコマンドを使用して比較します。
     </para>
 <screen>stonith -t apcmaster -h</screen>
     <para>
@@ -266,12 +270,12 @@ hostlist</screen>
      最初のプラグインは、ネットワークポートとtelnetプロトコルを持つAPC UPSをサポートします。2番目のプラグインはAPC SMARTプロトコルをシリアル回線で使用します。これはその他多数のAPC UPS製品ラインでサポートされているものです。
     </para>
    </example>
-   <example id="ex-ha-fencing-kdump">
+   <example xml:id="ex-ha-fencing-kdump">
     <title>kdumpデバイスの設定</title>
     <para> kdump機能を有効にしたノードをすべて監視するには、<literal>stonith:fence_kdump</literal>リソースエージェント(パッケージ<systemitem class="resource">fence-agents</systemitem>で提供)を使用します。構成の例については、以下のリソースを参照してください。</para>
     <screen>configure
      primitive st-kdump stonith:fence_kdump \
-     params nodename="alice "\ <co id="co-ha-fenc-kdump-nodename"/>
+     params nodename="alice "\ <co xml:id="co-ha-fenc-kdump-nodename"/>
      params pcmk_host_check="dynamic-list" \
      params pcmk_reboot_action="off" \
      params pcmk_monitor_action="metadata" \
@@ -289,11 +293,11 @@ hostlist</screen>
     <screen> /usr/lib64/fence_kdump_send -i <replaceable>INTERVAL</replaceable> -p <replaceable>PORT</replaceable> -c 1 alice bob charly [...]</screen>
     <para> kdumpが完了すると、kdumpを実行するノードが自動的に再起動します。<literal>fence_kdump</literal>リソースで使用するポートを必ずファイアウォールで開いておくようにします。デフォルトポートは<literal>7410</literal>です。</para>
    </example>
-  </sect2>
+  </section>
 
   
- </sect1>
- <sect1 id="sec-ha-fencing-monitor">
+ </section>
+ <section xml:id="sec-ha-fencing-monitor">
   <title>フェンシングデバイスの監視</title>
 
   <para>
@@ -320,8 +324,8 @@ hostlist</screen>
   <para>
    監視操作の設定方法の詳細は、GUIアプローチについては<xref linkend="pro-ha-config-gui-parameters"/>、コマンドラインアプローチについては<xref linkend="sec-ha-manual-config-monitor"/>を参照してください。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-special">
+ </section>
+ <section xml:id="sec-ha-fencing-special">
   <title>特殊なフェンシングデバイス</title>
 
   <para>
@@ -363,7 +367,7 @@ hostlist</screen>
     </term>
     <listitem>
      <para>
-      これは自己フェンシングデバイスです。共有ディスクに挿入されることがある、いわゆる<quote>ポイズンピル</quote>に反応します。共有ストレージ接続が失われた場合、このデバイスはノードの動作を停止します。このSTONITHエージェントを使用してストレージベースのフェンシングを実装する方法については、<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>を参照してください。詳細については、<ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>も参照してください。
+      これは自己フェンシングデバイスです。共有ディスクに挿入されることがある、いわゆる<quote>ポイズンピル</quote>に反応します。共有ストレージ接続が失われた場合、このデバイスはノードの動作を停止します。このSTONITHエージェントを使用してストレージベースのフェンシングを実装する方法については、<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>を参照してください。詳細については、<link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>も参照してください。
      </para>
 
      <important>
@@ -409,8 +413,8 @@ hostlist</screen>
   <para>
    <literal>suicide</literal>は、<quote>自分のホストを停止させない</quote>というルールに対する唯一の例外です。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-recommend">
+ </section>
+ <section xml:id="sec-ha-fencing-recommend">
   <title>基本的な推奨事項</title>
 
   <para>
@@ -466,8 +470,8 @@ hostlist</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-fencing-more">
+ </section>
+ <section xml:id="sec-ha-fencing-more">
   <title>詳細</title>
   <variablelist>
    <varlistentry>
@@ -480,13 +484,13 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-     <term><ulink url="http://www.linux-ha.org/wiki/STONITH"/></term>
+     <term><link xlink:href="http://www.linux-ha.org/wiki/STONITH"/></term>
     <listitem>
      <para> STONITHに関する情報。High Availability Linux Projectのホームページにあります。 </para>
     </listitem>
      </varlistentry>
      <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/>
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/>
     </term>
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
@@ -499,7 +503,7 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
+    <term><link xlink:href="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
     </term>
     <listitem>
      <para>
@@ -508,5 +512,5 @@ hostlist</screen>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_geocluster.xml
+++ b/ja/xml/ha_geocluster.xml
@@ -1,13 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_geocluster.xml" id="cha-ha-geo">
- <title>Geoクラスタ(マルチサイトクラスタ)</title>
- <abstract>
-  <para> <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>は、ローカルクラスタとメトロエリアクラスタのほかに、地理的に離れたクラスタ(Geoクラスタ。マルチサイトクラスタとも呼ばれます)もサポートしています。これは、それぞれひとつのローカルクラスタで持った複数の地理的に離れたサイトを持てることを意味します。これらクラスタ間のフェールオーバーは、より高いレベルのエンティティである<literal>booth</literal>によって管理されます。Geo Clustering for SUSE Linux Enterprise High Availability Extensionの個別の拡張として、Geoクラスタに対するサポートが提供されています。Geoクラスタの使用方法および設定方法の詳細については、『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』を参照してください。<ulink url="http://www.suse.com/documentation/"/>または<filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename>の下にあるインストール済みシステムから入手できます。 </para>
- </abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_geocluster.xml" xml:id="cha-ha-geo"><title>Geoクラスタ(マルチサイトクラスタ)</title><info><abstract>
+  <para> <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>は、ローカルクラスタとメトロエリアクラスタのほかに、地理的に離れたクラスタ(Geoクラスタ。マルチサイトクラスタとも呼ばれます)もサポートしています。これは、それぞれひとつのローカルクラスタで持った複数の地理的に離れたサイトを持てることを意味します。これらクラスタ間のフェールオーバーは、より高いレベルのエンティティである<literal>booth</literal>によって管理されます。Geo Clustering for SUSE Linux Enterprise High Availability Extensionの個別の拡張として、Geoクラスタに対するサポートが提供されています。Geoクラスタの使用方法および設定方法の詳細については、『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>または<filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename>の下にあるインストール済みシステムから入手できます。 </para>
+ </abstract></info>
+ 
+ 
 </chapter>

--- a/ja/xml/ha_glossary.xml
+++ b/ja/xml/ha_glossary.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glossary PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE glossary>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<glossary xml:base="ha_glossary.xml" id="gl-heartb">
- <title>用語集</title>
+<glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_glossary.xml" xml:id="gl-heartb"><title>用語集</title><info/>
+ 
  <glossentry><glossterm>アクティブ/アクティブ、アクティブ/パッシブ</glossterm>
   <glossdef>
    <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>bindnetaddr</systemitem> (バインドネットワークアドレス)</glossterm>
+ <glossentry><glossterm>bindnetaddr (バインドネットワークアドレス)</glossterm>
   <glossdef>
    <para>
     Corosyncエグゼクティブのバインド先のネットワークアドレス。 
@@ -43,7 +47,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">boothd</systemitem> (ブースデーモン)</glossterm>
+ <glossentry><glossterm>boothd (ブースデーモン)</glossterm>
   <glossdef>
    <para>
     Geoクラスタ内のそれぞれの参加クラスタおよびアービトレータが、サービスである<systemitem class="daemon">boothd</systemitem>を実行します。これは、別のサイトで実行しているブースデーモンに接続し、接続性の詳細を交換します。
@@ -99,7 +103,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">crmd</systemitem> (クラスタリソースマネージャデーモン)</glossterm>
+ <glossentry><glossterm>crmd (クラスタリソースマネージャデーモン)</glossterm>
   <glossdef>
    <para>
     CRMは、crmdというデーモンとして実装されます。 crmdは各クラスタノード上にインスタンスを持ちます。マスタとして動作するcrmdインスタンスを1つ選択することにより、クラスタのすべての意思決定が一元化されます。選択したcrmdプロセス(またはそのプロセスが実行されているノード)で障害が発生したら、新しいcrmdプロセスが確立されます。
@@ -120,7 +124,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-dc"><glossterm>DC (指定コーディネータ)</glossterm>
+ <glossentry xml:id="glos-dc"><glossterm>DC (指定コーディネータ)</glossterm>
   <glossdef>
    <para>
     クラスタ内のCRMは、指定コーディネータ(DC)として選択されます。DCは、ノードのフェンシングやリソースの移動など、クラスタ全体におよぶ変更が必要かどうかを判断できる、クラスタ内で唯一のエンティティです。DCは、CIBのマスターコピーが保持されるノードでもあります。その他すべてのノードは、現在のDCから設定とリソース割り当て情報を取得します。DCは、メンバーシップの変更後、クラスタ内のすべてのノードから選抜されます。
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-failover"><glossterm>フェールオーバー</glossterm>
+ <glossentry xml:id="glo-failover"><glossterm>フェールオーバー</glossterm>
   <glossdef>
    <para>
     リソースまたはノードが1台のマシンで失敗し、影響を受けるリソースが別のノードで起動されたときに発生します。
@@ -203,7 +207,7 @@ Please see LICENSE.txt for this document's license.
 
 
  
-  <glossentry id="glos-lb">
+  <glossentry xml:id="glos-lb">
    <glossterm>負荷分散</glossterm>
    <glossdef>
      <para>複数のサーバを同じサービスに参加させて、同じ作業を行わせる機能。</para>
@@ -224,14 +228,14 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastaddr</systemitem> (マルチキャストアドレス)</glossterm>
+ <glossentry><glossterm>mcastaddr (マルチキャストアドレス)</glossterm>
   <glossdef>
    <para>
       Corosyncエグゼクティブによるマルチキャストに使用されるIPアドレス。このIPアドレスはIPv4またはIPv6のいずれかに設定できます。 
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastport</systemitem> (マルチキャストポート)</glossterm>
+ <glossentry><glossterm>mcastport (マルチキャストポート)</glossterm>
   <glossdef>
    <para>
       クラスタ通信に使用されるポート。
@@ -252,7 +256,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-geo"><glossterm>Geoクラスタ</glossterm>
+ <glossentry xml:id="glos-geo"><glossterm>Geoクラスタ</glossterm>
   <glossdef>
    <para>
     それぞれにローカルクラスタを持つ、複数の地理的に離れたサイトで構成されます。サイトはIPによって交信します。サイト全体のフェールオーバーはより高いレベルのエンティティ(ブース)によって調整されます。Geoクラスタは限られたネットワーク帯域幅および高レイテンシに対応する必要があります。ストレージは同期的にレプリケートされます。
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="gloss-quorum"><glossterm>クォーラム</glossterm>
+ <glossentry xml:id="gloss-quorum"><glossterm>クォーラム</glossterm>
   <glossdef>
    <para>
     クラスタでは、クラスタパーティションは、ノード(投票)の大多数を保有する場合、クォーラムを持つ(<quote>定数に達している</quote>)と定義されます。クォーラムはただ1つのパーティションで識別されます。複数の切断されたパーティションまたはノードが処理を続行してデータおよびサービスが破損されないようにする、アルゴリズムの一部です(スプリットブレイン)。クォーラムはフェンシングの前提条件で、このためクォーラムは一意になります。
@@ -326,7 +330,7 @@ Please see LICENSE.txt for this document's license.
   </glossdef>
  </glossentry>
 
- <glossentry id="glos-splitbrain"><glossterm>スプリットブレイン</glossterm>
+ <glossentry xml:id="glos-splitbrain"><glossterm>スプリットブレイン</glossterm>
   <glossdef>
    <para>
     クラスタノードが(ソフトウェアまたはハードウェア障害によって)互いに認識しない2つ以上のグループに分割される場合のシナリオです。STONITHによって、スプリットブレインがクラスタ全体に悪影響をおよぼさなくなります。<quote>パーティションされたクラスタ</quote>シナリオとも呼ばれます。
@@ -343,7 +347,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-stonith"><glossterm>STONITH</glossterm>
+ <glossentry xml:id="glo-stonith"><glossterm>STONITH</glossterm>
   <glossdef>
    <para>
     <quote>Shoot the other node in the head</quote>の略です。動作異常のノードをシャットダウンすることでクラスタに問題を発生させないようにするフェンシングメカニズムを指しています。

--- a/ja/xml/ha_hawk_rsc_config_i.xml
+++ b/ja/xml/ha_hawk_rsc_config_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_config_i.xml" id="sec-ha-config-hawk-rsc">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_config_i.xml" xml:id="sec-ha-config-hawk-rsc">
  <title>クラスタリソースの設定</title>
 
  <para>
@@ -47,29 +51,29 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <sect2 id="sec-ha-config-hawk-wizard">
+ <section xml:id="sec-ha-config-hawk-wizard">
   <title>セットアップウィザードでリソースを設定する</title>
   <para>
-   High Availability Extensionには、高可用性NFSサーバのセットアップなど、よく使われるいくつかのクラスタシナリオ用に、テンプレートの定義済みセットが付属しています。定義済みテンプレートは、<systemitem class="resource">hawk-templates</systemitem>パッケージに含まれています。ユーザ独自のウィザードテンプレートを定義することもできます。詳細については、<ulink url="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>を参照してください。
+   High Availability Extensionには、高可用性NFSサーバのセットアップなど、よく使われるいくつかのクラスタシナリオ用に、テンプレートの定義済みセットが付属しています。定義済みテンプレートは、<systemitem class="resource">hawk-templates</systemitem>パッケージに含まれています。ユーザ独自のウィザードテンプレートを定義することもできます。詳細については、<link xlink:href="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>を参照してください。
   </para>
-  <procedure id="pro-ha-config-hawk-wizard">
+  <procedure xml:id="pro-ha-config-hawk-wizard">
    <title>セットアップウィザードの使用</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>セットアップウィザード</guimenu>を選択します。<guimenu>クラスタセットアップウィザード</guimenu>に、使用可能なリソーステンプレートが一覧表示されます。エントリをクリックすると、Hawkはそのテンプレートについての簡単なヘルプテキストを表示します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      設定するリソースセットを選択して、<guimenu>次へ</guimenu>をクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      画面の指示に従います。オプションについての情報が必要な場合には、オプションをクリックすると、Hawkは簡単なヘルプテキストを表示します。
     </para>
@@ -86,51 +90,51 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-primitives">
+ <section xml:id="sec-ha-config-hawk-primitives">
   <title>単純なクラスタリソースの作成</title>
   <para>
    最も基本的なタイプのリソースを作成するには、次の手順に従います。
   </para>
-  <procedure id="pro-ha-config-hawk-primitives">
+  <procedure xml:id="pro-ha-config-hawk-primitives">
    <title>プリミティブリソースを追加する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面に、すべてのタイプのリソースのカテゴリが表示されます。ここにはすでに定義済みのすべてのリソースが表示されます。 
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>プリミティブ</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースを次のとおり指定します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        固有の<guimenu>リソースID</guimenu>を入力します。
       </para>
      </step>
-     <step id="step-ha-config-hawk-primitives-start" performance="required">
+     <step xml:id="step-ha-config-hawk-primitives-start">
       <para>
        <guimenu>クラス</guimenu>リストから、そのリソースに使用するリソースエージェントクラスを選択します。<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>service</guimenu>、または<guimenu>stonith</guimenu>を選択できます。 詳細については、<xref linkend="sec-ha-config-basics-raclasses"/>を参照してください。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ocf</guimenu>をクラスとして選択した場合、OCFリソースエージェントの<guimenu>プロバイダ</guimenu>を指定します。OCFの指定によって、複数のベンダが同じリソースエージェントを提供できるようになります。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>タイプ</guimenu>リストから、使用するリソースエージェントを選択します(たとえば<guimenu>IPaddr</guimenu>または<guimenu>Filesystem</guimenu>)。このリソースエージェントの簡単な説明が表示されます。
       </para>
@@ -140,7 +144,7 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step id="step-ha-config-hawk-parameters" performance="required">
+   <step xml:id="step-ha-config-hawk-parameters">
     <para>
      Hawkは、リソースに必要なパラメータと、追加パラメータを指定するために使用できる空のドロップダウンリストを自動的に表示します。
     </para>
@@ -148,24 +152,24 @@ Please see LICENSE.txt for this document's license.
      リソースの<guimenu>パラメータ</guimenu>(インスタンス属性)を定義するには次のとおり行います。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        それぞれ必要なパラメータの値を入力します。パラメータの隣のテキストボックスをクリックすると、簡単なヘルプテキストが表示されます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        パラメータを完全に削除するには、パラメータの隣のマイナスアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        他のパラメータを追加するには、空のドロップダウンリストをクリックし、パラメータを選択して、その値を入力します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawkは、重要なリソース<guimenu>操作</guimenu>を自動的に表示し、デフォルト値を提案します。ここで設定を変更しない場合、変更を確定するとすぐに、Hawkは提案した操作およびデフォルト値を追加します。
     </para>
@@ -173,7 +177,7 @@ Please see LICENSE.txt for this document's license.
      操作の変更または削除方法の詳細については、<xref linkend="pro-ha-config-hawk-operations"/>を参照してください。
     </para>
    </step>
-   <step id="step-ha-config-hawk-meta-attr" performance="required">
+   <step xml:id="step-ha-config-hawk-meta-attr">
     <para>
      Hawkは、たとえば<literal>target-role</literal>など、リソースの最も重要なメタ属性を自動的にリストにします。
     </para>
@@ -181,24 +185,24 @@ Please see LICENSE.txt for this document's license.
      <guimenu>メタ属性</guimenu>を変更または追加するには次のとおり行います。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        属性に(別の)値を設定するには、属性の隣のドロップダウンボックスから値を1つ選択するか、入力フィールドで値を編集します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        属性を完全に削除するには、その隣のマイナスアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        他のメタ属性を追加するには、空のドロップダウンボックスをクリックし、属性を選択します。属性のデフォルト値が表示されます。必要な場合は、上述したとおり変更します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>リソースの作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、リソースが正常に作成されたかどうかを表示します。
     </para>
@@ -216,9 +220,9 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-stonith">
+ <section xml:id="sec-ha-config-hawk-stonith">
   <title>STONITHリソースの作成</title>
   <important>
    <title>STONITHがない場合はサポートなし</title>
@@ -229,61 +233,61 @@ Please see LICENSE.txt for this document's license.
   <para>
    デフォルトでは、グローバルクラスタオプション<literal>stonith-enabled</literal>は<literal>true</literal>に設定されています。STONITHリソースが定義されていない場合、クラスタはどのリソースの開始も拒否します。1つ以上のSTONITHリソースを設定して、STONITHのセットアップを完了します。STONITHは他のリソースと同様に設定しますが、その動作はいくつかの点で異なっています。詳細については、<xref linkend="sec-ha-fencing-config"/>を参照してください。
   </para>
-  <procedure id="pro-ha-config-hawk-stonith">
+  <procedure xml:id="pro-ha-config-hawk-stonith">
    <title>STONITHリソースの追加</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面には、すべてのタイプのリソースのカテゴリと、定義済みのすべてのリソースが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>プリミティブ</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースを次のとおり指定します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        固有の<guimenu>リソースID</guimenu>を入力します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>クラス</guimenu>リストで、リソースエージェントクラスとして<guimenu>stonith</guimenu>を選択します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>タイプ</guimenu>リストから、使用しているSTONITHデバイスのSTONITHプラグインを選択します。このプラグインの簡単な説明が下に表示されます。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawkは、自動的にそのリソースに必要な<guimenu>パラメータ</guimenu>を表示します。それぞれのパラメータの値を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawkは、重要なリソース<guimenu>操作</guimenu>を表示し、デフォルト値を提案します。ここで設定を変更しない場合、確定するとすぐに、Hawkは提案した操作およびデフォルト値を追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      特に変更する理由がない場合には、<guimenu>メタ属性</guimenu>の設定はデフォルトを採用してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更を確認して、STONITHリソースを作成します。
     </para>
@@ -292,41 +296,41 @@ Please see LICENSE.txt for this document's license.
   <para>
    フェンシングを設定するには、制約の追加とクローンの使用のいずれか、またはその両方を行います。詳細については、<xref linkend="cha-ha-fencing"/>を参照してください。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-templates">
+ <section xml:id="sec-ha-config-hawk-templates">
   <title>リソーステンプレートの使用</title>
   <para>
    類似した設定のリソースを多く作成する最も簡単な方法は、リソーステンプレートを定義することです。リソーステンプレートを定義した後は、プリミティブの中や、特定のタイプの制約で参照できるようになります。リソーステンプレートの機能と使用方法の詳細については、<xref linkend="sec-ha-config-basics-constraints-templates"/>を参照してください。
   </para>
-  <procedure id="pro-ha-config-hawk-templates-create">
+  <procedure xml:id="pro-ha-config-hawk-templates-create">
    <title>リソーステンプレートの作成</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面には、すべてのタイプのリソースのカテゴリに加えて、<guimenu>テンプレート</guimenu>カテゴリが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>テンプレート</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>テンプレートID</guimenu>を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      プリミティブを指定するリソーステンプレートを指定します。<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>に従って、<xref linkend="step-ha-config-hawk-primitives-start" xrefstyle="select:label"/>を開始します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>リソースの作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、リソーステンプレートが正常に作成されたかどうかを表示します。
     </para>
@@ -343,54 +347,54 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-templates-use">
+  <procedure xml:id="pro-ha-config-hawk-templates-use">
    <title>リソーステンプレートの参照</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しく作成したリソーステンプレートをプリミティブで参照するには、次の手順に従います。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面に、すべてのタイプのリソースのカテゴリが表示されます。定義済みのすべてのリソースが表示されます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>プリミティブ</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        固有の<guimenu>リソースID</guimenu>を入力します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>テンプレートの使用</guimenu>をオンにして、ドロップダウンリストから参照するテンプレートを選択します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        必要であれば、さらに<guimenu>パラメータ</guimenu>、<guimenu>操作</guimenu>、または<guimenu>メタ属性</guimenu>を<xref linkend="pro-ha-config-hawk-primitives"/>で説明した方法で指定します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しく作成したリソーステンプレートをコロケーションまたは順序の制約で参照するには、<xref linkend="pro-ha-config-hawk-constraints-collocation-order"/>で説明する手順に従います。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-constraints">
+ <section xml:id="sec-ha-config-hawk-constraints">
   <title>リソース制約の設定</title>
   <para>
    すべてのリソースを設定したら、クラスタがそれらを扱う方法を指定します。リソース制約を使えば、リソースがどのクラスタノードで実行されるか、リソースをどの順番でロードするか、そして特定のリソース型のどのリソースに依存するかを指定することができます。
@@ -405,23 +409,23 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-constraints-location">
+  <procedure xml:id="pro-ha-config-hawk-constraints-location">
    <title>場所の制約を追加または変更する</title>
    <para>
     場所の制約の場合には、制約ID、リソース、スコアおよびノードを指定します。
    </para>
 
-   <step id="step-ha-config-hawk-constraints-start" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-start">
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>制約</guimenu>を選択します。<guimenu>制約</guimenu>画面に、すべてのタイプの制約のカテゴリが表示されます。定義済みのすべての制約が表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しい<guimenu>場所</guimenu>制約を追加するには、対応するカテゴリのプラスアイコンをクリックします。
     </para>
@@ -429,27 +433,27 @@ Please see LICENSE.txt for this document's license.
      既存の制約を変更するには、制約の隣にあるレンチアイコンをクリックして、<guimenu>制約の編集</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      固有の<guimenu>制約ID</guimenu>を入力します。既存の制約を変更する場合には、IDはすでに定義されています。
     </para>
    </step>
-   <step id="step-ha-config-hawk-constraints-stop" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-stop">
     <para>
      制約を設定する<guimenu>リソース</guimenu>を選択します。リストには、そのクラスタに設定されているすべてのリソースのIDが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      制約の<guimenu>Score (スコア)</guimenu>を設定します。正の値は、次のステップで指定する<guimenu>ノード</guimenu>でリソースを実行できることを示します。負の値は、リソースをそのノードで実行すべきではないことを示します。スコアを<literal>INFINITY</literal>に設定すれば、リソースはこのノードで実行されるように強制されます。<literal>-INFINITY</literal>に設定すれば、リソースはそのノードで実行してはならないことになります。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      制約を設定する<guimenu>ノード</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>制約の作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、制約が正常に作成されたかどうかを表示します。
     </para>
@@ -466,22 +470,22 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-constraints-collocation-order">
+  <procedure xml:id="pro-ha-config-hawk-constraints-collocation-order">
    <title>コロケーションまたは順序の制約を追加または変更する</title>
    <para>
     どちらの制約の場合でも、制約IDとスコアを指定してから、リソースを依存チェーンに追加します。
    </para>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>制約</guimenu>を選択します。<guimenu>制約</guimenu>画面には、すべてのタイプの制約のカテゴリと、定義済みのすべての制約が表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しい<guimenu>コロケーション</guimenu>または<guimenu>順序</guimenu>制約を追加するには、対応するカテゴリのプラスアイコンをクリックします。
     </para>
@@ -489,12 +493,12 @@ Please see LICENSE.txt for this document's license.
      既存の制約を変更するには、制約の隣にあるレンチアイコンをクリックして、<guimenu>制約の編集</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      固有の<guimenu>制約ID</guimenu>を入力します。既存の制約を変更する場合には、IDはすでに定義されています。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>スコア</guimenu>を定義します。
     </para>
@@ -505,27 +509,27 @@ Please see LICENSE.txt for this document's license.
      順序の制約の場合、0より大きなスコアなら必須となります。そうでなければ、単なる提案として扱われます。デフォルト値は、<literal>INFINITY</literal>です。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      順序の制約の場合、オプション<guimenu>シンメトリック</guimenu>は常に有効にしていてください。これは、リソースを停止するときには逆順で行うという指定です。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      制約のリソースを定義するには、次の手順に従います。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>リソースを制約に追加</guimenu>リストからリソースを選択します。リストには、そのクラスタに設定されているすべてのリソースとリソーステンプレートのIDが表示されます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選択したリソースを追加するには、リストの隣のプラスアイコンをクリックします。下に新しいリストが表示されます。次のリソースをリストから選択します。コロケーション制約と順序の制約はどちらもリソース間の依存関係を定義するのものなので、少なくとも2つのリソースが必要です。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>リソースを制約に追加</guimenu>リストから残りのリソースのいずれかを選択します。リソースを追加するには、プラスアイコンをクリックします。
       </para>
@@ -539,24 +543,24 @@ Please see LICENSE.txt for this document's license.
        ただし、コロケーション制約を定義した場合、リソース間に矢印が表示され、依存関係を示しますが、これは起動順ではありません<emphasis/>。最上位のリソースは次のリソースなど順に依存するため、クラスタはまず最後のリソースを置く場所を決め、次にその決定に基づいて依存するものを配置していきます。制約が満たされないと、クラスタは依存するリソースが実行しないようにすることがあります。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        コロケーションまたは順序の制約に必要なだけ、リソースを追加します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        2つのリソースの順序を交換するには、リソースの右側にある二重線の矢印をクリックすると、依存チェーンの中でリソースが交換されます。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      必要であれば、リソースごとに、役割(<literal>Master</literal>、<literal>Slave</literal>、<literal>Started</literal>、<literal>Stopped</literal>)などのパラメータをさらに指定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>制約の作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、制約が正常に作成されたかどうかを表示します。
     </para>
@@ -576,29 +580,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    コロケーションまたは順序の制約を定義するための別のフォーマットとして、リソースセットを使用することができます。これらは、グループとして同じ意味論に従います。
   </para>
-  <procedure id="pro-ha-config-hawk-constraints-sets">
+  <procedure xml:id="pro-ha-config-hawk-constraints-sets">
    <title>コロケーションまたは順序の制約のためにリソースセットを使用する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-config-hawk-constraints-collocation-order"/>で説明した方法に従って、コロケーションまたは順序の制約を定義します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースを依存チェーンに追加した場合には、右側にあるチェーンアイコンをクリックして、リソースをリソースセットに入れることができます。リソースセットは、セットに属しているリソースの周囲のフレームによって示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      また、リソースセットに複数のリソースを追加したり、複数のリソースセットを作成したりすることもできます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースセットからリソースを取り出すには、そのリソースの上にあるハサミアイコンをクリックします。
     </para>
@@ -616,14 +620,14 @@ Please see LICENSE.txt for this document's license.
      リソースはセットから除かれて、依存チェーンの中の元の場所に戻ります。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更を確認して、制約の設定を完了します。
     </para>
    </step>
   </procedure>
   <para>
-   制約の設定の詳細や、順序およびコロケーションの基本的な概念についての詳細なバックグラウンド情報は、<ulink url="http://www.clusterlabs.org/doc/"/>で提供されているドキュメントを参照してください。
+   制約の設定の詳細や、順序およびコロケーションの基本的な概念についての詳細なバックグラウンド情報は、<link xlink:href="http://www.clusterlabs.org/doc/"/>で提供されているドキュメントを参照してください。
   </para>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
@@ -642,27 +646,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
-  <procedure id="pro-ha-config-hawk-constraints-remove">
+  <procedure xml:id="pro-ha-config-hawk-constraints-remove">
    <title>制約の削除</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>制約</guimenu>を選択します。<guimenu>制約</guimenu>画面には、すべてのタイプの制約のカテゴリと、定義済みのすべての制約が表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      制約の隣のレンチアイコンをクリックして<guimenu>制約の削除</guimenu>を選択します。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failover">
+ <section xml:id="sec-ha-config-hawk-failover">
   <title>リソースフェールオーバーノードの指定</title>
   <para>
    リソースに障害が発生すると、自動的に再起動されます。現在のノードで再起動できない場合、または現在のノードでN回失敗した場合は、別のノードへのフェールオーバーが試行されます。新しいノードへのマイグレートを行う基準(<literal>migration-threshold</literal>)となるリソースの失敗数を定義できます。クラスタ内に3つ以上ノードがある場合、特定のリソースのフェールオーバー先のノードはHigh Availabilityソフトウェアにより選択されます。
@@ -670,29 +674,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースがフェールオーバーする特定のノードを前もって指定するには、次の手順に従います。
   </para>
-  <procedure id="pro-ha-config-hawk-failover">
-   <step performance="required">
+  <procedure xml:id="pro-ha-config-hawk-failover">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-config-hawk-constraints-location"/>に記されている手順に従って、そのリソースの場所の制約を設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>に説明されている手順に従ってリソースに<literal>migration-threshold</literal>メタ属性を追加し、<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>migration-thresholdの<guimenu>値</guimenu>を入力します。INFINITYではない正の値を指定する必要があります。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースの失敗回数を自動的に失効させる場合は、<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>、<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>に記されている手順に従って<literal>failure-timeout</literal>メタ属性をそのリソースに追加し、失敗タイムアウトの<guimenu>値</guimenu>を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースの初期設定として、追加のフェールオーバーノードを指定する場合は、追加の場所の制約を作成します。
     </para>
@@ -704,9 +708,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースの失敗回数は、自動的に期限切れにする代わりに、いつでも、手動でクリーンアップすることもできます。詳細については、<xref linkend="sec-ha-config-hawk-cleanup"/>を参照してください。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failback">
+ <section xml:id="sec-ha-config-hawk-failback">
   <title>リソースフェールバックノードの指定(リソースの固着性)</title>
   <para>
    ノードがオンライン状態に戻り、クラスタ内にある場合は、リソースが元のノードにフェールバックすることがあります。このことを防ぐ、またはリソースのフェールバック先として別のノードを指定するには、リソースの固着性の値を変更します。リソースの固着性は、リソースを作成するとき、または作成した後のどちらでも指定できます。
@@ -717,28 +721,28 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-stickiness">
+  <procedure xml:id="pro-ha-config-hawk-stickiness">
    <title>リソースの固着性を指定する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>、<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>に従って、<literal>resource-stickiness</literal>メタ属性をリソースに追加します。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      リソースの固着性として、<literal>-INFINITY</literal>と<literal>INFINITY</literal>の間の値を指定します。 
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-utilization">
+ <section xml:id="sec-ha-config-hawk-utilization">
   <title>負荷インパクトに基づくリソース配置の設定</title>
   <para>
    すべてのリソースが同等ではありません。Xenゲストなどの一部のリソースでは、そのホストであるノードがリソースの容量要件を満たす必要があります。配置したリソースの要件の合計が提供容量よりも大きくなった場合には、リソースのパフォーマンスが低下するか、または失敗します。
@@ -784,74 +788,74 @@ Please see LICENSE.txt for this document's license.
   <para>
    ノードが提供する容量とリソースが要求する容量を設定した後、グローバルクラスタオプションで配置ストラテジを設定する必要があります。これを設定しないと、容量の設定は有効になりません。負荷のスケジュールに使用できるストラテジがいくつかあります。たとえば、負荷をできるだけ少ない数のノードに集中したり、使用可能なすべてのノードに均等に分散できます。詳細については、<xref linkend="sec-ha-config-basics-utilization"/>を参照してください。
   </para>
-  <procedure id="pro-ha-config-hawk-placement">
+  <procedure xml:id="pro-ha-config-hawk-placement">
    <title>配置ストラテジを設定する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタのプロパティ</guimenu>を選択して、グローバルクラスタオプションとそれらの現在の値を表示します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>新しいプロパティの追加</guimenu>ドロップダウンリストから、<literal>placement-strategy</literal>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要件に応じて、<guimenu>配置ストラテジ</guimenu>を適切な値に設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      プラスアイコンをクリックして、新しいクラスタプロパティ(値を含む)を追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更内容を確認します。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-monitor">
+ <section xml:id="sec-ha-config-hawk-monitor">
   <title>リソース監視の設定</title>
   <para>
    High Availability Extensionは、ノードの障害を検出できるだけではなく、ノードの個々のリソースで障害が発生した場合、そのことも検出できます。リソースが実行中であるかどうか確認するには、そのリソースにリソースの監視を設定します。リソースを監視するには、タイムアウト、開始遅延のいずれか、または両方と、間隔を指定します。間隔の指定によって、CRMにリソースステータスの確認頻度を指示します。<literal>start</literal>または<literal>stop</literal>操作に対する<literal>Timeout</literal>など、特定のパラメータも設定できます。
   </para>
-  <procedure id="pro-ha-config-hawk-operations">
+  <procedure xml:id="pro-ha-config-hawk-operations">
    <title>監視操作を追加または変更する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面には、すべてのタイプのリソースのカテゴリと、定義済みのすべてのリソースが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更するリソースを選択し、その隣のレンチアイコンをクリックして、<guimenu>リソースの編集</guimenu>を選択します。リソースの定義が表示されます。Hawkは、重要なリソース操作(<literal>monitor</literal>、<literal>start</literal>、<literal>stop</literal>)を自動的に表示し、デフォルト値を提案します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      操作の値を変更するには
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        操作の隣のペンアイコンをクリックします。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        表示されるダイアログで、次の値を指定します。
       </para>
@@ -881,24 +885,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        変更を確認してダイアログを閉じ、<guimenu>リソースの編集</guimenu>画面に戻ります。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      操作を完全に削除するには、その隣のマイナスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      他の操作を追加するには、空のドロップダウンボックスをクリックし、操作を選択します。操作のデフォルト値が表示されます。必要に応じて、ペンアイコンをクリックしてこれを変更します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>変更の適用</guimenu>をクリックして、設定を完了します。画面上のメッセージが、リソースが正常に更新されたかどうかを表示します。
     </para>
@@ -910,9 +914,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースの障害を表示するには、Hawkで<guimenu>クラスタステータス</guimenu>画面に切り替えて、関係するリソースを選択します。リソースの隣のレンチアイコンをクリックして、<guimenu>詳細の表示</guimenu>を選択します。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-group">
+ <section xml:id="sec-ha-config-hawk-group">
   <title>クラスタリソースグループの構成</title>
   <para>
    クラスタリソースの中には、他のコンポーネントやリソースに依存しており、各コンポーネントや各リソースを特定の順序で開始することや、同じサーバ上で一緒に実行することが必要なものもあります。この構成を簡単にするため、グループのコンセプトをサポートしています。
@@ -927,39 +931,39 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ha-config-hawk-group">
+  <procedure xml:id="pro-ha-config-hawk-group">
    <title>リソースグループを追加する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面には、すべてのタイプのリソースのカテゴリと、定義済みのすべてのリソースが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>グループ</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      固有の<guimenu>グループID</guimenu>を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      グループのメンバーを定義するには<guimenu>使用可能なプリミティブ</guimenu>のリストから1つまたは複数のエントリを選択し、&lt; アイコンをクリックして、<guimenu>グループの子</guimenu>リストに追加します。新しいグループメンバーは、リストの一番下に追加されます。グループメンバーの順序を定義するには、この時点でグループメンバーの追加および削除を必要な順序で行う必要があります。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      必要に応じ、<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select: lable title nopage"/>、<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>に説明されている手順で、<guimenu>メタ属性</guimenu>を変更または追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>グループの作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、グループが正常に作成されたかどうかを表示します。
     </para>
@@ -976,9 +980,9 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-confighawk-clone">
+ <section xml:id="sec-ha-confighawk-clone">
   <title>クローンリソースの設定</title>
   <para>
    特定のリソースをクラスタ内の複数のノードで同時に実行することが必要な場合には、それらのリソースをクローンとして設定します。たとえば、STONITHのようなりソースや、OCFS2のようなクラスタファイルシステムのクローンを作成することには意味があります。提供されているどのリソースも、クローンとして設定できます。クローンは、リソースのリソースエージェントによってサポートされます。クローンリソースは、動作しているノードに応じて設定を変えることもできます。
@@ -992,39 +996,39 @@ Please see LICENSE.txt for this document's license.
     クローンには、プリミティブまたはグループのいずれかをサブリソースとして含めることができます。Hawkでは、クローンの作成中にプリミティブを作成したり変更したりすることはできません。クローンを追加する前に、プリミティブを作成し、必要に応じて設定しておいてください。詳細については、<xref linkend="pro-ha-config-hawk-primitives"/>または<xref linkend="pro-ha-config-hawk-group"/>を参照してください。
    </para>
   </note>
-  <procedure id="pro-ha-config-hawk-clone">
+  <procedure xml:id="pro-ha-config-hawk-clone">
    <title>クローンを追加または変更する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。<guimenu>リソース</guimenu>画面には、すべてのタイプのリソースのカテゴリと、定義済みのすべてのリソースが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>クローン</guimenu>カテゴリを選択し、プラスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      固有の<guimenu>クローンID</guimenu>を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>子リソース</guimenu>リストから、クローンのサブリソースとして使用するプリミティブまたはグループを選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      必要に応じ、<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>、<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>に説明されている手順で、<guimenu>メタ属性</guimenu>を変更または追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>クローンを作成</guimenu>をクリックして、設定を完了します。画面上のメッセージが、クローンが正常に作成されたかどうかを表示します。
     </para>
@@ -1041,5 +1045,5 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_hawk_rsc_manage_i.xml
+++ b/ja/xml/ha_hawk_rsc_manage_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_manage_i.xml" id="sec-ha-config-hawk-manage">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_manage_i.xml" xml:id="sec-ha-config-hawk-manage">
  <title>クラスタリソースの管理</title>
 
  <para>
@@ -46,7 +50,7 @@ Please see LICENSE.txt for this document's license.
   </mediaobject>
  </figure>
 
- <sect2 id="sec-ha-config-hawk-start">
+ <section xml:id="sec-ha-config-hawk-start">
   <title>リソースの開始</title>
   <para>
    クラスタリソースは、起動する前に、正しく設定されているようにします。たとえば、Apacheサーバをクラスタリソースとして使用する場合は、まず、Apacheサーバをセットアップし、Apacheの環境設定を完了してから、クラスタで個々のリソースを起動します。
@@ -66,27 +70,27 @@ Please see LICENSE.txt for this document's license.
   <para>
    Hawkでリソースを作成するときには、<literal>target-role</literal>メタ属性でその初期状態を設定することができます。その値を<literal>stopped</literal>に設定した場合、リソースは、作成後、自動的に開始することはありません。
   </para>
-  <procedure id="pro-ha-config-hawk-start">
+  <procedure xml:id="pro-ha-config-hawk-start">
    <title>新しいリソースを起動する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のリソースビューのいずれかで、リソースの隣のレンチアイコンをクリックして、<guimenu>開始</guimenu>を選択します。継続するには、表示されるメッセージに対して確認します。リソースが開始すると、Hawkはすぐにリソースの色を緑に変え、それがどのノードで実行されているかを表示します。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-cleanup">
+ <section xml:id="sec-ha-config-hawk-cleanup">
   <title>リソースのクリーンアップ</title>
   <para>
    リソースは、失敗した場合は自動的に再起動しますが、失敗のたびにリソースの失敗回数が増加します。
@@ -97,95 +101,95 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースの失敗回数は、(リソースに<literal>failure-timeout</literal>オプションを設定することにより)自動的にリセットするか、または次に示すように手動でリセットできます。
   </para>
-  <procedure id="pro-ha-config-hawk-clean">
+  <procedure xml:id="pro-ha-config-hawk-clean">
    <title>リソースをクリーンアップする</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のリソースビューのいずれかで、リソースの隣のレンチアイコンをクリックして、<guimenu>クリーンアップ</guimenu>を選択します。継続するには、表示されるメッセージに対して確認します。
     </para>
 
     <para>
-     これによって指定したノード上の指定したリソースに対して、コマンド<command>crm_resource<option> -C</option></command>および<command>crm_failcount<option> -D</option></command>が実行されます。
+     これによって指定したノード上の指定したリソースに対して、コマンド<command>crm_resource</command> <option> -C</option>および<command>crm_failcount</command> <option> -D</option>が実行されます。
     </para>
    </step>
   </procedure>
   <para>
    詳細は、<command>crm_resource</command>および<command>crm_failcount</command>のマニュアルページを参照してください。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-remove">
+ <section xml:id="sec-ha-config-hawk-remove">
   <title>クラスタリソースの削除</title>
   <para>
    リソースをクラスタから削除する必要がある場合は、次の手順に従って、設定エラーが発生しないようにします。
   </para>
 
 
-  <procedure id="pro-ha-config-hawk-rm">
+  <procedure xml:id="pro-ha-config-hawk-rm">
    <title>クラスタリソースの削除</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-config-hawk-clean"/>の説明に従って、すべてのノードでリソースをクリーンアップします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のリソースビューのいずれかで、リソースの隣のレンチアイコンをクリックして、<guimenu>開始</guimenu>を選択します。継続するには、表示されるメッセージに対して確認します。
     </para>
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      変更するリソースを選択し、その隣のレンチアイコンをクリックして、<guimenu>リソースの削除</guimenu>を選択します。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-migrate">
+ <section xml:id="sec-ha-config-hawk-migrate">
   <title>クラスタリソースの移行</title>
   <para>
    <xref linkend="sec-ha-config-hawk-failover"/>で説明したように、ソフトウェアまたはハードウェアの障害時には、クラスタは定義可能な特定のパラメータ(たとえばマイグレーションしきい値やリソースの固着性など)に従って、リソースを自動的にフェールオーバー(マイグレート)させます。それ以外に、クラスタ内の別のノードにリソースを手動で移行させることもできます。または、リソースを現在のノードから出して、どこに移動するかはクラスタに判断させることもできます。
   </para>
-  <procedure id="pro-ha-config-hawk-migrate">
+  <procedure xml:id="pro-ha-config-hawk-migrate">
    <title>リソースを手動で移行する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のリソースビューのいずれかで、リソースの隣のレンチアイコンをクリックして、<guimenu>移動</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新規ウィンドウで、リソースの移動先ノードを選択します。
     </para>
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
      これによって移動先ノードに対して<literal>INFINITY</literal>スコアの場所の制約が作成されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      または、リソースを<guimenu>現在のノードから</guimenu>移動するように選択します。
     </para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
 
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      <guimenu>OK</guimenu>をクリックして、マイグレーションを確認します。
     </para>
@@ -222,33 +226,33 @@ Please see LICENSE.txt for this document's license.
   <para>
    リソースを再び元に戻すには、次の手順に従います。
   </para>
-  <procedure id="pro-ha-config-hawk-migrate-back">
+  <procedure xml:id="pro-ha-config-hawk-migrate-back">
    <title>移行制約をクリアする</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のリソースビューのいずれかで、リソースの隣のレンチアイコンをクリックして、<guimenu>再配置ルールを無視</guimenu>を選択します。継続するには、表示されるメッセージに対して確認します。
     </para>
     <para>
-     これによって、<command>crm_resource <option>-U</option></command>コマンドが使用されます。リソースは元の場所に戻ることができます<emphasis/>。あるいは現在の場所に残ることもあります(リソースの固着性によって)。
+     これによって、<command>crm_resource </command> <option>-U</option>コマンドが使用されます。リソースは元の場所に戻ることができます<emphasis/>。あるいは現在の場所に残ることもあります(リソースの固着性によって)。
     </para>
    </step>
   </procedure>
   <para>
-   詳細は、<command>crm_resource</command>のマニュアルページ、または<citetitle>Pacemaker Explained</citetitle>を参照してください。<ulink url="http://www.clusterlabs.org/doc/"/>から入手できます。特に、「<citetitle>Resource Migration</citetitle>」のセクションを参照してください。
+   詳細は、<command>crm_resource</command>のマニュアルページ、または<citetitle>Pacemaker Explained</citetitle>を参照してください。<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手できます。特に、「<citetitle>Resource Migration</citetitle>」のセクションを参照してください。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-maint-mode">
+ <section xml:id="sec-ha-config-hawk-maint-mode">
   <title>保守モードの使用</title>
     <para>クラスタ設定の変更時、個々のノードに対するソフトウェアパッケージの更新時、または上位製品バージョンへのクラスタのアップグレード時であっても、個々のクラスタコンポーネント上、またはクラスタ全体でテストや保守タスクを実行する必要がある場合があります。 </para>
     <para>
@@ -291,39 +295,39 @@ Please see LICENSE.txt for this document's license.
    <para>
    保守モード中にリソースおよびクラスタで何が発生するかの詳細については、<xref linkend="sec-ha-config-basics-maint-mode"/>を参照してください。
   </para>
-  <procedure id="pro-ha-config-hawk-maint-mode-rsc">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-rsc">
    <title>リソースへの保守モードの適用</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>リソース</guimenu>を選択します。保守モードまたは非管理対象モードにするリソースを選択し、そのリソースの隣のレンチアイコンをクリックして、<guimenu>リソースの編集</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>メタ属性</guimenu>カテゴリが開きます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      空のドロップダウンリストから<guimenu>maintenance</guimenu>属性を選択し、プラスアイコンをクリックして追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <literal>maintenance</literal>の隣のチェックボックスをオンにして、maintenance属性を<literal>yes</literal>に設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      変更内容を確認します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      該当するリソースの保守作業が完了したら、そのリソースの<literal>maintenance</literal>属性の隣のチェックボックスをオフにします。
     </para>
@@ -333,23 +337,23 @@ Please see LICENSE.txt for this document's license.
    </step>
   </procedure>
 
-  <procedure id="pro-ha-config-hawk-maint-mode-nodes">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-nodes">
    <title>ノードへの保守モードの適用</title>
    <para>
     1つのノードを保守モードにする必要がある場合があります。
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      個々のノードのビューのいずれかで、ノードの隣のレンチアイコンをクリックして、<guimenu>保守</guimenu>を選択します。
     </para>
@@ -357,38 +361,38 @@ Please see LICENSE.txt for this document's license.
      これにより、<literal>maintenance="true"</literal>というインスタンス属性がノードに追加されます。保守モードのノードでこれまで実行されていたリソースは、<literal>unmanaged</literal>になります。保守モードを終了するまで、このノードに新しいリソースが割り当てられることはありません。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      保守モードを無効化するには、そのノードの隣のレンチアイコンをクリックして<guimenu>準備完了</guimenu>を選択します。
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-maint-mode-cluster">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-cluster">
    <title>クラスタへの保守モードの適用</title>
    <para>
     クラスタ全体に保守モードを設定または設定解除するには、次の手順に従います。
    </para>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタ設定</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>CRMの環境設定</guimenu>グループで、空のドロップダウンボックスから<guimenu>maintenance-mode</guimenu>属性を選択し、プラスアイコンをクリックして追加します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <literal>maintenance-mode=true</literal>を設定するには、<literal>maintenance-mode</literal>の隣のチェックボックスをオンにして、変更を確認します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタ全体の保守作業が完了したら、<literal>maintenance-mode</literal>属性の隣のチェックボックスをオフにします。
     </para>
@@ -397,27 +401,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-history">
+ <section xml:id="sec-ha-config-hawk-history">
   <title>クラスタ履歴の表示</title>
 
   <para>
    Hawkには、クラスタの過去のイベントを表示する、次のような機能があります(いくつかの詳細さのレベルがあります)。
   </para>
-  <procedure id="pro-ha-config-hawk-recent">
+  <procedure xml:id="pro-ha-config-hawk-recent">
    <title>ノードまたリソースの最近のイベントの表示</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>クラスタステータス</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>ツリービュー</guimenu>または<guimenu>テーブルビュー</guimenu>で、対象とするリソースまたはノードの隣のレンチアイコンをクリックして、<guimenu>最近のイベントを表示</guimenu>を選択します。
     </para>
@@ -426,28 +430,28 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-history-explorer">
+  <procedure xml:id="pro-ha-config-hawk-history-explorer">
    <title>履歴エクスプローラで遷移を表示する </title>
    <para>
     <guimenu>履歴エクスプローラ</guimenu>には、定義できるタイムフレームでの遷移情報が表示されます。ここではこれまでの実行内容が一覧され、不必要になったレポートを<guimenu>削除</guimenu>することができます。<guimenu>履歴エクスプローラ</guimenu>は、<literal>hb_report</literal>で提供される情報を使用します。 
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      左のナビゲーションバーで、<guimenu>履歴エクスプローラ</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      デフォルトでは、表示する期間は直前の24時間に設定されています。これを変更するには、<guimenu>開始時刻</guimenu> および<guimenu>終了時刻</guimenu>を設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>表示</guimenu>をクリックして、遷移データの収集を開始します。
     </para>
@@ -467,7 +471,7 @@ Please see LICENSE.txt for this document's license.
   <para>
    次の情報が表示されます。
   </para>
-  <variablelist id="vl-hawk-history-results">
+  <variablelist xml:id="vl-hawk-history-results">
    <title>履歴エクスプローラの結果</title>
    <varlistentry>
     <term><guimenu>時刻</guimenu>
@@ -493,7 +497,7 @@ Please see LICENSE.txt for this document's license.
 
     <listitem>
      <para>
-      ポップアップウィンドウが開き、その特定の遷移に属しているログ記録データのスニペットが表示されます。さまざまな詳細レベルを表示できます。<guimenu>詳細情報</guimenu>をクリックすると、<command>crm history transition <replaceable>peinput</replaceable></command> (リソースエージェントのログメッセージを含む)の出力が表示されますが、<guimenu>ログ全体</guimenu>には<systemitem>pengine</systemitem>、<systemitem>crmd</systemitem>、<systemitem>lrmd</systemitem>の詳細も含まれており、<command>crm history transition log <replaceable>peinput</replaceable></command>に相当します。
+      ポップアップウィンドウが開き、その特定の遷移に属しているログ記録データのスニペットが表示されます。さまざまな詳細レベルを表示できます。<guimenu>詳細情報</guimenu>をクリックすると、<command>crm history transition</command> <replaceable>peinput</replaceable> (リソースエージェントのログメッセージを含む)の出力が表示されますが、<guimenu>ログ全体</guimenu>には<systemitem>pengine</systemitem>、<systemitem>crmd</systemitem>、<systemitem>lrmd</systemitem>の詳細も含まれており、<command>crm history transition log</command> <replaceable>peinput</replaceable>に相当します。
      </para>
     </listitem>
    </varlistentry>
@@ -529,22 +533,22 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-simulator">
+ <section xml:id="sec-ha-config-hawk-simulator">
   <title>可能性のある障害シナリオを調べる</title>
 
   <para>
    Hawkには<guimenu>シミュレータ</guimenu>が用意されており、障害シナリオを、実際に発生する前に調べることができます。シミュレータモードに切り替える前に、ノードのステータスを変更したり、リソースと制約を追加または編集したり、クラスタ設定を変更したり、複数のリソース操作を実行したりして、どのようなクラスタの動作によってこれらのイベントが発生するのかを確認することができます。シミュレータモードが有効になっている間は、<guimenu>クラスタステータス</guimenu>画面の右下隅にコントロールダイアログが表示されます。シミュレータはすべての画面の変更内容を収集し、イベントの内部キューにそれらを追加します。キューに入れられたイベントによる実行シミュレーションは、コントロールダイアログで手動でトリガされるまでは実行されません。シミュレーションの実行後、実行結果の詳細(ログスニペット、遷移グラフ、CIB状態)を表示して分析することができます。
   </para>
-  <procedure id="pro-ha-config-hawk-simulator">
+  <procedure xml:id="pro-ha-config-hawk-simulator">
    <title>シミュレータモードに切り替える</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      最上位の行(ユーザ名の横)にあるレンチアイコンをクリックし、<guimenu>シミュレータ</guimenu>を選択することで、シミュレータモードをアクティブ化します。
     </para>
@@ -552,24 +556,24 @@ Please see LICENSE.txt for this document's license.
      Hawkのバックグラウンド色が変化して、シミュレータがアクティブであることが示されます。<guimenu>クラスタステータス</guimenu>画面の右下隅にシミュレータのコントロールダイアログが表示されます。そのタイトル<guimenu>シミュレータ(初期状態)</guimenu>は、まだシミュレータが実行されていないことを示します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレータのイベントキューを埋めます。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        ノードのステータスの変更をシミュレートするには、まずシミュレータコントロールダイアログの<guimenu>+Node</guimenu>をクリックします。操作する<guimenu>ノード</guimenu>を選択し、そのターゲット<guimenu>状態</guimenu>を選択します。変更を確認して、それらをコントローラダイアログに一覧表示されるイベントのキューに追加します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        リソースの操作をシミュレートするには、まずシミュレータコントロールダイアログの<guimenu>+Op</guimenu>をクリックします。操作する<guimenu>リソース</guimenu>を選択し、シミュレートする<guimenu>操作</guimenu>を選択します。 必要に応じて、<guimenu>間隔</guimenu>を定義します。操作を実行する<guimenu>ノード</guimenu>を選択し、ターゲットとする<guimenu>結果</guimenu>を選択します。変更を確認して、それらをコントローラダイアログに一覧表示されるイベントのキューに追加します。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレートするその他のノードのステータス変更やリソース操作に対して、前の手順を繰り返します。
     </para>
@@ -585,12 +589,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレートするその他の変更を挿入するには:
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>クラスタステータス</guimenu>、<guimenu>セットアップウィザード</guimenu>、<guimenu>クラスタ設定</guimenu>、<guimenu>リソース</guimenu>、または<guimenu>制約</guimenu>といったHawk画面のいずれかに切り替えます。
       </para>
@@ -601,7 +605,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </note>
      </step>
-     <step performance="required">
+     <step>
       <para>
        必要に応じて、画面上でパラメータの追加や変更を行います。
       </para>
@@ -610,19 +614,19 @@ Please see LICENSE.txt for this document's license.
        
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        シミュレータコントロールダイアログに戻るには、<guimenu>クラスタステータス</guimenu>画面に切り替えるか、もう一度最上位の行のレンチアイコンをクリックして<guimenu>シミュレータ</guimenu>をクリックします。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>挿入された状態</guimenu>に一覧されているイベントを削除する場合は、それぞれのエントリを選択して、リストのすぐ下のマイナスアイコンをクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレータコントロールダイアログで<guimenu>実行</guimenu>をクリックして、シミュレーションの実行を開始します。<guimenu>クラスタステータス</guimenu>画面に、シミュレートされるイベントが表示されます。たとえば、あるノードをアンクリーンとしてマークした場合、それはオフラインとして表示され、そのすべてのリソースは停止されます。シミュレータコントロールダイアログは、<guimenu>シミュレータ(最終状態)</guimenu>に変わります。
     </para>
@@ -638,70 +642,70 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレーションの実行に関する詳細情報を表示するには:
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        シミュレータダイアログの<guimenu>詳細</guimenu>リンクをクリックして、実行結果のログスニペットを表示します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>グラフ</guimenu>リンクをクリックして遷移グラフを表示します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>CIB (in)</guimenu>をクリックしてCIB状態を表示します。遷移の後のCIBを表示するには、<guimenu>CIB (out)</guimenu>をクリックします。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しいシミュレーションを最初から開始するには、 <guimenu>リセット</guimenu>ボタンをクリックします。 
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      シミュレーションモードを終了するには、シミュレータコントロールダイアログを閉じます。<guimenu>クラスタステータス</guimenu>画面は切り替わって、元の色に戻り、クラスタの現在の状態を表示します。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-crm-report">
+ <section xml:id="sec-ha-config-hawk-crm-report">
   <title>クラスタレポートの生成</title>
 
   <para>
    クラスタで発生している問題の分析と診断のために、Hawkはクラスタレポートを生成することができます。これは、クラスタ内のすべてのノードからの情報を集めたものです。
   </para>
-  <procedure id="pro-ha-config-hawk-crm-report">
+  <procedure xml:id="pro-ha-config-hawk-crm-report">
    <title><literal>hb_report</literal>を生成する</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-config-hawk-intro-connect"/>で説明したように、Webブラウザを起動してクラスタにログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      最上位の行のユーザ名の隣にあるレンチアイコンをクリックして、<guimenu>hb_reportの生成</guimenu>を選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      デフォルトでは、調査する期間は直前の1時間です。これを変更するには、<guimenu>開始時刻</guimenu> および<guimenu>終了時刻</guimenu>を設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>生成</guimenu>をクリックします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      レポートが作成されたら、対応するリンクをクリックして、<filename>*.tar.bz2</filename>ファイルをダウンロードします。
     </para>
@@ -710,5 +714,5 @@ Please see LICENSE.txt for this document's license.
   <para>
    <literal>hb_report</literal>および<literal>crm_report</literal>のようなツールが対応するログファイルの詳細については、<xref linkend="vle-ha-crm-report"/>を参照してくだい。
   </para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_installation.xml
+++ b/ja/xml/ha_installation.xml
@@ -1,20 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_installation.xml" id="cha-ha-installation">
- <title>インストールと基本セットアップ</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_installation.xml" xml:id="cha-ha-installation"><?dbfo-need height="20em"?><title>インストールと基本セットアップ</title><info><abstract>
   <para> この章では、<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>を最初からインストールしてセットアップする方法について説明します。自動セットアップまたは手動セットアップから選択します。自動セットアップでは、クラスタを起動して数分で実行できます(後でオプションを調整する選択あり)。一方、手動セットアップでは、起動時に個々のオプションを設定できます。 </para>
 
   <para>
    旧バージョンの<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>を実行するクラスタを移行する場合や、実行中のクラスタに属するノードでソフトウェアパッケージを更新する場合は、<xref linkend="app-ha-migration"/>を参照してください。
   </para>
- </abstract>
- <sect1 id="sec-ha-installation-terms">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-installation-terms">
   <title>用語の定義</title>
   <para>この章では、次に定義されるいくつかの用語を使用します。</para>
   <variablelist>
@@ -40,7 +44,7 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-mcastaddr">
+   <varlistentry xml:id="vle-ha-mcastaddr">
     <term>マルチキャストアドレス(<systemitem>mcastaddr</systemitem>)
    </term>
     <listitem>
@@ -80,11 +84,11 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-rrp">
+   <varlistentry xml:id="vle-ha-rrp">
     <term>冗長リングプロトコル(RRP)</term>
     <listitem>
      <para>
-       ネットワーク障害の一部または全体に対する災害耐性のために、複数の冗長ローカルエリアネットワークが使用できるようになります。この方法では、ひとつのネットワークが作動中である限り、クラスタ通信を維持できます。Corosyncはトーテム冗長リングプロトコルをサポートします。信頼できるソートされた方式でメッセージを配信するために、論理トークンパスリングがすべての参加ノードに課せられます。ノードがメッセージをブロードキャストできるのは、トークンを保持している場合のみです。詳細については、<ulink url="http://www.rcsc.de/pdf/icdcs02.pdf"/>を参照してください。
+       ネットワーク障害の一部または全体に対する災害耐性のために、複数の冗長ローカルエリアネットワークが使用できるようになります。この方法では、ひとつのネットワークが作動中である限り、クラスタ通信を維持できます。Corosyncはトーテム冗長リングプロトコルをサポートします。信頼できるソートされた方式でメッセージを配信するために、論理トークンパスリングがすべての参加ノードに課せられます。ノードがメッセージをブロードキャストできるのは、トークンを保持している場合のみです。詳細については、<link xlink:href="http://www.rcsc.de/pdf/icdcs02.pdf"/>を参照してください。
      </para>
      <para>
       Corosyncに定義済みの冗長通信チャネルを持つ場合、RRPを使用してこれらのインタフェースの使用方法をクラスタに伝えます。RRPでは次の3つのモードを使用できます(<literal>rrp_mode</literal>)。
@@ -119,7 +123,7 @@ Please see LICENSE.txt for this document's license.
       Csync2は、認証には、同期グループ内でIPアドレスと事前共有キーを使用します。管理者は、同期グループごとに1つのキーファイルを生成し、そのファイルをすべてのグループメンバにコピーする必要があります。
      </para>
      <para>
-      Csync2の詳細については、<ulink url="http://oss.linbit.com/csync2/paper.pdf"/>を参照してください。
+      Csync2の詳細については、<link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/>を参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -127,7 +131,7 @@ Please see LICENSE.txt for this document's license.
     <term><systemitem class="resource">conntrackツール</systemitem></term>
     <listitem>
      <para>
-      カーネル内の接続トラッキングシステムとやり取りできるようにして、iptablesでの<emphasis>ステートフルな</emphasis>パケット検査を可能にします。High Availability Extensionによって、クラスタノード間の接続ステータスを同期化するために使用されます。詳細については、<ulink url="http://conntrack-tools.netfilter.org/"/>を参照してください。
+      カーネル内の接続トラッキングシステムとやり取りできるようにして、iptablesでの<emphasis>ステートフルな</emphasis>パケット検査を可能にします。High Availability Extensionによって、クラスタノード間の接続ステータスを同期化するために使用されます。詳細については、<link xlink:href="http://conntrack-tools.netfilter.org/"/>を参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -138,16 +142,16 @@ Please see LICENSE.txt for this document's license.
       AutoYaSTは、ユーザの介入なしで、1つ以上のSUSE Linux Enterpriseシステムを自動的にインストールするためのシステムです。SUSE Linux Enterpriseでは、インストールと設定のデータを含むAutoYaSTプロファイルを作成できます。このプロファイルによって、インストールする対象と、インストールしたシステムが最終的に使用準備が整ったシステムになるように設定する方法がAutoYaSTに指示されます。そこでこのプロファイルはさまざまな方法による大量配備に使用できます(たとえば、既存のクラスタノードのクローンなど)。
      </para>
      <para>
-      様々なシナリオでのAutoYaSTの使用手順については、<ulink url="http://www.suse.com/doc"/>で入手できる『<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 導入ガイド</citetitle>』を参照してください。特に、「<citetitle>Automated Installation</citetitle>」の章を参照してください。
+      様々なシナリオでのAutoYaSTの使用手順については、<link xlink:href="http://www.suse.com/doc"/>で入手できる『<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 導入ガイド</citetitle>』を参照してください。特に、「<citetitle>Automated Installation</citetitle>」の章を参照してください。
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-installation-overview">
+
+ <section xml:id="sec-ha-installation-overview">
   <title>概要</title>
 
   <para>
@@ -156,7 +160,7 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-installation-add-on" xrefstyle="select:title"/>:
     </para>
@@ -166,7 +170,7 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>zypper</command> in -t pattern ha_sles</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタの初期セットアップ:
     </para>
@@ -174,32 +178,32 @@ Please see LICENSE.txt for this document's license.
      クラスタの一部になるすべてのノードにソフトウェアをインストールした後、最初にクラスタを設定するために次の手順が必要です。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-channels" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        オプション: <xref linkend="sec-ha-installation-setup-security" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-csync2" xrefstyle="select:title"/>。Csync2の設定がノードでのみ行われるのに対して、サービスであるCsync2および<systemitem class="daemon">xinetd</systemitem>はすべてのノードで開始する必要があります。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        オプション: <xref linkend="sec-ha-installation-setup-conntrackd" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-services" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-start" xrefstyle="select:title"/>。OpenAIS/Corosyncサービスはすべてのノード上で開始する必要があります。
       </para>
@@ -232,19 +236,19 @@ Please see LICENSE.txt for this document's license.
   <para>
    既存のノードをAutoYaSTで大量展開するためにクローンを作成することもできます。クローンを作成したノードには、同じパッケージがインストールされ、クローンノードは同じシステム設定を持つことになります。詳細については、<xref linkend="sec-ha-installation-autoyast"/>を参照してください。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-add-on">
+ <section xml:id="sec-ha-installation-add-on">
   <title>アドオンとしてのインストール</title>
 
   <para>
-   High Availability Extensionによるクラスタの設定と管理に必要なパッケージは、<literal>High Availability</literal>インストールパターンに含まれています。このパターンは、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>がアドオンとしてSUSE® Linux Enterprise Serverにインストールされている場合のみ使用できます。アドオン製品のインストール方法については、<ulink url="http://www.suse.com/doc"/>で入手できる『<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 導入ガイド</citetitle>』を参照してください。特に、「<citetitle>Installing Add-On Products</citetitle>」の章を参照してください。
+   High Availability Extensionによるクラスタの設定と管理に必要なパッケージは、<literal>High Availability</literal>インストールパターンに含まれています。このパターンは、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>がアドオンとしてSUSE® Linux Enterprise Serverにインストールされている場合のみ使用できます。アドオン製品のインストール方法については、<link xlink:href="http://www.suse.com/doc"/>で入手できる『<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 導入ガイド</citetitle>』を参照してください。特に、「<citetitle>Installing Add-On Products</citetitle>」の章を参照してください。
 
   </para>
 
-  <procedure id="pro-ha-install-pattern">
+  <procedure xml:id="pro-ha-install-pattern">
    <title>高可用性パターンのインストール</title>
-   <step performance="required">
+   <step>
     <para>
      YaSTを<systemitem class="username">root</systemitem>ユーザとして開始し、<menuchoice> <guimenu>ソフトウェア</guimenu><guimenu>ソフトウェア管理</guimenu></menuchoice>の順に選択します。
     </para>
@@ -252,12 +256,12 @@ Please see LICENSE.txt for this document's license.
      または、コマンドラインで<command>yast2 sw_single</command>を使用して、YaSTモジュールを<systemitem class="username">root</systemitem>として起動します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>フィルタ</guimenu>リストで、<guimenu>パターン</guimenu>を選択して、パターンリストで<guimenu>高可用性</guimenu>をアクティブにします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>同意する</guimenu>をクリックして、パッケージのインストールを開始します。
     </para>
@@ -267,7 +271,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </note>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタの一部になる<emphasis>すべての</emphasis>マシンにHigh Availabilityパターンをインストールします。
     </para>
@@ -276,9 +280,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-setup-auto">
+ <section xml:id="sec-ha-installation-setup-auto">
   <title>自動のクラスタセットアップ(sleha-bootstrap)</title>
 
   <para> <systemitem class="resource">sleha-bootstrap</systemitem>パッケージは、1ノードクラスタを起動して実行させ、他のノードを追加し、既存のクラスタからノードを削除するために必要なすべての機能を提供します。 </para>
@@ -331,40 +335,40 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-installation-setup-sleha-init">
+  <procedure xml:id="pro-ha-installation-setup-sleha-init">
    <title>最初のノードの自動設定</title>
    <para> <command>sleha-init</command>コマンドは、NTPの設定を確認し、クラスタ通信層(Corosync)の設定、および(オプションで)SBDの設定に導き、共有ストレージを保護します。次の手順に従います。詳細については、<command>sleha-init</command>マニュアルページを参照してください。 </para>
-   <step performance="required">
+   <step>
     <para> クラスタノードとして使用したい物理または仮想マシンに<systemitem class="username">root</systemitem>としてログインします。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 実行によって、ブートストラップスクリプトを開始します </para>
     <screen><prompt role="root">root # </prompt>sleha-init</screen>
     <para> NTPがブート時に開始するよう設定されていない場合、メッセージが表示されます。 </para>
     <para> それでも継続を選択する場合、スクリプトは自動的にSSHアクセスおよびCsync2同期ツールのキーを生成し、両方に必要なサービスを開始します。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> クラスタ通信層(Corosync)を設定するには、次のとおり実行します。 </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para> バインドするネットワークアドレスを入力します。デフォルトでは、スクリプトは<systemitem>eth0</systemitem>のネットワークアドレスを提案します。または、たとえば<literal>bond0</literal>のアドレスなど、別のネットワークアドレスを入力します。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> マルチキャストアドレスを入力します。スクリプトはデフォルトとして使用できるランダムなアドレスを提案します。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> マルチキャストポートを入力します。スクリプトはデフォルトとして<literal>5405</literal>を提案します。 </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para> SBDを設定するには(オプション)、SBDに使用したいブロックデバイスのパーティションに持続的なパスを入力します。パスはクラスタ内のすべてのノード全体で一致している必要があります。 </para>
     <para>
      
     </para>
     <para> 最後に、スクリプトはOpenAISサービスを開始し、1ノードクラスタをオンラインにして、Web管理インタフェースHawkを有効にします。Hawkに使用するURLが画面に表示されます。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> セットアッププロセスの詳細については、<filename>/var/log/sleha-bootstrap.log</filename>を確認してください。 </para>
    </step>
   </procedure>
@@ -386,7 +390,7 @@ Please see LICENSE.txt for this document's license.
    <screen><prompt role="root">root # </prompt><command>passwd</command> hacluster</screen>
   </important>
 
-  <procedure id="pro-ha-installation-setup-sleha-join">
+  <procedure xml:id="pro-ha-installation-setup-sleha-join">
    <title>既存のクラスタにノードを追加</title>
    <para> クラスタを(1つ上のノード上で)開始して実行する場合、<command>sleha-join</command>ブートストラップスクリプトでさらにクラスタノードを追加します。スクリプトは既存のクラスタノードへのアクセスのみが必要で、ご使用のマシンで自動的に基本セットアップを完了します。次の手順に従います。詳細については、<command>sleha-join</command>マニュアルページを参照してください。 </para>
    <para> 既存のクラスタノードをYaSTクラスタモジュールで設定した場合、<command>sleha-join</command>を実行する前に、次の前提条件が満たされていることを確認します。 </para>
@@ -399,26 +403,26 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
    <para> Hawkによって最初のノードにログインしている場合、クラスタステータス内の変更に従い、Webインタフェース内でアクティブ化されるリソースを表示できます。 </para>
-   <step performance="required">
+   <step>
     <para> クラスタを参加させることになる物理または仮想マシンに<systemitem class="username">root</systemitem>としてログインします。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 実行によって、ブートストラップスクリプトを開始します。 </para>
     <screen><prompt role="root">root # </prompt>sleha-join</screen>
     <para> NTPがブート時に開始するよう設定されていない場合、メッセージが表示されます。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> それでも継続を選択する場合、既存のノードのIPアドレスが求められます。IPアドレスを入力します。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 両方のマシン間にパスワードなしのSSHアクセスを設定していない場合、既存のノードの<systemitem class="username">root</systemitem>パスワードも求められます。 </para>
     <para> 指定されたノードにログインした後、スクリプトはCorosync設定をコピーし、SSHおよびCsync2を設定して、新しいクラスタノードとしてご使用のマシンをオンラインにします。それとは別に、Hawkに必要なサービスを開始します。OCFS2で共有ストレージを設定した場合、OCFS2ファイルシステムへのマウントポイントディレクトリも自動的に作成します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para> クラスタを追加したいすべてのマシンにこの手順を繰り返します。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> プロセスの詳細については、<filename>/var/log/sleha-bootstrap.log</filename>を確認してください。 </para>
    </step>
   </procedure>
@@ -439,24 +443,24 @@ Please see LICENSE.txt for this document's license.
 
   
 
-  <procedure id="pro-ha-installation-setup-sleha-remove">
+  <procedure xml:id="pro-ha-installation-setup-sleha-remove">
    <title>既存のクラスタからのノードの削除</title>
    <para> (複数のノードで)クラスタを起動して実行している場合、<command>sleha-remove</command>ブートストラップスクリプトによって、クラスタから1つのノードを削除することができます。この場合、クラスタから削除するノードのIPアドレスまたはホスト名が必要です。次の手順に従います。詳細については、<command>sleha-remove</command>マニュアルページを参照してください。 </para>
    
-   <step performance="required">
+   <step>
     <para> クラスタノードのいずれかに<systemitem class="username">root</systemitem>としてログインします。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 実行によって、ブートストラップスクリプトを開始します。 </para>
     <screen><prompt role="root">root # </prompt>sleha-remove -c <replaceable>IP_ADDR_OR_HOSTNAME</replaceable></screen>
     <para> このスクリプトは<systemitem class="daemon">sshd</systemitem>を有効にし、指定したノードのOpenAISサービスを停止させ、Csync2と同期化するためのファイルを残りのノードに伝播します。 </para>
     
     <para> ホスト名を指定していて、削除対象のノードにアクセスできない(またはホスト名が解決できない)場合、スクリプトによって通知が送信され、それでもノードを削除するかどうかを尋ねられます。IPアドレスを指定していて、ノードにアクセスできない場合は、ホスト名を入力するように求められ、それでもノードを削除するかどうかを尋ねられます。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> ノードをさらに削除するには、前述の手順を繰り返します。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> プロセスの詳細については、<filename>/var/log/sleha-bootstrap.log</filename>を確認してください。 </para>
    </step>
   </procedure>
@@ -466,25 +470,25 @@ Please see LICENSE.txt for this document's license.
   <procedure>
    <title>マシンからのHigh Availability Extensionソフトウェアの削除</title>
    <para>クラスタノードとして不要になったマシンからHigh Availability Extensionソフトウェアを削除するには、以下の手順を実行します。</para>
-   <step performance="required">
+   <step>
     <para>クラスタサービスを停止します:</para>
     <screen><prompt role="root">root # </prompt>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>High Availability Extensionアドオンを削除します:</para>
     <screen><prompt role="root">root # </prompt><command>zypper</command> rm -t products sle-hae</screen>
    </step>
   </procedure>
 
- </sect1>
- <sect1 id="sec-ha-installation-setup-manual">
+ </section>
+ <section xml:id="sec-ha-installation-setup-manual">
   <title>手動のクラスタセットアップ(YaST)</title>
 
   <para>
    最初のセットアップに関するすべての手順の概要については、<xref linkend="sec-ha-installation-overview"/>を参照してください。 
   </para>
 
-   <sect2 id="sec-ha-installation-setup-yast2cluster">
+   <section xml:id="sec-ha-installation-setup-yast2cluster">
    <title>YaSTクラスタモジュール</title>
    <para>
     次のセクションでは、YaSTクラスタモジュールを使用して、セットアップの各手順を実行します。これにアクセスするには、YaSTを<systemitem class="username">root</systemitem>として起動し、<menuchoice> <guimenu>高可用性</guimenu><guimenu>クラスタ</guimenu></menuchoice>の順に選択します。または、コマンドライン<command>yast2 cluster</command>でモジュールを開始します。
@@ -506,9 +510,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     YaSTクラスタモジュールのオプションには、現在のノードにしか適用しないものと、すべてのノードに自動的に移行できるものがあることにご注意ください。これについての詳しい情報は次のセクションを参照してください。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-channels">
+  <section xml:id="sec-ha-installation-setup-channels">
    <title>通信チャネルの定義</title>
    <para>
     クラスタノード間で通信を正常に機能させるには、少なくとも1つの通信チャネルを定義します。
@@ -534,37 +538,37 @@ Please see LICENSE.txt for this document's license.
      可能であれば、ネットワークデバイスのボンディングを選択します。
     </para>
    </important>
-   <procedure id="pro-ha-installation-setup-channel1">
+   <procedure xml:id="pro-ha-installation-setup-channel1">
     <title>最初の通信チャネルの定義</title>
     <para>
      クラスタノード間の通信には、マルチキャスト(UDP)またはユニキャスト(UDPU)のいずれかを使用します。
     </para>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>通信チャネル</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       マルチキャストを使用するには、次のとおり実行します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <guimenu>トランスポート</guimenu>プロトコルを<literal>UDP</literal>に設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>バインドネットワークアドレス</guimenu>を定義します。クラスタマルチキャストに使用するサブネットに値を設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>マルチキャストアドレス</guimenu>を定義します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>マルチキャストポート</guimenu>を定義します。
        </para>
@@ -586,27 +590,27 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ユニキャストを使用するには、次のとおり実行します。
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         <guimenu>トランスポート</guimenu>プロトコルを<literal>UDPU</literal>に設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>バインドネットワークアドレス</guimenu>を定義します。クラスタユニキャストに使用するサブネットに値を設定します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         <guimenu>マルチキャストポート</guimenu>を定義します。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para> ユニキャスト通信では、Corosyncはクラスタ内のすべてのノードのIPアドレスを認識する必要があります。クラスタの一部になる各ノードで、<guimenu>追加</guimenu>をクリックし、次の詳細を入力します。</para>
        <itemizedlist mark="bullet" spacing="normal">
         <listitem>
@@ -638,22 +642,22 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para> <guimenu>ノードIDの自動生成</guimenu>オプションはデフォルトで有効になっています。IPv4アドレスを使用している場合は、ノードIDはオプションですが、IPv6アドレスを使用している場合は必須です。各クラスタノードで固有のIDを自動生成するには(各ノードでIDを手動で指定するよりもエラーの発生が少ない)、このオプションを有効のままにします。</para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。YaSTが設定を<filename>/etc/corosync/corosync.conf</filename>に書き込みます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       必要な場合は、2つ目の通信チャネルを次で説明されるとおり定義します。または<guimenu>次へ</guimenu>をクリックして、<xref linkend="pro-ha-installation-setup-security"/>で続行します。
      </para>
     </step>
    </procedure>
 
-   <procedure id="pro-ha-installation-setup-channel2">
+   <procedure xml:id="pro-ha-installation-setup-channel2">
     <title>冗長通信チャネルの定義</title>
     <para>
      ネットワークデバイスボンディングが何らかの理由で使用できない場合、第2の選択は、Corosyncに冗長通信チャネル(2つ目のリング)を定義することです。この方法では、2つの物理的に分かれたネットワークが通信に使用できます。1つのネットワークが失敗しても、クラスタノードは、もう一方のネットワークを介して通信できます。
@@ -664,17 +668,17 @@ Please see LICENSE.txt for this document's license.
       複数のリングが設定されている場合は、各ノードが複数のIPアドレスを持つことができます。これはすべてのノードの<filename>/etc/hosts</filename>に反映する必要があります。
      </para>
     </important>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>通信チャネル</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>冗長チャネル</guimenu>を有効にします。冗長チャネルは、定義した最初の通信チャネルと同じプロトコルを使用する必要があります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       マルチキャストを使用する場合、<guimenu>バインドネットワークアドレス</guimenu>、<guimenu>マルチキャストアドレス</guimenu>、および<guimenu>マルチキャストポート</guimenu>を冗長チャネル用に定義します。
      </para>
@@ -685,7 +689,7 @@ Please see LICENSE.txt for this document's license.
       これで、Corosyncに、2つ目のトークンパスリングを形成する追加の通信チャネルを定義したことになります。<filename>/etc/corosync/corosync.conf</filename>で、プライマリリング(設定した最初のチャネル)にはringnumber <literal>0</literal>が設定され、2つ目のリング(冗長チャネル)にはringnumber <literal>1</literal>が設定されます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Corosyncに、異なるチャネルを使用する方法とタイミングを伝えるには、使用したい<guimenu>rrp_mode</guimenu>(<literal>active</literal>または<literal>passive</literal>)を選択します。このモードに関する詳細については、<xref linkend="vle-ha-rrp"/>を参照するか、<guimenu>ヘルプ</guimenu>をクリックしてください。RRPが使用されるとただちに、デフォルトでは、ノード間の通信に、(TCPの代わりに)SCTP (Stream Control Transmission Protocol)が使用されます。High Availability Extensionは現在のリングステータスを監視し、不具合が起きたら冗長リングを自動的に再有効化します。または、<command>corosync-cfgtool</command>によって、リングステータスを手動で確認することもできます。使用可能なオプションは<option>-h</option>で参照できます。
      </para>
@@ -693,12 +697,12 @@ Please see LICENSE.txt for this document's license.
       通信チャネルが1つだけ定義されている場合、<guimenu>rrp-mode</guimenu>が自動的に無効化されます(値<literal>なし</literal>)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。YaSTが設定を<filename>/etc/corosync/corosync.conf</filename>に書き込みます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ設定を先に進めるには、<guimenu>次へ</guimenu>をクリックして、<xref linkend="sec-ha-installation-setup-security"/>で続行します。
      </para>
@@ -707,26 +711,26 @@ Please see LICENSE.txt for this document's license.
    <para>
     <filename>/etc/corosync/corosync.conf.example</filename>で、UDPセットアップ用にファイル例を見つけます。UDPセットアップの例は<filename>/etc/corosync/corosync.conf.example.udpu</filename>で参照できます。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-security">
+  <section xml:id="sec-ha-installation-setup-security">
    <title>認証設定の定義</title>
    <para>
     次のステップでは、クラスタの認証設定を定義します。共有シークレットが必要なHMAC/SHA1認証を使用して、メッセージを保護し、認証することができます。指定した認証キー(パスワード)が、クラスタ中のすべてのノードで使用されます。
    </para>
-   <procedure id="pro-ha-installation-setup-security">
+   <procedure xml:id="pro-ha-installation-setup-security">
     <title>安全な認証を有効にする</title>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>Security</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>安全認証の有効化</guimenu>をオンにします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新しく作成したクラスタの場合は、<guimenu>認証キーファイルの生成</guimenu>をクリックします。認証キーが作成され、<filename>/etc/corosync/authkey</filename>に書き込まれます。
      </para>
@@ -745,22 +749,22 @@ Please see LICENSE.txt for this document's license.
       ご使用のマシンを既存のクラスタに参加させたい場合、新しいキーファイルは生成しないでください。代わりに、いずれかのノードから<filename>/etc/corosync/authkey</filename>を(手動またはCsync2によって)ご使用のマシンにコピーします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。YaSTが設定を<filename>/etc/corosync/corosync.conf</filename>に書き込みます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ設定を先に進めるには、<guimenu>次へ</guimenu>をクリックして、<xref linkend="sec-ha-installation-setup-csync2"/>で続行します。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-installation-setup-csync2">
+  <section xml:id="sec-ha-installation-setup-csync2">
    <title>すべてのノードへの設定の転送</title>
    <para>
     結果として生成された設定ファイルをすべてのノードに手動でコピーする代わりに、<command>csync2</command>ツールを使用して、クラスタ内のすべてのノードにレプリケートします。
@@ -769,12 +773,12 @@ Please see LICENSE.txt for this document's license.
     これには、次の基本手順を必要とします。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-yast" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-start" xrefstyle="select:title"/>。
      </para>
@@ -796,25 +800,25 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <para>Csync2の詳細については、<ulink url="http://oss.linbit.com/csync2/"/>と<ulink url="http://oss.linbit.com/csync2/paper.pdf"/>にアクセスしてください。</para>
-   <procedure id="pro-ha-installation-setup-csync2-yast">
+   <para>Csync2の詳細については、<link xlink:href="http://oss.linbit.com/csync2/"/>と<link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/>にアクセスしてください。</para>
+   <procedure xml:id="pro-ha-installation-setup-csync2-yast">
     <title>YaSTによるCsync2の設定</title>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>Csync2</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       同期グループを指定するには、<guimenu>同期ホスト</guimenu>グループで<guimenu>追加</guimenu>をクリックし、クラスタ内のすべてのノードのローカルホスト名を入力します。ノードごとに、<command>hostname</command>コマンドから返された文字列を正確に使用する必要があります。
      </para>
     </step>
-    <step id="step-csync2-generate-key" performance="required">
+    <step xml:id="step-csync2-generate-key">
      <para>
       <guimenu>事前共有キーの生成</guimenu>をクリックして、同期グループのキーファイルを生成します。キーファイルは、<filename>/etc/csync2/key_hagroup</filename>に書き込まれます。このファイルは、作成後に、クラスタのすべてのメンバーに手動でコピーする必要があります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのノード間で、通常、同期される必要のあるファイルを<guimenu>同期ファイル</guimenu>リストに入れるには、<guimenu>推奨ファイルの追加</guimenu>をクリックします。
      </para>
@@ -830,28 +834,28 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </figure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       同期するファイルのリストからファイルを<guimenu>編集</guimenu>、<guimenu>追加</guimenu>、または<guimenu>削除</guimenu>する場合は、該当する各ボタンを使用します。ファイルごとに絶対パス名を入力する必要があります。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>Csync2をオンにする</guimenu>をクリックして、Csync2をアクティブにします。これによって<command>chkconfig csync2</command>が実行され、ブート時にCsync2が自動的に起動します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。YaSTがCsync2の設定内容を<filename>/etc/csync2/csync2.cfg</filename>に書き込みます。ここで同期プロセスを開始するには、<xref linkend="pro-ha-installation-setup-csync2-start"/>で続行します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ設定を先に進めるには、<guimenu>次へ</guimenu>をクリックして、<xref linkend="sec-ha-installation-setup-conntrackd"/>で続行します。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-installation-setup-csync2-start">
+   <procedure xml:id="pro-ha-installation-setup-csync2-start">
     <title>Csync2による設定ファイルの同期</title>
     <para>
      Csync2でファイルを正常に同期するには、次の前提条件を満たしておく必要があります。
@@ -882,7 +886,7 @@ rcxinetd start</screen>
       </note>
      </listitem>
     </itemizedlist>
-    <step performance="required">
+    <step>
      <para>
       設定をコピーしたいノード<emphasis>から</emphasis>、次のコマンドを実行します。
      </para>
@@ -897,7 +901,7 @@ rcxinetd start</screen>
 ERROR from peer hex-14: File is also marked dirty here!
 Finished with 1 errors.</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       現在のノードのファイルバージョンが<quote>最良</quote>だと確信する場合は、そのファイルを強制して再同期を行い、競合を解決できます。
      </para>
@@ -906,7 +910,7 @@ csync2 -x</screen>
     </step>
    </procedure>
    <para>
-    Csync2オプションの詳細については、<command>csync2 <option>-help</option></command>を実行してください。
+    Csync2オプションの詳細については、<command>csync2 </command> <option>-help</option>を実行してください。
    </para>
    <note>
     <title>変更後の同期のプッシュ</title>
@@ -914,23 +918,23 @@ csync2 -x</screen>
      Csync2は変更のみをプッシュします。ノード間のファイルを絶えず同期しているわけでは<emphasis>ありません</emphasis>。
     </para>
     <para>
-     同期が必要なファイルを更新する際はいつも、変更を加えたノード上で<command>csync2 <option>-xv</option></command>を実行することで、変更をその他のノードにプッシュする必要があります。変更されていないファイルを持つその他のノード上でこのコマンドを実行しても、何も起こりません。
+     同期が必要なファイルを更新する際はいつも、変更を加えたノード上で<command>csync2 </command> <option>-xv</option>を実行することで、変更をその他のノードにプッシュする必要があります。変更されていないファイルを持つその他のノード上でこのコマンドを実行しても、何も起こりません。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-conntrackd">
+  <section xml:id="sec-ha-installation-setup-conntrackd">
    <title>クラスタノード間の接続ステータスの同期</title>
    <para>
     iptablesに対して<emphasis>ステートフルな</emphasis>パケット検査ができるようにするには、conntrackツールを設定して使用します。 
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-conntrackd" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <systemitem class="daemon">conntrackd</systemitem> (クラス: <literal>ocf</literal>、プロバイダ: <literal>heartbeat</literal>)のリソースの設定。Hawkを使用する場合、Hawkによって提案されるデフォルト値を使用します。
      </para>
@@ -940,44 +944,44 @@ csync2 -x</screen>
     conntrackツールを設定したら、これを<xref linkend="cha-ha-lvs" xrefstyle="select:title"/>に使用できます。
    </para>
 
-   <procedure id="pro-ha-installation-setup-conntrackd">
+   <procedure xml:id="pro-ha-installation-setup-conntrackd">
     <title>YaSTによる<systemitem class="resource">conntrackd</systemitem>の設定</title>
     <para>
      YaSTクラスタモジュールを使用して、ユーザスペース<systemitem class="daemon">conntrackd</systemitem>を設定します。これには、その他の通信チャネルに使用されていない専用のネットワークインタフェースが必要です。デーモンは後でリソースエージェントによって起動できます。
     </para>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>conntrackdの設定</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>専用インタフェース</guimenu>を選択して、接続ステータスを同期します。選択したインタフェースのIPv4アドレスが自動的に検出され、YaSTに表示されます。これはすでに設定済みで、マルチキャストをサポートしている必要があります。
 
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       接続ステータスの同期に使用する<guimenu>マルチキャストアドレス</guimenu>を定義します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>グループ番号</guimenu>で、接続ステータスを同期させるグループのID番号を定義します。
       
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>/etc/conntrackd/conntrackd.conf の生成</guimenu>をクリックして、<systemitem class="daemon">conntrackd</systemitem>の設定ファイルを作成します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタ設定を先に進めるには、<guimenu>次へ</guimenu>をクリックして、<xref linkend="sec-ha-installation-setup-services"/>で続行します。
      </para>
@@ -994,21 +998,21 @@ csync2 -x</screen>
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-services">
+  <section xml:id="sec-ha-installation-setup-services">
    <title>サービスの設定</title>
    <para>
     YaSTクラスタモジュールは、ブート時にノード上で一定のサービスを開始するかどうか定義します。サービスを手動で開始または停止するためにモジュールを使用することもできます。クラスタノードをオンラインにし、クラスタリソースマネージャを起動するには、OpenAISをサービスとして実行する必要があります。
    </para>
-   <procedure id="pro-ha-installation-setup-services">
+   <procedure xml:id="pro-ha-installation-setup-services">
     <title>クラスタサービスの有効化</title>
-    <step performance="required">
+    <step>
      <para>
       YaSTクラスタモジュール内で、<guimenu>サービス</guimenu>カテゴリに切り替えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       このクラスタノードがブートするたびにOpenAISを開始するには、<guimenu>ブート</guimenu>グループで該当するオプションを選択します。<guimenu>ブート</guimenu>グループで、<guimenu>オフ</guimenu>を選択する場合は、このノードがブートするたびに手動でOpenAISを起動する必要があります。OpenAISを手動で起動するには、<command>rcopenais start</command>コマンドを使用します。
      </para>
@@ -1022,21 +1026,21 @@ csync2 -x</screen>
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       クラスタリソースの設定、管理、および監視に、Pacemaker GUIを使用する場合は、<guimenu>mgmtdを有効にする</guimenu>をオンにします。このデーモンは、GUIのために必要です。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       OpenAISをただちに開始または停止するには、それぞれのボタンをクリックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>現在のマシン上でのクラスタ通信に必要なポートをファイアウォールで開くには、<guimenu>ファイアウォールでポートを開く</guimenu>をアクティブにします。この設定は、<filename>/etc/sysconfig/SuSEfirewall2.d/services/cluster</filename>に書きこまれます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       既存のクラスタノードでオプションを変更した場合、変更を確認して、クラスタモジュールを終了します。この設定は、すべてのクラスタノードではなく、ご使用のマシンにのみ適用されることにご注意ください。
      </para>
@@ -1056,21 +1060,21 @@ csync2 -x</screen>
      </figure>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-start">
+  <section xml:id="sec-ha-installation-start">
    <title>クラスタをオンラインにする</title>
    <para>
     最初のクラスタ設定が完了した後、<emphasis>各</emphasis>クラスタノード上でOpenAIS/Corosyncサービスを開始し、スタックをオンラインにします。
    </para>
    <procedure>
     <title>OpenAIS/Corosyncを起動してステータスをチェック</title>
-    <step performance="required">
+    <step>
      <para>
       既存のノードにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       サービスがすでに実行していることを確認します。
      </para>
@@ -1080,12 +1084,12 @@ csync2 -x</screen>
      </para>
 <screen><prompt role="root">root # </prompt>rcopenais start</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       それぞれのクラスタノードに対してこの手順を繰り返します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       ノードの1つで、<command>crm status</command>コマンドを使用してクラスタの状態を確認します。すべてのノードがオンラインの場合、出力は次のようになります。
      </para>
@@ -1105,9 +1109,9 @@ csync2 -x</screen>
    <para>
     基本設定が完了し、ノードがオンラインになった後、crmシェルやPacemaker GUI、HA Web Konsoleなどのクラスタ管理ツールのいずれかを使用して、クラスタリソースの設定を開始できます。詳細については、次の章を参照してください。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-installation-autoyast">
+  </section>
+ </section>
+ <section xml:id="sec-ha-installation-autoyast">
   <title>AutoYaSTによる大量展開</title>
 
   <para>
@@ -1116,7 +1120,7 @@ csync2 -x</screen>
 
 
 
-  <procedure id="pro-ha-installation-clone-node">
+  <procedure xml:id="pro-ha-installation-clone-node">
    <title>AutoYaSTによるクラスタノードのクローン作成</title>
    <important>
     <title>同一のハードウェアを使用している環境</title>
@@ -1124,43 +1128,43 @@ csync2 -x</screen>
      このシナリオでは、同じハードウェア構成を持つ一群のマシンに<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>を展開していることを前提としています。
     </para>
    </important>
-   <para>構成が互いに異なるハードウェアにクラスタノードを展開する必要がある場合は、<ulink url="http://www.suse.com/doc"/>で入手できる『SUSE Linux Enterprise 11 SP4 導入ガイド<citetitle/><citetitle/><citetitle><phrase role="productnumber">』の「自動インストール」の章にあるセクション「ルールベースの自動インストール」<phrase os="sles"/></phrase></citetitle>を参照してください。 </para>
-   <step performance="required">
+   <para>構成が互いに異なるハードウェアにクラスタノードを展開する必要がある場合は、<link xlink:href="http://www.suse.com/doc"/>で入手できる『SUSE Linux Enterprise 11 SP4 導入ガイド<citetitle/><citetitle/><citetitle><phrase role="productnumber">』の「自動インストール」の章にあるセクション「ルールベースの自動インストール」<phrase os="sles"/></phrase></citetitle>を参照してください。 </para>
+   <step>
     <para>
      クローンを作成するノードが正しくインストールされ、設定されていることを確認します。詳細については、<xref linkend="sec-ha-installation-add-on"/>、<xref linkend="sec-ha-installation-setup-auto"/>、または<xref linkend="sec-ha-installation-setup-manual"/>をそれぞれ参照してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      単純な大量インストールについては、『SUSE Linux Enterprise 11 SP4 導入ガイド<citetitle><phrase role="productnumber"><phrase os="sles"/></phrase></citetitle>』の説明に従ってください。これには、次の基本ステップがあります。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        AutoYaSTプロファイルの作成AutoYaST GUIを使用して、既存のシステム設定をもとにプロファイルを作成し、変更します。AutoYaSTでは、<guimenu>高可用性</guimenu>モジュールを選択し、<guimenu>クローン</guimenu>ボタンをクリックします。必要な場合は、他のモジュールの設定を調整し、その結果のコントロールファイルをXMLとして保存します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        AutoYaSTプロファイルのソースと、他のノードのインストールルーチンに渡すパラメータを決定します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        SUSE Linux Enterprise Serverのソースと<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>インストールデータを決定します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        自動インストールのブートシナリオを決定し、設定します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        パラメータを手動で追加するか、または<filename>info</filename>ファイルを作成することにより、インストールルーチンにコマンド行を渡します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        自動インストールプロセスを開始および監視します。
       </para>
@@ -1173,14 +1177,14 @@ csync2 -x</screen>
    クローンのインストールに成功したら、次の手順を実行して、クローンノードをクラスタに加えます。
   </para>
 
-  <procedure id="pro-ha-installation-clone-start">
+  <procedure xml:id="pro-ha-installation-clone-start">
    <title>クローンノードをオンラインにする</title>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-installation-setup-csync2"/>の説明に従って、Csync2を使用して、設定済みのノードからクローンノードへ重要な設定ファイルを転送します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ノードをオンラインにするには、<xref linkend="sec-ha-installation-start"/>の説明のとおり、クローンノード上でOpenAISサービスを開始します。
     </para>
@@ -1190,5 +1194,5 @@ csync2 -x</screen>
   <para>
    これで、<filename>/etc/corosync/corosync.conf</filename>ファイルがCsync2を介してクローンノードに適用されたので、クローンノードがクラスタに加わります。CIBは、クラスタノード間で自動的に同期されます。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_intro.xml
+++ b/ja/xml/ha_intro.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE preface PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE preface>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<preface xml:base="ha_intro.xml" id="pre-ha">
- <title>このガイドについて</title>
+<preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_intro.xml" xml:id="pre-ha"><title>このガイドについて</title><info/>
+ 
  <para>
   <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>は、オープンソースクラスタ化技術の統合スイートで、可用性の高い物理Linuxクラスタと仮想Linuxクラスタを実装できます。構成と管理をすばやく効率的に行うため、High Availability Extensionにはグラフィカルユーザインタフェース(GUI)とコマンドラインインタフェース(CLI)の両方が備わっています。さらに、HA Web Konsole (Hawk)も標準装備しているので、WebインターフェイスからでもLinuxクラスタを管理できます。
  </para>
@@ -58,12 +62,12 @@ Please see LICENSE.txt for this document's license.
   このマニュアル中の多くの章に、他の資料やリソースへのリンクが記載されています。それらは、システム上で参照できる追加ドキュメントやインターネットから入手できるドキュメントなどです。
  </para>
  <para>
-  ご使用製品の利用可能なマニュアルと最新のドキュメントアップデートの概要については、<ulink url="http://www.suse.com/doc/"/>を参照してください。
+  ご使用製品の利用可能なマニュアルと最新のドキュメントアップデートの概要については、<link xlink:href="http://www.suse.com/doc/"/>を参照してください。
  </para>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_feedback_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_typografie_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_making_i.xml" parse="xml"/>
+ <xi:include href="common_intro_feedback_i.xml" parse="xml"/>
+ <xi:include href="common_intro_typografie_i.xml" parse="xml"/>
+ <xi:include href="common_intro_making_i.xml" parse="xml"/>
  
  
 </preface>

--- a/ja/xml/ha_lvs.xml
+++ b/ja/xml/ha_lvs.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_lvs.xml" id="cha-ha-lvs">
- <title>Linux仮想サーバによる負荷分散</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_lvs.xml" xml:id="cha-ha-lvs"><title>Linux仮想サーバによる負荷分散</title><info/>
+ 
 
  <para>
   LVS(Linux仮想サーバ)は、複数のサーバにネットワーク接続を振り分けてワークロードを共有させる基本フレームワークの提供を目的としています。Linux仮想サーバは、1つ以上のロードバランサとサービス実行用の数台の実際のサーバから成るサーバクラスタですが、外部のクライアントには1つの高速な大型サーバのように見えます。この単一サーバのように見えるサーバは、 <emphasis>仮想サーバ</emphasis>と呼ばれます。Linux仮想サーバは、高度にスケーラブルで可用性の高いネットワークサービス(Web、キャッシュ、メール、FTP、メディア、VoIPなど)の構築に使用できます。
@@ -14,14 +18,14 @@ Please see LICENSE.txt for this document's license.
  <para>
   実際のサーバとロードバランサは、高速LANまたは地理的に分散されたWANのいずれでも、相互に接続できます。ロードバランサは、さまざまなサーバに要求をディスパッチできます。ロードバランサによって、クラスタのパラレルサービスが1つのIPアドレス(仮想IPアドレスまたはVIP)上の仮想サービスであるかのようにみえます。要求のディスパッチでは、IP負荷分散技術か、アプリケーションレベル負荷分散技術を使用できます。クラスタ内のノードのトランスペアレントな追加または削除によって、システムのスケーラビリティが達成されます。ノードまたはデーモンの障害の検出とシステムの適宜な再設定によって、高度な可用性が提供されます。
  </para>
- <sect1 id="sec-ha-lvs-overview">
+ <section xml:id="sec-ha-lvs-overview">
   <title>概念の概要</title>
 
   <para>
    以降のセクションでは、主要なLVSのコンポーネントと概念の概要を示します。
   </para>
 
-  <sect2 id="sec-ha-lvs-overview-director">
+  <section xml:id="sec-ha-lvs-overview-director">
    <title>Director</title>
    <para>
     LVSの主要コンポーネントは、ip_vs (またはIPVS)カーネルコードです。このコードは、Linuxカーネル内でトランスポート層の負荷分散(レイヤ-4スイッチング)を実装します。IPVSコードを含むLinuxカーネルを実行するノードは、<emphasis>ディレクター</emphasis>と呼ばれます。ディレクターで実行されるIPVSコードは、LVSの必須機能です。
@@ -32,9 +36,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     デフォルトでは、IPVSモジュールはカーネルにインストールされている必要はありません。IPVSカーネルモジュールは、<systemitem class="resource">cluster-network-kmp-default</systemitem>パッケージに含まれています。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-userspace">
+  <section xml:id="sec-ha-lvs-overview-userspace">
    <title>ユーザスペースのコントローラとデーモン</title>
    <para>
     <systemitem class="daemon">ldirectord</systemitem>デーモンは、Linux仮想サーバを管理し、負荷分散型仮想サーバのLVSクラスタ内の実サーバを監視するユーザスペースデーモンです。設定ファイル<filename>/etc/ha.d/ldirectord.cf</filename>は、仮想サービスとそれらに関連付けられた実サーバを指定し、LVSリダイレクタとしてサーバを設定する方法を<systemitem class="daemon">ldirecord</systemitem>に指示します。このデーモンは、その初期化時にクラスタの仮想サービスを生成します。
@@ -45,9 +49,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     <systemitem class="daemon">ldirectord</systemitem>は<systemitem>ipvsadm</systemitem>ツール(<systemitem class="resource">ipvsadm</systemitem>パッケージ)を使用して、Linuxカーネル内の仮想サーバテーブルを操作します。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-forwarding">
+  <section xml:id="sec-ha-lvs-overview-forwarding">
    <title>パケット転送</title>
    <para>
     ディレクターがクライアントから実サーバにパケットを送信する方法は、3つあります。
@@ -78,16 +82,16 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-schedulers">
+  <section xml:id="sec-ha-lvs-overview-schedulers">
    <title>スケジューリングアルゴリズム</title>
    <para>
     クライアントから要求された新しい接続に使用する実サーバの決定は、さまざまなアルゴリズムを使用して実装されます。それらは、モジュールとして使用可能であり、特定のニーズに合わせて調整できます。使用可能なモジュールの概要については、<command>ipvsadm(8)</command>のマニュアルページを参照してください。ディレクターは、クライアントから接続要求を受信すると、<emphasis>スケジュール</emphasis>に基づいて実際のサーバをクライアントに割り当てます。スケジューラは、IPVSカーネルコードの一部として、次の新しい接続を取得する実際のサーバを決定します。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-lvs-ldirectord">
+  </section>
+ </section>
+ <section xml:id="sec-ha-lvs-ldirectord">
   <title>YaSTによるIP負荷分散の設定</title>
 
   <para>
@@ -113,69 +117,69 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="sec-ha-lvs-ldirectord-global">
+  <procedure xml:id="sec-ha-lvs-ldirectord-global">
    <title>グローバルパラメータを設定する</title>
    <para>
     次の手順では、重要なグローバルパラメータの設定方法を示します。個々のパラメータ(および、ここに記載されていないパラメータ)の詳細については、<guimenu>ヘルプ</guimenu>をクリックするか、<systemitem class="daemon">ldirectord</systemitem>のマニュアルページを参照してください。
    </para>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>確認間隔</guimenu>で、<systemitem class="daemon">ldirectord</systemitem>が各実サーバに接続していて、それらがまだオンラインかどうか確認する間隔を定義します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>確認タイムアウト</guimenu>で、最後の確認後に実サーバが応答する期限を設定します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>障害発生回数</guimenu>では、<systemitem class="daemon">ldirectord</systemitem>が、何回、実サーバに要求すると、確認が失敗したと見なされるか定義できます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>ネゴシエーションタイムアウト</guimenu>で、ネゴシエーション確認のタイムアウトを秒単位で定義します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>フォールバック</guimenu>で、すべての実サーバがダウンした場合にWebサービスのリダイレクト先にするWebサーバのホスト名とIPアドレスを入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      実サーバへの接続ステータスが変わったら、システムにアラートを送信させたい場合は、有効な電子メールアドレスを<guimenu>電子メールアラート</guimenu>に入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>電子メールアラート頻度</guimenu>で、実サーバにアクセスできない状態が続く場合、何秒後に電子メールアラートを繰り返すか定義します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>電子メールアラートステータス</guimenu>で、電子メールアラートを送信する必要のあるサーバのステータスを指定します。複数の状態を定義する場合は、カンマで区切ったリストを使用します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>自動リロード</guimenu>で、変更の有無について、<systemitem class="daemon">ldirectord</systemitem>に設定ファイルを継続的に監視させるかどうか定義します。<literal>yes</literal>に設定した場合は、変更のたびに、設定ファイルが自動的にリロードされます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>休止</guimenu>スイッチで、障害が発生した実サーバをカーネルのLVSテーブルから削除するかどうか定義します。<guimenu>はい</guimenu>に設定すると、障害のあるサーバは削除されません。代わりに、それらの重み付けが<literal>0</literal>に設定され、新しい接続が受け入れられなくなります。すでに確立している接続は、タイムアウトするまで持続します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ロギングに代替パスを使用する場合は、<guimenu>ログファイル</guimenu>でログのパスを指定します。デフォルトでは、<systemitem class="daemon">ldirectord</systemitem>は、そのログを<filename>/var/log/ldirectord.log</filename>に書き込みます。
     </para>
    </step>
   </procedure>
 
-  <figure id="fig-ha-lvs-yast-global">
+  <figure xml:id="fig-ha-lvs-yast-global">
    <title>YaST IP負荷分散 - グローバルパラメータ</title>
    <mediaobject>
     <imageobject role="fo">
@@ -187,27 +191,27 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <procedure id="sec-ha-lvs-ldirectord-virtual">
+  <procedure xml:id="sec-ha-lvs-ldirectord-virtual">
    <title>仮想サービスを設定する</title>
    <para>
     仮想サービスごとに、2、3のパラメータを定義することによって、1つ以上の仮想サービスを設定できます。次の手順で、仮想サービスの重要なパラメータを設定する方法を示します。個々のパラメータ(および、ここに記載されていないパラメータ)の詳細については、<guimenu>ヘルプ</guimenu>をクリックするか、<systemitem class="daemon">ldirectord</systemitem>のマニュアルページを参照してください。
    </para>
-   <step performance="required">
+   <step>
     <para>
      YaST IP負荷分散モジュール内で、<guimenu>仮想サーバ設定</guimenu>タブに切り替えます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>追加</guimenu>で新しい仮想サーバを追加するか、<guimenu>編集</guimenu>で既存の仮想サーバを編集します。新しいダイアログに、使用可能なオプションが表示されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>仮想サーバ</guimenu>で、共有仮想IPアドレス(IPv4またはIPv6)とポートを入力します。これらのアドレスとポートで、ロードバランサと実サーバをLVSとしてアクセスできます。IPアドレスとポート番号の代わりに、ホスト名とサービスも指定できます。または、ファイアウォールマークを使用することもできます。ファイアウォールマークは、<literal>VIP:port</literal>サービスの任意の集まりを1つの仮想サービスにまとめる方法です。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>実サーバ</guimenu>で実際のサーバを指定するには、サーバのIPアドレス(IPv4、IPv6、またはホスト名)、ポート(またはサービス名)、および転送方法を入力する必要があります。転送方法は、<literal>gate</literal>、<literal>ipip</literal>、または<literal>masq</literal>のいずれかにする必要があります(<xref linkend="sec-ha-lvs-overview-forwarding"/>参照)。
     </para>
@@ -215,47 +219,47 @@ Please see LICENSE.txt for this document's license.
      <guimenu>追加</guimenu>ボタンをクリックし、実サーバごとに必要な引数を入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>確認タイプ</guimenu>で、実サーバがまだアクティブかどうかをテストするために実行する必要のある確認のタイプを選択します。たとえば、要求を送信し、応答に予期どおりの文字列が含まれているかどうか確認するには、［<literal>ネゴシエーション</literal>］を選択します。
     </para>
    </step>
-   <step id="step-ha-lvs-ldirectord-service" performance="required">
+   <step xml:id="step-ha-lvs-ldirectord-service">
     <para>
      <guimenu>確認のタイプ</guimenu>を［<literal>ネゴシエーション</literal>］に設定した場合は、監視するサービスのタイプも定義する必要があります。<guimenu>サービス</guimenu>ドロップダウンリストから選択してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>要求</guimenu>で、確認間隔中に各実サーバで要求されるオブジェクトへのURLを入力します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      実サーバからの応答に一定の文字列(<quote>I'm alive</quote>メッセージ)が含まれているかどうか確認する場合は、一致する必要のある正規表現を定義します。正規表現を<guimenu>受信</guimenu>に入力します。実サーバからの応答にこの表現が含まれている場合、実サーバはアクティブとみなされます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="step-ha-lvs-ldirectord-service"/>で選択した<guimenu>サービス</guimenu>のタイプによっては、認証のためのパラメータをさらに指定する必要があります。<guimenu>認証タイプ</guimenu>タブに切り替えて、<guimenu>ログイン</guimenu>、<guimenu>パスワード</guimenu>、<guimenu>データベース</guimenu>、または<guimenu>シークレット</guimenu>などの詳細を入力します。 詳細については、YaSTヘルプのテキストか、<systemitem class="daemon">ldirectord</systemitem>のマニュアルページを参照してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>その他</guimenu>タブに切り替えます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ロードに使用する<guimenu>スケジューラ</guimenu>を選択します。使用可能なスケジューラについては、<command>ipvsadm(8)</command>のマニュアルページを参照してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用する<guimenu>プロトコル</guimenu>を選択します。仮想サービスをIPアドレスとポートとして指定する場合は、プロトコルを<literal>tcp</literal>または<literal>udp</literal>のどちらかにする必要があります。仮想サービスをファイアウォールマークとして指定する場合は、プロトコルを<literal>fwm</literal>にする必要があります。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      必要な場合は、さらにパラメータを定義します。<guimenu>OK</guimenu>を選択して、設定を確認します。YaSTが設定を<filename>/etc/ha.d/ldirectord.cf</filename>に書き込みます。
     </para>
@@ -264,7 +268,7 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <figure id="fig-ha-lvs-yast-virtual">
+  <figure xml:id="fig-ha-lvs-yast-virtual">
    <title>YaST IP負荷分散 - 仮想サービス</title>
    <mediaobject>
     <imageobject role="fo">
@@ -276,25 +280,25 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <example id="ex-ha-lvs-ldirectord">
+  <example xml:id="ex-ha-lvs-ldirectord">
    <title>単純なldirectord設定</title>
    <para>
     <xref linkend="fig-ha-lvs-yast-global"/>と<xref linkend="fig-ha-lvs-yast-virtual"/>で示された値を使用すると、次のような設定になり、<filename>/etc/ha.d/ldirectord.cf</filename>で定義されます。
    </para>
-<screen>autoreload = yes <co id="co-ha-ldirectord-autoreload"/>
-checkinterval = 5 <co id="co-ha-ldirectord-checkintervall"/>
-checktimeout = 3 <co id="co-ha-ldirectord-checktimeout"/>
-quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
-    virtual = 192.168.0.200:80 <co id="co-ha-ldirectord-virtual"/>
-    checktype = negotiate <co id="co-ha-ldirectord-checktype"/>
-    fallback = 127.0.0.1:80 <co id="co-ha-ldirectord-fallback"/>
-    protocol = tcp <co id="co-ha-ldirectord-protocol"/>
-    real = 192.168.0.110:80 gate <co id="co-ha-ldirectord-real"/>
+<screen>autoreload = yes <co xml:id="co-ha-ldirectord-autoreload"/>
+checkinterval = 5 <co xml:id="co-ha-ldirectord-checkintervall"/>
+checktimeout = 3 <co xml:id="co-ha-ldirectord-checktimeout"/>
+quiescent = yes <co xml:id="co-ha-ldirectord-quiescent"/>
+    virtual = 192.168.0.200:80 <co xml:id="co-ha-ldirectord-virtual"/>
+    checktype = negotiate <co xml:id="co-ha-ldirectord-checktype"/>
+    fallback = 127.0.0.1:80 <co xml:id="co-ha-ldirectord-fallback"/>
+    protocol = tcp <co xml:id="co-ha-ldirectord-protocol"/>
+    real = 192.168.0.110:80 gate <co xml:id="co-ha-ldirectord-real"/>
     real = 192.168.0.120:80 gate <xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/>
-    receive = "still alive" <co id="co-ha-ldirectord-receive"/>
-    request = "test.html" <co id="co-ha-ldirectord-request"/>
-    scheduler = wlc <co id="co-ha-ldirectord-scheduler"/>
-    service = http <co id="co-ha-ldirectord-service"/></screen>
+    receive = "still alive" <co xml:id="co-ha-ldirectord-receive"/>
+    request = "test.html" <co xml:id="co-ha-ldirectord-request"/>
+    scheduler = wlc <co xml:id="co-ha-ldirectord-scheduler"/>
+    service = http <co xml:id="co-ha-ldirectord-service"/></screen>
    <calloutlist>
     <callout arearefs="co-ha-ldirectord-autoreload">
      <para>
@@ -367,8 +371,8 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     この設定を使用すると、次のような処理フローになります: <systemitem class="daemon">ldirectord</systemitem>が、5秒ごとに(<xref linkend="co-ha-ldirectord-checkintervall" xrefstyle="select:label nopage"/>)各実サーバに接続し、<xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/>と<xref linkend="co-ha-ldirectord-request" xrefstyle="select:label nopage"/>で指定されているように、<literal>192.168.0.110:80/test.html</literal>または<literal>192.168.0.120:80/test.html</literal>を要求します。予期された<literal>still alive</literal>文字列(<xref linkend="co-ha-ldirectord-receive" xrefstyle="select:label nopage"/>)を、最後の確認から 3秒以内(<xref linkend="co-ha-ldirectord-checktimeout" xrefstyle="select:label nopage"/>)に実サーバから受信しない場合は、実サーバが使用可能なサーバのプールから削除されます。ただし、<literal>quiescent=yes</literal>が設定されているので(<xref linkend="co-ha-ldirectord-quiescent" xrefstyle="select:label nopage"/>)、実サーバは、LVSテーブルからは削除されず、代わりに、その重み付けが<literal>0</literal>に設定されます。その結果、この実サーバへの新しい接続は受け付けられなくなります。すでに確立されている接続は、タイムアウトするまで持続します。
    </para>
   </example>
- </sect1>
- <sect1 id="sec-ha-lvs-further">
+ </section>
+ <section xml:id="sec-ha-lvs-further">
   <title>追加設定</title>
 
   <para>
@@ -397,16 +401,16 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-lvs-more">
+ </section>
+ <section xml:id="sec-ha-lvs-more">
   <title>その他の情報</title>
 
   <para>
-   Linux仮想サーバの詳細については、プロジェクトのホームページ(<ulink url="http://www.linuxvirtualserver.org/"/>)を参照してください。
+   Linux仮想サーバの詳細については、プロジェクトのホームページ(<link xlink:href="http://www.linuxvirtualserver.org/"/>)を参照してください。
   </para>
 
   <para>
    <systemitem class="daemon">ldirectord</systemitem>の詳細については、その総合的なマニュアルページを参照してください。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_management.xml
+++ b/ja/xml/ha_management.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_management.xml" id="app-ha-management">
- <title>クラスタ管理ツール</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_management.xml" xml:id="app-ha-management"><title>クラスタ管理ツール</title><info/>
+ 
  <para>
   High Availability Extensionには、クラスタをコマンドラインから管理する際に役立つ、包括的なツールセットが付属しています。この章では、CIBおよびクラスタリソースでのクラスタ構成を管理するために必要なツールを紹介します。リソースエージェントを管理する他のコマンドラインツールや、セットアップのデバッグ(およびトラブルシューティング)に使用するツールについては、<xref linkend="app-ha-troubleshooting"/>で説明されています。
  </para>

--- a/ja/xml/ha_migration.xml
+++ b/ja/xml/ha_migration.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_migration.xml" id="app-ha-migration">
- <title>クラスタアップグレードとソフトウェアパッケージの更新</title>
- <abstract>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_migration.xml" xml:id="app-ha-migration"><title>クラスタアップグレードとソフトウェアパッケージの更新</title><info><abstract>
   <para>
    この章では、<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>の別バージョン(メジャーリリースまたはサービスパック)にクラスタをアップグレードするシナリオおよびクラスタノード上でパッケージを個別に更新するシナリオの2種類を取り上げます。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-migration-terminology">
+ 
+ 
+ <section xml:id="sec-ha-migration-terminology">
   <title>用語集</title>
   
   <para>
@@ -57,13 +61,13 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-upgrade">
+ <section xml:id="sec-ha-migration-upgrade">
   <title>最新の製品バージョンへのクラスタアップグレード</title>
   
   <para>
-   サポートされるアップグレードパスおよびアップグレードの実行方法は、クラスタが実行されている現在の製品バージョンおよび移行したいターゲットバージョンによって異なります。アップグレードに関する一般的な情報については、『<citetitle/>SUSE Linux Enterprise Server 11  導入ガイド』の「<citetitle/>SUSE Linux Enterpriseのアップデート」の章を参照してください。<ulink url="http://www.suse.com/documentation/"/>で入手できます。
+   サポートされるアップグレードパスおよびアップグレードの実行方法は、クラスタが実行されている現在の製品バージョンおよび移行したいターゲットバージョンによって異なります。アップグレードに関する一般的な情報については、『<citetitle/>SUSE Linux Enterprise Server 11  導入ガイド』の「<citetitle/>SUSE Linux Enterpriseのアップデート」の章を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>で入手できます。
   </para>
   
   <important>
@@ -84,7 +88,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
   </important>
- <sect2 id="sec-ha-migration-sle11">
+ <section xml:id="sec-ha-migration-sle11">
   <title>SLES 10からSLE HA 11へのアップグレード</title>
 
    <important>
@@ -134,34 +138,34 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect3 id="sec-ha-migration-sle11-prep">
+  <section xml:id="sec-ha-migration-sle11-prep">
    <title>準備とバックアップ</title>
    <para>
     クラスタを次の製品バージョンへアップグレードし、適宜、データを変換するには、その前に、現在のクラスタを準備する必要があります。
    </para>
-   <procedure id="pro-ha-migration-sle11-prep">
+   <procedure xml:id="pro-ha-migration-sle11-prep">
     <title>SUSE Linux Enterprise Server 10 SP4クラスタを準備する</title>
-    <step performance="required">
+    <step>
      <para>
       クラスタにログインします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       Heartbeat環境設定ファイル<filename>/etc/ha.d/ha.cf</filename>をレビューし、すべての通信メディアがマルチキャストをサポートしているかどうかチェックします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のファイルがすべてのノード で等しいことを確認します。<filename>/etc/ha.d/ha.cf</filename>および<filename>/var/lib/heartbeat/crm/cib.xml</filename>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       各ノードで<command>rcheartbeat stop</command>を実行することで、すべてのノードをオフラインにします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       最新バージョンへの更新前の一般的なシステムバックアップ(推奨)に加えて、次のファイルをバックアップします。これらのファイルは、SUSE Linux Enterprise Server 11へのアップグレード後の変換スクリプトの実行で必要になります。
      </para>
@@ -188,36 +192,36 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </itemizedlist>
     </step>
-    <step performance="required">
+    <step>
      <para>
       EVMS2リソースがある場合は、非LVM EVMS2ボリュームをSUSE Linux Enterprise Server 10上の互換ボリュームに変換します。これらは、変換処理中(<xref linkend="sec-ha-migration-sle11-convert"/>参照)に、LVM2ボリュームグループになります。変換後は、<command>vgchange -c y</command>を使用して、各ボリュームグループをHigh Availabilityクラスタのメンバとして必ずマークしてください。
 
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-install">
+  <section xml:id="sec-ha-migration-sle11-install">
    <title>アップグレード/インストール</title>
    <para>
     クラスタを準備してファイルをバックアップしたら、クラスタノード上でSUSE Linux Enterprise 11のフレッシュインストールを行います。
    </para>
-   <procedure id="pro-ha-migration-sle11-install">
+   <procedure xml:id="pro-ha-migration-sle11-install">
     <title>SUSE Linux Enterprise 11にアップグレードする</title>
-    <step performance="required">
+    <step>
      <para>
       すべてのクラスタノードにSUSE Linux Enterprise Server 11をフレッシュインストールします。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのクラスタノードで、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11を、SUSE Linux Enterprise Server上のアドオンとしてインストールします。詳細については、<xref linkend="sec-ha-installation-add-on"/>を参照してください。
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-convert">
+  <section xml:id="sec-ha-migration-sle11-convert">
    <title>データの変換</title>
    <para>
     SUSE Linux Enterprise Server 11およびHigh Availability Extensionのインストールが完了したら、データ変換を開始できます。High Availability Extensionとともに出荷される変換スクリプトは、注意深く設定されていますが、完全な自動モードですべての設定を行うことはできません。このスクリプトでは、実行する変更について管理者に警告し、対話と管理者側での決定を必要とします。管理者は、クラスタの詳細を知っている必要があり、変更の妥当性を検証する責任があります。変換スクリプトは、<filename>/usr/lib/heartbeat</filename>(<filename>64ビットマシンの場合は、/usr/lib64/heartbeat</filename>)に格納されています。
@@ -228,9 +232,9 @@ Please see LICENSE.txt for this document's license.
      変換プロセスをよく知るために、まず、変換をテストすること(変更なしで)を強くお勧めします。同じテストディレクトリを使用すると、ファイルを1回コピーするだけで、テストランを繰り返すことができます。
     </para>
    </note>
-   <procedure id="pro-ha-migration-sle11-test">
+   <procedure xml:id="pro-ha-migration-sle11-test">
     <title>変換をテストする</title>
-    <step performance="required">
+    <step>
      <para>
       ノードの1つで、テストディレクトリを作成し、そのテストディレクトリにバックアップファイルをコピーします。
      </para>
@@ -240,7 +244,7 @@ $ cp /var/lib/heartbeat/hostcache /tmp/hb2openais-testdir
 $ cp /etc/logd.cf /tmp/hb2openais-testdir
 $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のコマンドで、テストランを開始します。
      </para>
@@ -250,7 +254,7 @@ $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
      </para>
 <screen>$ /usr/lib64/heartbeat/hb2openais.sh -T /tmp/hb2openais-testdir -U</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       結果として生成された<filename>openais.conf</filename>ファイルと<filename>cib-out.xml</filename>ファイルを読んで検証します。
      </para>
@@ -262,27 +266,27 @@ $ crm_verify -V -x cib-out.xml</screen>
    <para>
     変換段階の詳細については、インストールしたHigh Availability Extensionの<filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>を参照してください。
    </para>
-   <procedure id="pro-ha-migration-sle11-convert">
+   <procedure xml:id="pro-ha-migration-sle11-convert">
     <title>データの変換</title>
     <para>
      テストランを実行し、出力をチェックしたら、データ変換を開始できます。変換は、<emphasis>1つ</emphasis>のノードで実行するだけで済みます。メインクラスタ設定(CIB)が自動的にその他のノードにレプリケートされます。レプリケートの必要がある他のすべてのファイルは、変換スクリプトによって自動的にコピーされます。
     </para>
-    <step performance="required">
+    <step>
      <para>
       変換スクリプトで他のクラスタノードにファイルを正常にコピーするため、<systemitem class="username">root</systemitem>に許可されたアクセスで<systemitem class="daemon">sshd</systemitem>がすべてのノードで実行されていることを確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       すべてのOCFS2ファイルシステムがマウント解除されていることを確認します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       High Availability ExtensionにはデフォルトのOpenAIS設定ファイルが付属しています。以降の手順で、デフォルトの環境設定を上書きしたくない場合は、<filename>/etc/ais/openais.conf</filename>環境設定ファイルのコピーを作成します。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       変換スクリプトを<systemitem class="username">root</systemitem>として起動します。sudoを使用する場合は、<option>-u</option>オプションで特権ユーザを指定します。
      </para>
@@ -291,7 +295,7 @@ $ crm_verify -V -x cib-out.xml</screen>
       <filename>/etc/ha.d/ha.cf</filename>に保存されている環境設定に基づいて、スクリプトは、OpenAISクラスタスタック用の新しい環境設定ファイル<filename>/etc/ais/openais.conf</filename>を生成します。スクリプトは、CIBの設定を分析し、HeartbeatからOpenAISへの変更に伴いクラスタ設定の変更が必要かどうか通知してきます。すべてのファイル処理は、変換が実行されるノードで行われ、他のノードにレプリケートされます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       画面の指示に従います。
      </para>
@@ -304,16 +308,16 @@ $ crm_verify -V -x cib-out.xml</screen>
     アップグレードプロセスの完了後、SUSE Linux Enterprise Server 10に戻ることはできません。
    </para>
 
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-more">
+  <section xml:id="sec-ha-migration-sle11-more">
    <title>その他の情報</title>
    <para>
     変換スクリプトおよび変換の各段階の詳細については、インストールしたHigh Availability Extensionの<filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>を参照してください。
    </para>
-  </sect3>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp1">
   <title>SLE HA 11からSLE HA 11 SP1へのアップグレード</title>
 
    <note>
@@ -325,7 +329,7 @@ $ crm_verify -V -x cib-out.xml</screen>
 
 
 
-  <procedure id="pro-ha-migration-rolling-upgrade">
+  <procedure xml:id="pro-ha-migration-rolling-upgrade">
    <title>ローリングアップグレードを実行する</title>
 
     <warning>
@@ -335,36 +339,36 @@ $ crm_verify -V -x cib-out.xml</screen>
       ソフトウェアの更新中にノード上のクラスタリソースマネージャがアクティブな場合、アクティブノードのフェンシングのような予期しない結果を招く場合があります。
      </para>
     </warning>
-   <step performance="required">
+   <step>
     <para>
      アップグレードするノードで<systemitem class="username">root</systemitem>としてログインし、OpenAISを停止します。
     </para>
 <screen>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      システムバックアップが最新で、復元可能かどうか確認します。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-tolatest" performance="required">
+   <step xml:id="step-ha-migration-upgrade-tolatest">
     <para>
      SUSE Linux Enterprise Server 11からSUSE Linux Enterprise Server 11 SP1、および<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11から<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP1へのアップグレードを実行します。 お使いの製品のアップグレード方法の詳細については、『SUSE Linux Enterprise Server 11 SP1 Deployment Guide』の「<citetitle>Updating SUSE Linux Enterprise</citetitle>」の章を参照してください。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-ais" performance="required">
+   <step xml:id="step-ha-migration-upgrade-ais">
     <para>
      アップグレードしたノードでOpenAIS/Corosyncを再起動して、ノードをクラスタに再加入させます。
     </para>
 <screen>rcopenais start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次のノードをオフラインにし、そのノードに関して手順を繰り返します。
     </para>
    </step>
   </procedure>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp2">
   <title>SLE HA 11 SP1からSLE HA 11 SP2へのアップグレード</title>
 
   <para>
@@ -398,8 +402,8 @@ $ crm_verify -V -x cib-out.xml</screen>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP2に装備されている新機能は、<emphasis>すべての</emphasis>クラスタノードが最新の製品バージョンにアップグレードされた後でないと使用できません。SP1/SP2の混合クラスタは、ローリングアップグレード中の短いタイムフレームのみ、サポートされます。ローリングアップグレードは1週間以内に完了してください。
    </para>
   </important>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp3">
   <title>SLE HA 11 SP2からSLE HA 11 SP3へのアップグレード</title>
 
   <para>
@@ -416,9 +420,9 @@ $ crm_verify -V -x cib-out.xml</screen>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3に装備されている新機能は、<emphasis>すべての</emphasis>クラスタノードが最新の製品バージョンにアップグレードされた後でないと使用できません。SP2/SP3の混合クラスタは、ローリングアップグレード中の短いタイムフレームのみ、サポートされます。ローリングアップグレードは1週間以内に完了してください。
    </para>
   </important>
- </sect2>
+ </section>
   
-  <sect2 id="sec-ha-migration-sle11-sp4">
+  <section xml:id="sec-ha-migration-sle11-sp4">
    <title>SLE HA 11 SP3からSLE HA 11 SP4へのアップグレード</title>
    
    <para>
@@ -429,7 +433,7 @@ $ crm_verify -V -x cib-out.xml</screen>
     <xref linkend="pro-ha-migration-rolling-upgrade"/>で説明したように実行しますが、次の点が異なります。<xref linkend="step-ha-migration-upgrade-tolatest" xrefstyle="select:name"/>で、SUSE Linux Enterprise Server 11  SP3からSUSE Linux Enterprise Server 11 SP4、および<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3から<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4へのアップグレードを実行します。
    </para>
    
-   <note id="note-ha-cib-upgrade">
+   <note xml:id="note-ha-cib-upgrade">
     <title>CIB構文バージョンのアップグレード</title>
     <para>リソースをグループ化するタグと一部のACLの機能は、<literal>pacemaker-2.0</literal>以上のCIB構文バージョンでのみ動作します。(現在のバージョンを確認するには、<command>cibadmin -Q |grep validate-with</command>を実行します)。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3からアップグレードした場合、デフォルトではCIBバージョンがアップグレード<emphasis>されません</emphasis>。最新のCIBバージョンに手動でアップグレードするには、以下のコマンドのいずれかを使用します:</para>
     <screen><prompt role="root">root # </prompt>cibadmin --upgrade --force</screen>
@@ -443,10 +447,10 @@ $ crm_verify -V -x cib-out.xml</screen>
      <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4に装備されている新機能は、<emphasis>すべての</emphasis>クラスタノードが最新の製品バージョンにアップグレードされた後でないと使用できません。SP3/SP4の混合クラスタは、ローリングアップグレード中の短いタイムフレームのみ、サポートされます。ローリングアップグレードは1週間以内に完了してください。
     </para>
    </important>
-  </sect2>
+  </section>
   
- </sect1>
- <sect1 id="sec-ha-update">
+ </section>
+ <section xml:id="sec-ha-update">
   <title>クラスタノード上のソフトウェアパッケージの更新</title>
   
   <warning>
@@ -461,7 +465,7 @@ $ crm_verify -V -x cib-out.xml</screen>
    ノード上にパッケージ更新をインストールする前に、次の内容を確認してください。
   </para>
   
-  <itemizedlist id="il-ha-update-cond" mark="bullet" spacing="normal">
+  <itemizedlist xml:id="il-ha-update-cond" mark="bullet" spacing="normal">
    <title>クラスタスタックを停止する条件</title>
    <listitem>
     <para>
@@ -499,13 +503,13 @@ $ crm_verify -V -x cib-out.xml</screen>
   </para>
   
   <screen><prompt role="root">root # </prompt>rcopenais start</screen>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-more">
+ <section xml:id="sec-ha-migration-more">
   <title>その他の情報</title>
 
   <para>
-   アップグレード先の製品の変更点と新機能の詳細については、それぞれのリリースノートを参照してください。リリースノートは、<ulink url="https://www.suse.com/releasenotes/"/>で入手できます。
+   アップグレード先の製品の変更点と新機能の詳細については、それぞれのリリースノートを参照してください。リリースノートは、<link xlink:href="https://www.suse.com/releasenotes/"/>で入手できます。
   </para>
- </sect1>
+ </section>
 </appendix>

--- a/ja/xml/ha_naming.xml
+++ b/ja/xml/ha_naming.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_naming.xml" id="app-naming">
-  <title>命名規則</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_naming.xml" xml:id="app-naming"><title>命名規則</title><info/>
+  
   <para>このガイドでは、クラスタノードと名前、クラスタリソース、および制約に次の命名規則を使用します。
   </para>
   
-  <variablelist id="vl-naming-cluster-names-nodes">
+  <variablelist xml:id="vl-naming-cluster-names-nodes">
     
     <varlistentry>
       <term>クラスタノード</term>

--- a/ja/xml/ha_netbonding.xml
+++ b/ja/xml/ha_netbonding.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_netbonding.xml" id="cha-ha-netbonding">
- <title>ネットワークデバイスボンディング</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_netbonding.xml" xml:id="cha-ha-netbonding"><title>ネットワークデバイスボンディング</title><info/>
+ 
  <para>
   多くのシステムで、通常のEthernetデバイスの標準のデータセキュリティ/可用性の要件を超えるネットワーク接続の実装が望ましいことがあります。その場合、数台のEthernetデバイスを集めて1つのボンディングデバイスを設定できます。
  </para>
@@ -17,7 +21,7 @@ Please see LICENSE.txt for this document's license.
   OpenAISの使用時は、クラスタソフトウェアでボンディングデバイスが管理されることはありません。したがって、ボンディングデバイスにアクセスする可能性のあるクラスタノードごとに、ボンディングデバイスを設定する必要があります。
  </para>
 
- <sect1 id="sec-ha-netbond-yast">
+ <section xml:id="sec-ha-netbond-yast">
   <title>YaSTによるボンディングデバイスの設定</title>
 
   <para>
@@ -25,27 +29,27 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      <systemitem class="username">root</systemitem>としてYaSTを開始し、<menuchoice> <guimenu>ネットワークデバイス</guimenu><guimenu>ネットワーク設定</guimenu></menuchoice>の順に選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>ネットワーク設定</guimenu>で、<guimenu>概要</guimenu>タブに切り替えて、使用可能なデバイスを表示します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      1つのボンディングデバイスに集めるEthernetデバイスにIPアドレスが割り当てられているかどうかチェックします。割り当てられている場合は、それを変更します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選択するデバイスを選択して、<guimenu>編集</guimenu>をクリックします。
       </para>
      </step>
-     <step id="step-bond-slave" performance="required">
+     <step xml:id="step-bond-slave">
       <para>
        開いている<guimenu>ネットワークカードのセットアップ</guimenu>ダイアログの<guimenu>アドレス</guimenu>タブで、<guimenu>リンクとIPなしのセットアップ(ボンディングスレーブ)</guimenu>オプションを選択します。
       </para>
@@ -60,24 +64,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>次へ</guimenu>をクリックして、<guimenu>ネットワーク設定</guimenu>ダイアログの<guimenu>Overview</guimenu>タブに戻ります。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新しいボンディングデバイスを追加するには:
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <guimenu>追加</guimenu>をクリックして、<guimenu>デバイスの型</guimenu>を<guimenu>ボンド</guimenu>に変更します。<guimenu>次へ</guimenu>で続行します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        IPアドレスをボンディングデバイスに割り当てる方法を選択します。3つの方法から選択できます。
       </para>
@@ -102,12 +106,12 @@ Please see LICENSE.txt for this document's license.
        ご使用の環境に適合する方法を使用します。OpenAISで仮想IPアドレスを管理する場合は、<guimenu>静的割り当てIPアドレス</guimenu>を選択し、インタフェースにIPアドレスを割り当てます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ボンドスレーブ</guimenu>タブに切り替えます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="step-bond-slave" xrefstyle="select:label       nopage"/>でボンディングスレーブとして設定したEthernetデバイスが表示されます。ボンドに含めるEthernetデバイスを選択するため、<guimenu>ボンドスレーブ</guimenu>の該当するオプションのチェックボックスをオンにします。
       </para>
@@ -122,7 +126,7 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ボンドドライバオプション</guimenu>を編集します。次のモードを使用できます。
       </para>
@@ -192,22 +196,22 @@ Please see LICENSE.txt for this document's license.
        </varlistentry>
       </variablelist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ボンドドライバオプション</guimenu>には、パラメータ<literal>miimon=100</literal>を必ず追加します。このパラメータがなければ、リンクが定期的にチェックされないため、ボンディングドライバは、障害リンクで引き続きパケットを失う可能性があります。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>次へ</guimenu>をクリックして、<guimenu>OK</guimenu>でYaSTを終了し、ボンディングデバイスの設定を完了します。YaSTが<filename>/etc/sysconfig/network/ifcfg-bond<replaceable>DEVICENUMBER</replaceable></filename>に設定を書き込みます。
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-netbond-hotpug-yast">
+ <section xml:id="sec-ha-netbond-hotpug-yast">
   <title>ボンディングスレーブのホットプラグ</title>
 
   <para>
@@ -220,12 +224,12 @@ Please see LICENSE.txt for this document's license.
    <para>
     手動の設定を行う場合は、『SUSE Linux Enterprise Server 11 Administration Guide』の「<citetitle>Basic Networking</citetitle>」の章の「<citetitle>Hotplugging of Bonding Slaves</citetitle>」というセクションを参照してください。
    </para>
-   <step performance="required">
+   <step>
     <para>
      <systemitem class="username">root</systemitem>としてYaSTを開始し、<menuchoice> <guimenu>ネットワークデバイス</guimenu><guimenu>ネットワーク設定</guimenu></menuchoice>の順に選択します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>ネットワーク設定</guimenu>で、<guimenu>Overview</guimenu>タブに切り替えて、すでに設定済みのデバイスを表示します。ボンディングスレーブがすでに設定済みの場合、<guimenu>メモ</guimenu>列にそのことが示されます。
     </para>
@@ -240,39 +244,39 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      1つのボンディングデバイスに集められたEthernetデバイスのそれぞれに対して、次の手順を実行します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選択するデバイスを選択して、<guimenu>編集</guimenu>をクリックします。<guimenu>Network Card Setup</guimenu>ダイアログが開きます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>一般</guimenu>タブに切り替えて、<guimenu>デバイスのアクティブ化</guimenu>が［<literal>ホットプラグ</literal>］に設定されていることを確認します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>ハードウェア</guimenu>タブに切り替えます。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>Udevルール</guimenu>で、<guimenu>変更</guimenu>をクリックして<guimenu>BusID</guimenu>オプションを選択します。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <guimenu>OK</guimenu>および<guimenu>次へ</guimenu>をクリックして、<guimenu>ネットワーク設定</guimenu>ダイアログの<guimenu>Overview</guimenu>タブに戻ります。この時点でEthernetデバイスエントリをクリックすると、下のペインにバスIDを含むデバイスの詳細が表示されます。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>OK</guimenu>をクリックして変更を確定し、ネットワーク設定を終了します。
     </para>
@@ -282,8 +286,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    ブート時に<filename>/etc/init.d/network</filename>はホットプラグスレーブを待機しませんが、ボンドの準備が整うのを待機します。これには少なくとも1つのスレーブが利用可能であることが必要です。スレーブインタフェースの1つがシステムから削除されると(NICドライバからアンバインド、NICドライバの<command>rmmod</command>、または実際のPCIホットプラグ取り外し)、カーネルによってボンドから自動的に削除されます。システムに新しいカードが追加されると(スロットのハードウェアが置換されると)、<systemitem>udev</systemitem>は、バスベースの永続名規則を適用することで名前を変更し、<command>ifup</command>を呼び出します。<command>ifup</command>呼び出しによって、ボンドに自動的に追加されます。
   </para>
- </sect1>
- <sect1 id="sec-ha-netbonding-more">
+ </section>
+ <section xml:id="sec-ha-netbonding-more">
   <title>その他の情報</title>
 
   <para>
@@ -292,5 +296,5 @@ Please see LICENSE.txt for this document's license.
   <para>High Availabilityセットアップの場合は、そのファイルで説明されている<option>miimon</option>および<option>use_carrier</option>オプションが特に重要です。</para>
 
 
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_news.xml
+++ b/ja/xml/ha_news.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_news.xml" id="cha-ha-changes">
- <title>新機能</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_news.xml" xml:id="cha-ha-changes"><title>新機能</title><info/>
+ 
  <para>
   以降のセクションでは、バージョン移行に伴う重要なソフトウェア変更の概要を示します。この概要では、たとえば、基本設定の完全な再設定が行われたか、設定ファイルが他の場所へ移動されたか、または他の顕著な変更が行われたかどうかを示しています。
  </para>
  <para>
-  詳細と最新情報については、それぞれのプロダクトバージョンのリリースノートを参照してください。これらは、<filename>/usr/share/doc/release-notes</filename>にあるインストール済みシステム、またはオンライン(<ulink url="https://www.suse.com/releasenotes/"/>)で入手できます。
+  詳細と最新情報については、それぞれのプロダクトバージョンのリリースノートを参照してください。これらは、<filename>/usr/share/doc/release-notes</filename>にあるインストール済みシステム、またはオンライン(<link xlink:href="https://www.suse.com/releasenotes/"/>)で入手できます。
  </para>
- <sect1 id="sec-ha-changes-sle11">
+ <section xml:id="sec-ha-changes-sle11">
   <title>バージョン10 SP3からバージョン11への変更点</title>
 
   <para>
@@ -24,10 +28,10 @@ Please see LICENSE.txt for this document's license.
    SUSE® Linux Enterprise Server 10 SP3からSUSE Linux Enterprise Server 11へのHigh Availabilityコンポーネントの変更内容の詳細については、以降のセクションを参照してください。
   </para>
 
-  <sect2 id="sec-ha-changes-sle11-new">
+  <section xml:id="sec-ha-changes-sle11-new">
    <title>新しく追加された機能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-fail">
+    <varlistentry xml:id="vle-ha-news-fail">
      <term>マイグレーションのしきい値と失敗タイムアウト</term>
      <listitem>
       <para>
@@ -35,7 +39,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-news-defaults">
+    <varlistentry xml:id="vle-ha-news-defaults">
      <term>リソースと操作のデフォルト</term>
      <listitem>
       <para>
@@ -92,12 +96,12 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-changed">
+  <section xml:id="sec-ha-changes-sle11-changed">
    <title>変更された機能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-options">
+    <varlistentry xml:id="vle-ha-news-options">
      <term>リソースとクラスタオプションに関する命名規則</term>
      <listitem>
       <para>
@@ -203,9 +207,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-removed">
+  <section xml:id="sec-ha-changes-sle11-removed">
    <title>削除された機能</title>
    <variablelist>
     <varlistentry>
@@ -225,9 +229,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp1">
   <title>バージョン11からバージョン11 SP1への変更点</title>
 
   <variablelist>
@@ -337,8 +341,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp2">
   <title>バージョン11 SP1からバージョン11 SP2への変更点</title>
 
   <variablelist>
@@ -459,8 +463,8 @@ Please see LICENSE.txt for this document's license.
 
 
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp3">
   <title>バージョン11 SP2からバージョン11 SP3への変更点</title>
 
   <variablelist>
@@ -579,8 +583,8 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
   
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp4">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp4">
   <title>バージョン11 SP3からバージョン11 SP4への変更点</title>
   <variablelist>
    <varlistentry>
@@ -597,7 +601,7 @@ Please see LICENSE.txt for this document's license.
        <para>エージェントリストを記述した「<citetitle>HA OCFエージェント</citetitle>」の章を削除しました。この削除に伴い、「<citetitle>トラブルシューティングとリファレンス</citetitle>」の部分も削除し、<xref linkend="app-ha-troubleshooting" xrefstyle="select:title"/>の章を付録に移動しました。</para>
       </listitem>
       <listitem>
-       <para>Geo Clustering for SUSE Linux Enterprise High Availability Extensionのマニュアルを別のドキュメントに移動しました(Fate#316120)。地理的に離れたクラスタの使用方法および設定方法の詳細については、『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』を参照してください。<ulink url="http://www.suse.com/documentation/"/>または<filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename>の下にあるインストール済みシステムから入手できます。</para>
+       <para>Geo Clustering for SUSE Linux Enterprise High Availability Extensionのマニュアルを別のドキュメントに移動しました(Fate#316120)。地理的に離れたクラスタの使用方法および設定方法の詳細については、『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>または<filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename>の下にあるインストール済みシステムから入手できます。</para>
       </listitem>
       <listitem>
        <para><literal>master-slave</literal>リソースの用語を変更しました。現在はアップストリームマニュアルで<literal>multi-state</literal>リソースと呼ばれています。</para>
@@ -688,7 +692,7 @@ Please see LICENSE.txt for this document's license.
        <para><xref linkend="cha-ha-config-basics"/>で説明されている新機能を反映させるため、章を更新しました。</para>
       </listitem>
       <listitem>
-       <para>Geoクラスタに関連するすべてのHawk機能の説明を別のドキュメントに移動しました。新しい『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』<citetitle/>(<ulink url="http://www.suse.com/documentation/"/>から入手可能)を参照してください。</para>
+       <para>Geoクラスタに関連するすべてのHawk機能の説明を別のドキュメントに移動しました。新しい『Geo Clustering for SUSE Linux Enterprise High Availability Extensionクイックスタート』<citetitle/>(<link xlink:href="http://www.suse.com/documentation/"/>から入手可能)を参照してください。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -737,7 +741,7 @@ Please see LICENSE.txt for this document's license.
       </listitem>
       <listitem>
        <para>CIB検証バージョンのアップグレード後に使用可能になる新しいACL機能に従って章を更新しました。詳細については、<xref linkend="note-ha-cib-upgrade"/>を参照してください。</para>
-       <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3からアップグレードする一方で、それまで使用してきたCIBバージョンを保持している場合は、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』の「<citetitle>アクセス制御リスト</citetitle>」の章を参照してください。<ulink url="http://www.suse.com/documentation/"/>から入手できます。</para>
+       <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3からアップグレードする一方で、それまで使用してきたCIBバージョンを保持している場合は、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』の「<citetitle>アクセス制御リスト</citetitle>」の章を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -748,16 +752,16 @@ Please see LICENSE.txt for this document's license.
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>: ウォッチドッグおよびウォッチドッグタイマにアクセスする他のソフトウェアに関するメモを追加しました(<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>: ウォッチドッグおよびウォッチドッグタイマにアクセスする他のソフトウェアに関するメモを追加しました(<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>: ブート時にウォッチドッグドライバをロードする方法を追加しました(<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>: ブート時にウォッチドッグドライバをロードする方法を追加しました(<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-fencing"/>: <literal>msgwait</literal>タイムアウト(<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)に関連した<literal>stonith-timeout</literal>の長さに関するアドバイスを追加しました。 </para>
+       <para><xref linkend="pro-ha-storage-protect-fencing"/>: <literal>msgwait</literal>タイムアウト(<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)に関連した<literal>stonith-timeout</literal>の長さに関するアドバイスを追加しました。 </para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-sbd-daemon"/>を調整しました(<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-sbd-daemon"/>を調整しました(<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
       </listitem>
       <listitem>
        <para><literal>no-quorum-policy=ignore</literal>によってクラスタに発生するダブルフェンシングを、STONITHリソース設定に<literal>pcmk_delay_max</literal>パラメータを使用することで回避する方法について説明しています(Fate#31713)。</para>
@@ -770,7 +774,7 @@ Please see LICENSE.txt for this document's license.
     <term><xref linkend="cha-ha-rear"/></term>
     <listitem>
      <para>この章は全面的に改訂され、Rearバージョン<literal>1.16</literal>に更新されました。</para>
-     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4には、RPMパッケージ<systemitem class="resource">rear</systemitem>に付属するバージョン<literal>1.10.0</literal>およびRPMパッケージ<systemitem class="resource">rear116</systemitem>に付属するバージョン<literal>1.16</literal>の2つのバージョンのRearが付属しています。Rearバージョン<literal>1.10.0</literal>のマニュアルについては、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』を参照してください。<ulink url="http://www.suse.com/documentation/"/>から入手できます。</para>
+     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4には、RPMパッケージ<systemitem class="resource">rear</systemitem>に付属するバージョン<literal>1.10.0</literal>およびRPMパッケージ<systemitem class="resource">rear116</systemitem>に付属するバージョン<literal>1.16</literal>の2つのバージョンのRearが付属しています。Rearバージョン<literal>1.10.0</literal>のマニュアルについては、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。</para>
     </listitem>
    </varlistentry>
    
@@ -831,5 +835,5 @@ Please see LICENSE.txt for this document's license.
    
    
 
- </sect1>
+ </section>
 </appendix>

--- a/ja/xml/ha_nfs_quick_config_i.xml
+++ b/ja/xml/ha_nfs_quick_config_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_config_i.xml" id="sec-ha-quick-nfs-initial">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_config_i.xml" xml:id="sec-ha-quick-nfs-initial">
  <title>Initial Configuration</title>
 
  <para>
@@ -18,7 +19,7 @@ Please see LICENSE.txt for this document's license.
   3 or 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-initial-drbd-resource">
+ <section xml:id="sec-ha-quick-nfs-initial-drbd-resource">
   <title>Configuring a DRBD Resource</title>
   <para>
    First, it is necessary to configure a DRBD resource to hold your data.
@@ -56,9 +57,9 @@ Please see LICENSE.txt for this document's license.
    Csync2, refer to <xref linkend="sec-ha-installation-setup-csync2"/>.
   </para>
   
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-initial-lvm-config">
+ <section xml:id="sec-ha-quick-nfs-initial-lvm-config">
   <title>Configuring LVM</title>
   <para>
    To use LVM with DRBD, it is necessary to change some options in the LVM
@@ -162,9 +163,9 @@ mkfs -t ext3 /dev/nfs/sales
 mkfs -t ext3 /dev/nfs/engineering</screen>
    </listitem>
   </orderedlist>
- </sect2>
+ </section>
 
- <sect2 os="sles" id="sec-ha-quick-nfs-initial-setup">
+ <section os="sles" xml:id="sec-ha-quick-nfs-initial-setup">
   <title>Initial Cluster Setup</title>
   <para>
    Use the YaST cluster module for the initial cluster setup. The process
@@ -192,11 +193,11 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
    Then start the OpenAIS/Corosync service as described in
    <xref linkend="sec-ha-installation-start"/>.
   </para>
- </sect2>
+ </section>
 
  
 
- <sect2 id="sec-ha-quick-nfs-initial-pacemaker">
+ <section xml:id="sec-ha-quick-nfs-initial-pacemaker">
   <title>Creating a Basic Pacemaker Configuration</title>
   <para>
    Configure a STONITH device as described in
@@ -236,5 +237,5 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
 crm(live)configure# property no-quorum-policy="ignore"
 crm(live)configure# rsc_defaults resource-stickiness="200"
 crm(live)configure# commit</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_nfs_quick_failover_i.xml
+++ b/ja/xml/ha_nfs_quick_failover_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_failover_i.xml" id="sec-ha-quick-nfs-failover">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_failover_i.xml" xml:id="sec-ha-quick-nfs-failover">
  <title>Ensuring Smooth Cluster Failover</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   failover.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time">
   <title>NFSv4 Lease Time</title>
   <para>
    For exports used by NFSv4 clients, the NFS server hands out
@@ -43,9 +44,9 @@ Please see LICENSE.txt for this document's license.
    may cause a prolonged period of NFS lock-up that clients experience
    during an NFS service transition on the cluster.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time-change">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time-change">
   <title>Modifying NFSv4 Lease Time</title>
   <para>
    To allow for faster failover, you may decrease the grace period.
@@ -65,5 +66,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>NFSD_V4_GRACE=10</screen>
   <para>Restart the NFS services.</para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_nfs_quick_install_i.xml
+++ b/ja/xml/ha_nfs_quick_install_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_install_i.xml" id="sec-ha-quick-nfs-prereq">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_install_i.xml" xml:id="sec-ha-quick-nfs-prereq">
  <title>Prerequisites and Installation</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   sure that the following prerequisites are fulfilled.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-prereq-pkg">
+ <section xml:id="sec-ha-quick-nfs-prereq-pkg">
   <title>Software Requirements</title>
   <itemizedlist os="sles" mark="bullet" spacing="normal">
    <listitem>
@@ -112,9 +113,9 @@ Please see LICENSE.txt for this document's license.
    </para>
    
   </note>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-prereq-services">
+ <section xml:id="sec-ha-quick-nfs-prereq-services">
   <title>Services at Boot Time</title>
   <para os="sles">
    After you have installed the required packages, take care of a few
@@ -142,5 +143,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_nfs_quick_intro_i.xml
+++ b/ja/xml/ha_nfs_quick_intro_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_intro_i.xml" id="sec-ha-quick-nfs-intro">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_intro_i.xml" xml:id="sec-ha-quick-nfs-intro">
  <title>Introduction</title>
 
  <para>
@@ -18,4 +19,4 @@ Please see LICENSE.txt for this document's license.
   enterprise: NFSv3 and NFSv4. The solution described in this document is
   applicable to NFS clients using either version.
  </para>
-</sect1>
+</section>

--- a/ja/xml/ha_nfs_quick_rsc_i.xml
+++ b/ja/xml/ha_nfs_quick_rsc_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_rsc_i.xml" id="sec-ha-quick-nfs-resources">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_rsc_i.xml" xml:id="sec-ha-quick-nfs-resources">
  <title>Cluster Resources for a A Highly Available NFS Service</title>
 
  <para>
@@ -110,7 +111,7 @@ Please see LICENSE.txt for this document's license.
   </para>
  </example>
 
- <sect2 id="sec-ha-quick-nfs-resources-drbd">
+ <section xml:id="sec-ha-quick-nfs-resources-drbd">
   <title>DRBD Master/Slave Resource</title>
   <para>
    To configure this resource, issue the following commands from the
@@ -136,9 +137,9 @@ crm(live)configure# commit</screen>
    Check this with the <command>crm_mon</command> command, or by looking at
    the contents of <filename>/proc/drbd</filename>.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsserver">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsserver">
   <title>NFS Kernel Server Resource</title>
   <para>
    In the <literal>crm</literal> shell, the resource for the NFS server
@@ -166,9 +167,9 @@ crm(live)configure# commit</screen>
    After you have committed this configuration, Pacemaker should start the
    NFS Kernel server processes on both nodes.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-lvm">
+ <section xml:id="sec-ha-quick-nfs-resources-lvm">
   <title>LVM and File System Resources</title>
   <orderedlist spacing="normal">
    <listitem>
@@ -241,9 +242,9 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsexport">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsexport">
   <title>NFS Export Resources</title>
   <para>
    Once your DRBD, LVM, and file system resources are working properly,
@@ -251,7 +252,7 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
    available NFS export resources, use the <literal>exportfs</literal>
    resource type.
   </para>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
    <title>NFSv4 Virtual File System Root</title>
    <para>
     If clients exclusively use NFSv3 to connect to the server, you do not
@@ -305,8 +306,8 @@ crm(live)configure# commit</screen>
      </para>
     </listitem>
    </orderedlist>
-  </sect3>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
+  </section>
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
    <title>Non-root NFS Exports</title>
    <para>
     All NFS exports that do <emphasis>not</emphasis> represent an NFSv4
@@ -368,10 +369,10 @@ crm(live)configure# primitive p_exportfs_engineering \
      <screen>exportfs -v</screen>
     </listitem>
    </orderedlist>
-  </sect3>
- </sect2>
+  </section>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-ipaddr">
+ <section xml:id="sec-ha-quick-nfs-resources-ipaddr">
   <title>Resource for Floating IP Address</title>
   <para>
    To enable smooth and seamless failover, your NFS clients will be
@@ -435,5 +436,5 @@ crm(live)configure# primitive p_exportfs_engineering \
     will suffer service interruptions on cluster failover.
    </para>
   </note>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_nfs_quick_use_i.xml
+++ b/ja/xml/ha_nfs_quick_use_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_use_i.xml" id="sec-ha-quick-nfs-use">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_use_i.xml" xml:id="sec-ha-quick-nfs-use">
  <title>Using the NFS Service</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   NFS client. It covers NFS clients using NFS versions 3 and 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv3">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv3">
   <title>Connecting with NFS Version 3</title>
   <para>
    To connect to the highly available NFS service with an NFS version 3
@@ -42,9 +43,9 @@ Please see LICENSE.txt for this document's license.
    For further NFSv3 mount options, consult the <command>nfs</command> man
    page.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv4">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv4">
   <title>Connecting with NFS Version 4</title>
   <important>
    <para>
@@ -72,5 +73,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>mount -t nfs4 -o rsize=32768,wsize=32768 \
   10.9.9.180:/engineering /home/engineering</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/ja/xml/ha_ocfs2.xml
+++ b/ja/xml/ha_ocfs2.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_ocfs2.xml" id="cha-ha-ocfs2">
- <title>OCFS2</title><indexterm class="startofrange" id="idx-filesystems-ocfs2"> <primary>ファイルシステム</primary> <secondary>OCFS2</secondary> </indexterm>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_ocfs2.xml" xml:id="cha-ha-ocfs2"><title>OCFS2</title><info><abstract>
   <para>
    OCFS 2 (Oracle Cluster File System 2)は、Linux 2.6以降のカーネルに完全に統合されている汎用ジャーナリングファイルシステムです。Oracle Cluster File System 2を利用すれば、アプリケーションバイナリファイル、データファイル、およびデータベースを、共有ストレージ中のデバイスに保管することができます。このファイルシステムには、クラスタ中のすべてのノードが同時に読み書きすることができます。ユーザスペース管理デーモンは、クローンリソースを介して管理され、HAスタック(特に、OpenAIS/CorosyncおよびDLM (Distributed Lock Manager))との統合を実現します。
   </para>
- </abstract>
- <sect1 id="sec-ha-ocfs2-features">
+ </abstract></info>
+ <indexterm class="startofrange" xml:id="idx-filesystems-ocfs2"> <primary>ファイルシステム</primary> <secondary>OCFS2</secondary> </indexterm>
+ 
+ <section xml:id="sec-ha-ocfs2-features">
   <title>特長と利点</title>
 
   <para>
@@ -104,8 +108,8 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-ocfs2-utils">
+ </section>
+ <section xml:id="sec-ha-ocfs2-utils">
   <title>OCFS2のパッケージと管理ユーティリティ</title>
 
   <para>
@@ -197,8 +201,8 @@ Please see LICENSE.txt for this document's license.
     </tbody>
    </tgroup>
   </table>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create-service">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create-service">
   <title>OCFS2サービスとSTONITHリソースの設定</title>
 
 
@@ -218,7 +222,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ocfs2-resources">
+  <procedure xml:id="pro-ocfs2-resources">
    <title>DLMリソースおよびO2CBリソースの設定</title>
    <para>
     設定は複数のプリミティブおよび1つのベースクローンを含むベースグループで設定されます。ベースグループとベースクローンはどちらも後でさまざまなシナリオで使用できます(例: OCFS2およびcLVM)。必要に応じてそれぞれのプリミティブを持つベースグループを拡張する必要があるだけです。ベースグループは内部コロケーションおよび順序付けを持つため、個々のグループ、クローン、その依存性をいくつも指定する必要がなく、セットアップ全体を容易にします。
@@ -226,17 +230,17 @@ Please see LICENSE.txt for this document's license.
    <para>
     クラスタ内の1つのノードについて、次の手順を実行してください。
    </para>
-   <step performance="required">
+   <step>
     <para>
      シェルを起動し、<systemitem class="username">root</systemitem>または同等のものとしてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     <command>crm <option>configure</option></command>を実行します。
+     <command>crm</command> <option>configure</option>を実行します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次を入力して、DLMおよびO2CBのプリミティブリソースを作成します。
     </para>
@@ -250,7 +254,7 @@ Please see LICENSE.txt for this document's license.
      <literal>dlm</literal>クローンリソースが、分散ロックマネージャサービスを制御し、クラスタ内のすべてのノード上でこのサービスが開始するようにします。ベースグループの内部コロケーションおよび順序付けによって、<literal>o2cb</literal>サービスは、すでに実行している<literal>dlm</literal>サービスのコピーを持つノード上でのみ開始されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      次を入力してベースグループおよびベースクローンを作成します。
 
@@ -259,19 +263,19 @@ Please see LICENSE.txt for this document's license.
 <command>clone</command> base-clone base-group \
       meta interleave="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>show</command>で変更内容をレビューします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      すべて正しければ、<command>commit</command>で変更を送信し、<command>exit</command>でcrmライブ設定を終了します。
     </para>
    </step>
   </procedure>
 
-  <procedure id="pro-ocfs2-stonith">
+  <procedure xml:id="pro-ocfs2-stonith">
    <title>STONITHリソースの設定</title>
    <note>
     <title>必要なSTONITHデバイス</title>
@@ -279,22 +283,22 @@ Please see LICENSE.txt for this document's license.
      フェンシングデバイスを設定する必要があります。STONITHなしでは、設定内に配置されたメカニズム(<literal>external/sbd</literal>など)は失敗します。
     </para>
    </note>
-   <step performance="required">
+   <step>
     <para>
      シェルを起動し、<systemitem class="username">root</systemitem>または同等のものとしてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-storage-protect-sbd-create"/>で説明されるとおり、SBDパーティションを作成します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     <command>crm <option>configure</option></command>を実行します。
+     <command>crm</command> <option>configure</option>を実行します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <literal>external/sdb</literal>をフェンシングデバイスとして設定し、<literal>/dev/sdb2</literal>を共有ストレージ上のハートビートとフェンシング専用のパーティションにします。
     </para>
@@ -302,19 +306,19 @@ Please see LICENSE.txt for this document's license.
       params pcmk_delay_max="15" \
       op monitor interval="15" timeout="15"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>show</command>で変更内容をレビューします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      すべて正しければ、<command>commit</command>で変更を送信し、<command>exit</command>でcrmライブ設定を終了します。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create">
   <title>OCFS2ボリュームの作成</title>
 
   <para>
@@ -336,7 +340,7 @@ Please see LICENSE.txt for this document's license.
    次に、<xref linkend="pro-ocfs2-volume"/>で説明されているように、<command>mkfs.ocfs2</command>で、OCFS2ボリュームを作成し、フォーマットします。そのコマンドの重要なパラメータは、<xref linkend="tab-ha-ofcs2-mkfs-ocfs2-params"/>に一覧されています。詳細情報とコマンド構文については、<command>mkfs.ocfs2</command>のマニュアルページを参照してください。
   </para>
 
-  <table id="tab-ha-ofcs2-mkfs-ocfs2-params">
+  <table xml:id="tab-ha-ofcs2-mkfs-ocfs2-params">
    <title>重要なOCFS2パラメータ </title>
    <tgroup cols="2">
     <thead>
@@ -449,22 +453,22 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <procedure id="pro-ocfs2-volume">
+  <procedure xml:id="pro-ocfs2-volume">
    <title>OCFS2ボリュームを作成し、フォーマットする</title>
    <para>
     クラスタノードの<emphasis>1つ</emphasis>だけで、次の手順を実行します。
    </para>
-   <step performance="required">
+   <step>
     <para>
      端末ウィンドウを開いて、<systemitem class="username">root</systemitem>としてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタがオンラインであることをコマンド<command>crm status</command>で確認します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>mkfs.ocfs2</command>ユーティリティを使用して、ボリュームを作成およびフォーマットします。このコマンドの指定形式については、<command>mkfs.ocfs2</command>マニュアルページを参照してください。
     </para>
@@ -475,27 +479,27 @@ Please see LICENSE.txt for this document's license.
 
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-mount">
+ </section>
+ <section xml:id="sec-ha-ocfs2-mount">
   <title>OCFS2ボリュームのマウント</title>
 
   <para>
    OCFS2ボリュームは、手動でマウントするか、クラスタマネージャでマウントできます(<xref linkend="pro-ocfs2-mount-cluster"/>参照)。
   </para>
 
-  <procedure id="pro-ocfs2-mount-manual">
+  <procedure xml:id="pro-ocfs2-mount-manual">
    <title>OCFS2ボリュームを手動でマウントする</title>
-   <step performance="required">
+   <step>
     <para>
      端末ウィンドウを開いて、<systemitem class="username">root</systemitem>としてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタがオンラインであることをコマンド<command>crm status</command>で確認します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      コマンドラインから、<command>mount</command>コマンドを使ってボリュームをマウントします。
     </para>
@@ -509,22 +513,22 @@ Please see LICENSE.txt for this document's license.
    </para>
   </warning>
 
-  <procedure id="pro-ocfs2-mount-cluster">
+  <procedure xml:id="pro-ocfs2-mount-cluster">
    <title>クラスタマネージャでOCFS2ボリュームをマウントする</title>
    <para>
     High AvailabilityソフトウェアでOCFS2ボリュームをマウントするには、クラスタ内でocf File Systemリソースを設定します。次の手順では、<command>crm</command>シェルを使用してクラスタリソースを設定します。リソースの設定には、Pacemaker GUIを使用することもできます。
    </para>
-   <step performance="required">
+   <step>
     <para>
      シェルを起動し、<systemitem class="username">root</systemitem>または同等のものとしてログインします。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     <command>crm <option>configure</option></command>を実行します。
+     <command>crm</command> <option>configure</option>を実行します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      OCFS2ファイルシステムをクラスタ内のすべてのノードにマウントするように、Pacemakerを設定します。
     </para>
@@ -532,19 +536,19 @@ Please see LICENSE.txt for this document's license.
       params device="/dev/sdb1" directory="/mnt/shared" fstype="ocfs2" options="acl" \
       op monitor interval="20" timeout="40"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ocfs2-resources"/>で設定したベースグループにファイルシステムのプリミティブを追加します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        入力
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt>edit base-group</screen>
      </step>
 
-     <step performance="required">
+     <step>
       <para>
        Viエディタが開いたら、そこに次のようにグループを変更し、変更を保存します。
       </para>
@@ -556,19 +560,19 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      <command>show</command>で変更内容をレビューします。必要なリソースをすべて設定したことを確認するには、<xref linkend="cha-ha-config-example"/>も参照してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      すべて正しければ、<command>commit</command>で変更を送信し、<command>exit</command>でcrmライブ設定を終了します。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-quota">
+ </section>
+ <section xml:id="sec-ha-ocfs2-quota">
   <title>OCFS2ファイルシステム上でクォータを使用する</title>
 
 
@@ -592,8 +596,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    パフォーマンス上の理由で、各クラスタノードはクォータの計算をローカルに行い、この情報を、10秒ごとに共通の中央ストレージに同期するようになっています。この間隔は、<command>tunefs.ocfs2</command>と、<option>usrquota-sync-interval</option>および<option>grpquota-sync-interval</option>オプションで調整することができます。クォータ情報は必ずしも常に正確というわけではないので、複数のクラスタノードを並列に運用している場合、ユーザまたはグループがクォータ制限をいくらか超えることもあります。
   </para>
- </sect1>
- <sect1 id="sec-ha-ocfs2-more">
+ </section>
+ <section xml:id="sec-ha-ocfs2-more">
   <title>詳細情報</title>
 
   <para>
@@ -602,7 +606,7 @@ Please see LICENSE.txt for this document's license.
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </term>
     <listitem>
      <para>
@@ -611,7 +615,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/documentation"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/documentation"/>
     </term>
     <listitem>
      <para>
@@ -620,5 +624,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist><indexterm class="endofrange" startref="idx-filesystems-ocfs2"/>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_rear.xml
+++ b/ja/xml/ha_rear.xml
@@ -1,26 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_rear.xml" id="cha-ha-rear">
- <title>Rearによる障害復旧</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_rear.xml" xml:id="cha-ha-rear"><title>Rearによる障害復旧</title><info><abstract>
   <para> Relax-and-Recover (旧称<quote>ReaR</quote>。この章ではRearと略記)は、システム管理者による使用を意図した障害復旧フレームワークです。Rearは、障害発生時に保護対象となる特定の運用環境に合わせて調整する必要があるBashスクリプトのコレクションです。</para>
   <para>特別な設定を必要とせずにそのまま使用できる障害復旧ソリューションはありません。したがって、障害が発生する<emphasis>前に</emphasis>準備しておくことが不可欠です。 </para>
   
- </abstract>
+ </abstract></info>
  
-  <sect1 id="sec-ha-rear-concept">
+ 
+ 
+  <section xml:id="sec-ha-rear-concept">
   <title>概念の概要</title>
   
  
   <para>以降のセクションでは、障害復旧の一般的な概念を述べ、Rearを使用した復旧を実現するために必要となる基本的な手順について説明します。また、Rearの要件に関するいくつかの指針、現在の製品に付属しているRearのバージョン、知っておくべき制限事項、およびシナリオとバックアップツールについても紹介します。</para>
    
    
-   <sect2 id="sec-ha-rear-concept-drp">
+   <section xml:id="sec-ha-rear-concept-drp">
     <title>障害復旧プランの作成</title>
     
     <para>
@@ -59,21 +63,21 @@ Please see LICENSE.txt for this document's license.
       </formalpara>
      </listitem>
     </itemizedlist>
-   </sect2>
+   </section>
   
-  <sect2 id="sec-ha-rear-concept-recovery">
+  <section xml:id="sec-ha-rear-concept-recovery">
    <title>障害復旧とは</title>
    <para>運用環境に存在するシステムが、ハードウェアの損傷、誤設定、ソフトウェア上の問題など、原因がどのようなものであっても破損した場合は、システムを再作成する必要があります。再作成は、同じハードウェア上または互換性のある代替ハードウェア上で実行できます。単にバックアップからファイルを復元するだけでは、システムを再作成することにはなりません。システムの再作成では、ファイルシステム、パーティション、マウントポイントの面からのシステムのストレージ作成や、ブートローダの再インストールなどの作業も必要になります。</para>
-  </sect2>
+  </section>
    
-  <sect2 id="sec-ha-rear-concept-basics">
+  <section xml:id="sec-ha-rear-concept-basics">
    <title>Rearによる障害復旧</title>
    <para>システムが正常に稼働しているときに、ファイルのバックアップを作成し、復旧メディア上に復旧システムを作成します。復旧システムには、復旧インストーラが収められています。</para>
    <para>システムが破損した場合は、損傷したハードウェアを必要に応じて交換し、復旧メディアから復旧システムをブートして復旧インストーラを起動します。復旧インストーラによるシステムの再作成では、まず、ストレージにパーティション、ファイルシステム、マウントポイントを作成し、続いてバックアップからファイルを復元します。最後に、ブートローダを再インストールします。 </para>
-  </sect2>
+  </section>
    
    
-  <sect2 id="sec-ha-rear-concept-requirements">
+  <section xml:id="sec-ha-rear-concept-requirements">
    <title>Rearの要件</title>
    <para>
     Rearを使用するには、運用環境を実行するマシンおよびそれと同一のテストマシンが必要です。つまり、同一のシステムが2台以上必要になります。ここでいう<quote>同一</quote>とは、たとえば、ネットワークカードを、同じカーネルドライバを使用する他のネットワークカードに置き換えることができるということです。 </para>
@@ -81,14 +85,14 @@ Please see LICENSE.txt for this document's license.
     <title>同一のドライバが必要</title>
     <para>運用環境のドライバと同じドライバを使用していないハードウェアコンポーネントは、Rearでは同一のコンポーネントとは見なされません。</para>
    </warning>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-versions">
+  <section xml:id="sec-ha-rear-concept-versions">
    <title>Rearのバージョン</title>
    <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4には、以下に挙げる2つのバージョンのReaが付属しています。</para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
-     <para>RPMパッケージ: <systemitem class="resource">rear</systemitem>に付属するRearバージョン<literal>1.10.0</literal>。このRearバージョンのマニュアルについては、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』を参照してください。<ulink url="http://www.suse.com/documentation/"/>から入手できます。</para>
+     <para>RPMパッケージ: <systemitem class="resource">rear</systemitem>に付属するRearバージョン<literal>1.10.0</literal>。このRearバージョンのマニュアルについては、『High Availability Guide for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3』を参照してください。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。</para>
     </listitem>
     <listitem>
      <para>RPMパッケージ<systemitem class="resource">rear116</systemitem>に付属するRearバージョン<literal>1.16</literal>。ここでは、このバージョンのRearを取り上げています。 </para>
@@ -99,9 +103,9 @@ Please see LICENSE.txt for this document's license.
     <para>一方、Rearバージョン1.10.0では固有のニーズに対応できない場合は(<xref linkend="sec-ha-rear-concept-limit" xrefstyle="select:label"/>も参照)、Rearバージョン1.16に手動でアップグレードします。インストール済みのバージョンが誤って別のバージョンに置き換わらないように、パッケージ<systemitem class="resource">rear</systemitem>と<systemitem class="resource">rear116</systemitem>は意図的に互いに衝突するようになっています。</para>
     <para>Rearバージョンをアップグレードするたびに、各自の障害復旧手順が引き続き機能していることを慎重に再検証する必要があります。</para>
    </important>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-limit">
+  <section xml:id="sec-ha-rear-concept-limit">
    <title>Btrfsに伴う制限事項</title>
     <para>Btrfsを使用する場合は次の制限事項が発生します。</para>
    
@@ -124,17 +128,17 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-scenarios">
+  <section xml:id="sec-ha-rear-concept-scenarios">
    <title>シナリオとバックアップのツール</title>
    <para>Rearでは、ハードディスク、フラッシュディスク、DVD/CD-RなどのローカルメディアからのブートやPXEを介したブートが可能な障害復旧システム(固有の復旧インストーラなど)を作成できます。バックアップデータは、<xref linkend="ex-ha-rear-nfs-server-backup" xrefstyle="select:label"/>に説明があるNFSなどのネットワークファイルシステムに保存できます。
     </para>
    <para>Rearは、ファイルのバックアップに取って代わるツールではなく、それを補完するツールです。Rearは、汎用的な<command>tar</command>コマンドのほか、いくつかのサードパーティのバックアップツールをデフォルトでサポートしています。このようなバックアップツールとして、Tivoli Storage Manager、QNetix Galaxy、Symantec NetBackup、EMC NetWorker、HP DataProtectorなどがあります。バックアップツールとしてEMC NetWorkerを使用したRearの設定例については<xref linkend="ex-ha-rear-config-EMC" xrefstyle="select:label"/>を参照してください。</para>
-  </sect2>
+  </section>
   
   
-  <sect2 id="sec-ha-rear-concept-overview">
+  <section xml:id="sec-ha-rear-concept-overview">
    <title>基本手順</title>
    <para>障害発生時にRearを使用して効果的な復旧を実現するには、以下の基本手順を実行する必要があります。 </para>
 
@@ -166,10 +170,10 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
+  </section>
+ </section>
   
- <sect1 id="sec-ha-rear-config">
+ <section xml:id="sec-ha-rear-config">
   <title>Rearおよびバックアップソリューションのセットアップ</title>
   <para>Rearをセットアップするには、少なくともRear設定ファイル<filename>/etc/rear/local.conf</filename>を編集する必要があります。さらに、Rearフレームワークを構成するBashスクリプトも必要に応じて編集します。 </para>
   <para>特に、Rearが実行する以下のタスクの定義が必要です。</para>
@@ -200,27 +204,27 @@ Please see LICENSE.txt for this document's license.
   <para>Rear設定ファイルを変更した場合は、次のコマンドを実行して、その出力を確認します。</para>
    <screen>rear dump</screen>
   
-  <example id="ex-ha-rear-nfs-server-backup">
+  <example xml:id="ex-ha-rear-nfs-server-backup">
    <title>NFSサーバを使用したファイルバックアップの保存</title>
    <para>Rearはさまざまなシナリオで使用できます。以下の例では、ファイルのバックアップを収めるストレージとしてNFSサーバを使用しています。
    </para>
   </example>
   
   <procedure>
-     <step performance="required">
-    <para>『SUSE Linux Enterprise Server 11 SP4 管理ガイド<phrase role="productnumber"><phrase os="sles"/></phrase>』の「<citetitle/>NFSでのファイルシステムの共有」の章の説明に従って、YaSTでNFSサーバを設定します。<ulink url="http://www.suse.com/documentation/"/>から入手できます。 </para>
+     <step>
+    <para>『SUSE Linux Enterprise Server 11 SP4 管理ガイド<phrase role="productnumber"><phrase os="sles"/></phrase>』の「<citetitle/>NFSでのファイルシステムの共有」の章の説明に従って、YaSTでNFSサーバを設定します。<link xlink:href="http://www.suse.com/documentation/"/>から入手できます。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>目的のNFSサーバの設定を<filename>/etc/exports</filename>ファイルで定義します。NFSサーバ上でバックアップデータの保存先とするディレクトリに、適切なマウントオプショが設定されていることを確認します。次に例を示します。</para>
      <screen><replaceable>/srv/nfs</replaceable> *(fsid=0,crossmnt,rw,no_root_squash,sync,no_subtree_check)</screen>
     <para>必要に応じて、<filename>/srv/nfs</filename>をNFSサーバ上のバックアップデータへのパスに置き換えて、マウントオプションを調整します。バックアップデータにアクセスするには、<literal>no_root_squash</literal>の指定が必要になることが普通です。これは、<command>rear mkbackup</command>コマンドが<systemitem class="username">root</systemitem>として実行されるためです。</para>
    </step>
-   <step performance="required">
+   <step>
     <para> さまざまな <varname>BACKUP</varname> パラメータ(設定ファイル<filename>/etc/rear/local.conf</filename>に記述されています)を調整して、該当のNFSサーバ上にRearからファイルのバックアップを保存できるようにします。この例は、インストールしたシステムの<filename>/usr/share/rear/conf/SLE11-ext3-example.conf</filename>にあります。 </para>
     </step>
   </procedure>
   
-  <example id="ex-ha-rear-config-EMC">
+  <example xml:id="ex-ha-rear-config-EMC">
    <title>サードパーティのバックアップツール(EMC NetWorkerなど)の使用</title>
    <para> <command>tar</command>の代わりにサードパーティのバックアップツールを使用するには、Rear設定ファイルを適切に設定する必要があります。</para>
    <para>以下は、EMC NetWorkerを使用する場合の設定例です。この設定スニペットを<filename>/etc/rear/local.conf</filename>に追加し、それぞれのセットアップに応じて調整します。</para>
@@ -232,9 +236,9 @@ Please see LICENSE.txt for this document's license.
     RETENTION_TIME="Month"</screen>
   </example>
   
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-rear-mkbackup">
+ <section xml:id="sec-ha-rear-mkbackup">
  <title>復旧インストールシステムの作成</title>
   <para><xref linkend="sec-ha-rear-config" xrefstyle="select:label"/>の説明に従ってRearを設定した後、Rear復旧インストーラを持つ復旧インストールシステムを作成したうえで、以下のコマンドを使用してファイルのバックアップを作成します。</para>
   <screen>rear -d  -D mkbackup</screen> 
@@ -256,9 +260,9 @@ Please see LICENSE.txt for this document's license.
   </listitem>
   
  </orderedlist>
-</sect1>
+</section>
  
- <sect1 id="sec-ha-rear-testing">
+ <section xml:id="sec-ha-rear-testing">
   <title>復旧プロセスのテスト</title>
 
   <para> 復旧システムを作成した後、運用マシンと同一のハードウェアを備えたテストマシンで復旧プロセスをテストします。<xref linkend="sec-ha-rear-concept-requirements"/>も参照してください。テストマシンの設定が適切で、メインマシンの代わりとして機能できることを確認します。
@@ -269,37 +273,37 @@ Please see LICENSE.txt for this document's license.
    <para>マシン上で障害復旧プロセスを十分にテストする必要があります。復旧手順を定期的にテストし、すべてが想定どおりに機能することを確認します。 </para>
   </warning>
 
-  <procedure id="pro-ha-rear-testing">
+  <procedure xml:id="pro-ha-rear-testing">
    <title>テストマシン上での障害復旧の実行</title>
-   <step performance="required">
+   <step>
     <para><xref linkend="sec-ha-rear-mkbackup" xrefstyle="select:label"/>で作成した復旧システムをDVDやCDに書き込み、復旧メディアを作成します。PXEを介したネットワークブートとすることもできます。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>復旧メディアからテストマシンをブートします。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> メニューから<guimenu>Recover (復旧)</guimenu>を選択します。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> <systemitem class="username">root</systemitem>としてログインします(パスワードは必要なし)。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 次のコマンドを入力して復旧インストーラを起動します。</para>
     <screen>rear -d -D recover</screen>
     <para>このプロセスでRearが実行する手順の詳細については<xref linkend="ol-ha-rear-recovers-steps"/>を参照してください。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>復旧プロセスが完了した後、システムが正常に再作成されたかどうか、および運用環境で元のシステムの代替として機能するかどうかを確認します。</para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-rear-recover">
+ </section>
+ <section xml:id="sec-ha-rear-recover">
   <title>障害からの復旧</title>
   <para>障害が発生した場合には、必要に応じて損傷したハードウェアを交換します。次に、<xref linkend="pro-ha-rear-testing" xrefstyle="select:label"/>の説明に従って、修復したマシンまたは元のシステムの代替として機能することをテスト済みの同一構成のマシンを使用して手順を進めます。</para>
   
 <para><command>rear recover</command>コマンドでは以下の手順が実行されます。</para>  
   
-  <orderedlist id="ol-ha-rear-recovers-steps" spacing="normal">
+  <orderedlist xml:id="ol-ha-rear-recovers-steps" spacing="normal">
    <title>回復プロセス</title>
    <listitem>
    <para>
@@ -317,10 +321,10 @@ Please see LICENSE.txt for this document's license.
    </para>
    </listitem>
    </orderedlist>
-  </sect1>
+  </section>
  
   
- <sect1 id="sec-ha-rear-more">
+ <section xml:id="sec-ha-rear-more">
   <title>その他の情報</title>
 
 
@@ -328,7 +332,7 @@ Please see LICENSE.txt for this document's license.
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://en.opensuse.org/SDB:Disaster_Recovery"/>
+     <link xlink:href="http://en.opensuse.org/SDB:Disaster_Recovery"/>
     </para>
    </listitem>
    <listitem>
@@ -342,5 +346,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_requirements.xml
+++ b/ja/xml/ha_requirements.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_requirements.xml" id="cha-ha-requirements">
- <title>システム要件と推奨事項</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_requirements.xml" xml:id="cha-ha-requirements"><?dbfo-need height="10em"?><title>システム要件と推奨事項</title><info><abstract>
   <para>
    次のセクションでは、<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase>のシステム要件と前提条件について説明します。また、クラスタセットアップの推奨事項についても説明します。
   </para>
- </abstract>
- <sect1 id="sec-ha-requirements-hw">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-requirements-hw">
   <title>ハードウェア要件</title>
 
   <para>
@@ -40,11 +44,11 @@ Please see LICENSE.txt for this document's license.
     
    </listitem>
   </itemizedlist>
- </sect1>
-<?dbfo-need height="10em"?>
+ </section>
 
 
- <sect1 id="sec-ha-requirements-sw">
+
+ <section xml:id="sec-ha-requirements-sw">
   <title>ソフトウェアの必要条件</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     <para>Geoクラスタを使用する場合は、Geo Clustering for SUSE Linux Enterprise High Availability Extension<phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> (利用可能なすべてのオンラインアップデートを適用済み)が、クラスタを構成するすべてのノードにインストールされていること。 </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-disk">
+ </section>
+ <section xml:id="sec-ha-requirements-disk">
   <title>ストレージ要件</title>
 
   <para> クラスタでデータの可用性を高めたい場合は、共有ディスクシステム(SAN: Storage Area Network)の利用をお勧めします。共有ディスクシステムを使用する場合は、次の要件を満たしていることを確認してください。 </para>
@@ -97,12 +101,12 @@ Please see LICENSE.txt for this document's license.
    </listitem>
    
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-other">
+ </section>
+ <section xml:id="sec-ha-requirements-other">
   <title>その他の要件と推奨事項</title>
   <para>サポートされていて、役に立つHigh Availabilityセットアップについては、次の推奨事項を検討してください。</para>
   <variablelist>
-   <varlistentry id="vle-ha-req-nodes">
+   <varlistentry xml:id="vle-ha-req-nodes">
     <term>クラスタノード数</term>
     <listitem>
      <para>
@@ -115,7 +119,7 @@ Please see LICENSE.txt for this document's license.
      </important>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-stonith">
+   <varlistentry xml:id="vle-ha-req-stonith">
     <term>STONITH</term>
     <listitem>
      <important>
@@ -133,7 +137,7 @@ Please see LICENSE.txt for this document's license.
      </itemizedlist>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-communication">
+   <varlistentry xml:id="vle-ha-req-communication">
     <term>冗長通信パス</term>
     <listitem>
      <para>High Availabilityセットアップがサポートされるには、2つ以上の冗長パスでクラスタ通信を設定する必要があります。これは次のように実行できます。 </para>
@@ -152,7 +156,7 @@ Please see LICENSE.txt for this document's license.
    <varlistentry>
     <term>時刻同期</term>
     <listitem>
-     <para> クラスタノードはクラスタ外のNTPサーバに同期する必要があります。詳細については、『SUSE Linux Enterprise Server 11 SP4 管理ガイド<citetitle/><phrase role="productnumber"><phrase os="sles"/></phrase>』(<ulink url="http://www.suse.com/doc/"/>から入手可能)を参照してください。特に、「<citetitle>Time Synchronization with NTP</citetitle>」の章を参照してください。 </para>
+     <para> クラスタノードはクラスタ外のNTPサーバに同期する必要があります。詳細については、『SUSE Linux Enterprise Server 11 SP4 管理ガイド<citetitle/><phrase role="productnumber"><phrase os="sles"/></phrase>』(<link xlink:href="http://www.suse.com/doc/"/>から入手可能)を参照してください。特に、「<citetitle>Time Synchronization with NTP</citetitle>」の章を参照してください。 </para>
      <para> ノードが同期されていない場合、ログファイルまたはクラスタレポートは分析が難しくなります。 </para>
     </listitem>
    </varlistentry>
@@ -174,18 +178,18 @@ Please see LICENSE.txt for this document's license.
        <para> このファイルにあるすべてのクラスタノードを、完全修飾ホスト名およびショートホスト名で一覧表示します。クラスタのメンバーが名前で互いを見つけられることが重要です。名前を使用できない場合、内部クラスタ通信は失敗します。 </para>
       </listitem>
      </itemizedlist>
-     <para> 詳細については、『SUSE Linux Enterprise Server 11 SP4 管理ガイド<citetitle/><phrase role="productnumber"><phrase os="sles"/></phrase>』(<ulink url="http://www.suse.com/doc"/>から入手可能)を参照してください。「<citetitle/>ネットワークの基礎」の章、「<citetitle/>YaSTによるネットワーク接続の設定」の「<citetitle/>ホスト名とDNSの設定」セクションを参照してください。 </para>
+     <para> 詳細については、『SUSE Linux Enterprise Server 11 SP4 管理ガイド<citetitle/><phrase role="productnumber"><phrase os="sles"/></phrase>』(<link xlink:href="http://www.suse.com/doc"/>から入手可能)を参照してください。「<citetitle/>ネットワークの基礎」の章、「<citetitle/>YaSTによるネットワーク接続の設定」の「<citetitle/>ホスト名とDNSの設定」セクションを参照してください。 </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-storage">
+   <varlistentry xml:id="vle-ha-req-storage">
     <term>ストレージ要件</term>
     <listitem>
      
      <para>一部のサービスでは、共有ストレージが必要な場合があります。詳細については、<xref linkend="sec-ha-requirements-disk"/>を参照してください。外部NFS共有またはDRBDを使用することもできます。外部NFS共有を使用する場合は、冗長通信パスを介してすべてのクラスタノードから確実にアクセスできる必要があります。詳細については、<xref linkend="vle-ha-req-communication"/>を参照してください。 </para>
-     <para>SBDをSTONITHデバイスとして使用する場合は、共有ストレージに対して追加の要件が適用されます。詳細については、<ulink url="http://linux-ha.org/wiki/SBD_Fencing"/>、「<citetitle/>Requirements」セクションを参照してください。</para>
+     <para>SBDをSTONITHデバイスとして使用する場合は、共有ストレージに対して追加の要件が適用されます。詳細については、<link xlink:href="http://linux-ha.org/wiki/SBD_Fencing"/>、「<citetitle/>Requirements」セクションを参照してください。</para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-ssh">
+   <varlistentry xml:id="vle-ha-req-ssh">
     <term>SSH</term>
     <listitem>
      <para> すべてのクラスタノードはSSHによって互いにアクセスできる必要があります。<command>hb_report</command>または<command>crm_report</command> (トラブルシューティング用)などのツールおよびHawkの<guimenu>履歴エクスプローラ</guimenu>は、ノード間にパスワード不要のSSHアクセスを必要とします。それがない場合、現在のノードからしかデータを収集できません。非標準のSSHポートを使用する場合は、<option>-X</option>オプションを使用します(マニュアルページを参照)。たとえば、SSHポートが<literal>3479</literal>の場合、次のコマンドを使用して、<literal>hb_report</literal>を起動します。</para>
@@ -207,5 +211,5 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
 
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_samba.xml
+++ b/ja/xml/ha_samba.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_samba.xml" id="cha-ha-samba">
- <title>Sambaクラスタリング</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_samba.xml" xml:id="cha-ha-samba"><title>Sambaクラスタリング</title><info><abstract>
   <para>
    クラスタ対応のSambaサーバは、異種混合ネットワークにHigh Availabilityソリューションを提供します。この章では、背景情報とクラスタ対応Sambaサーバの設定方法を説明します。
   </para>
- </abstract>
- <sect1 id="sec-ha-samba-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-samba-overview">
   <title>概念の概要</title>
 
   <para>
@@ -37,7 +41,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <figure id="fig-ha-samba-overview">
+  <figure xml:id="fig-ha-samba-overview">
    <title>CTDBクラスタの構造</title>
    <mediaobject>
     <imageobject role="fo">
@@ -79,8 +83,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    クラスタ対応SambaサーバがN+1ノードを持っている場合、Nノードだけのサーバより高速になることを目的としています。1つのノードは、クラスタ非対応のSambaサーバより遅くなることはありません。
   </para>
- </sect1>
- <sect1 id="sec-ha-samba-basicconf">
+ </section>
+ <section xml:id="sec-ha-samba-basicconf">
   <title>基本的な設定</title>
   
   <note>
@@ -94,24 +98,24 @@ Please see LICENSE.txt for this document's license.
    クラスタ対応Sambaサーバをセットアップするには、次の手順に従います。
   </para>
 
-  <procedure id="pro-ha-samba-basicconf">
+  <procedure xml:id="pro-ha-samba-basicconf">
    <title>クラスタ対応Sambaサーバの基本セットアップ</title>
-   <step performance="required">
+   <step>
     <para>
      クラスタを準備します。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        本書の<xref linkend="part-config"/>で説明されているように、クラスタを設定します(OpenAIS、Pacemaker、OCFS2など使用)。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        OCFS2などの共有ファイルシステムを設定し、マウントします(たとえば、<filename>/shared</filename>にマウント)。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        POSIX ACLをオンにする場合は、それを有効にします。
       </para>
@@ -134,7 +138,7 @@ Please see LICENSE.txt for this document's license.
        </listitem>
       </itemizedlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <systemitem class="service">ctdb</systemitem>、<systemitem class="service">smb</systemitem>、<systemitem class="service">nmb</systemitem>、<systemitem class="service">winbind</systemitem>の各サービスが無効になるようにします。
       </para>
@@ -145,20 +149,20 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      共有ファイルシステムにCTDBロックのディレクトリを作成します。
     </para>
     <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /shared/samba/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <filename>/etc/ctdb/nodes</filename>に、クラスタ内の各ノードの全プライベートIPアドレスを含むすべてのノードを挿入します。
     </para>
 <screen>192.168.1.10
 192.168.1.11</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>csync2</command>を使用して、設定ファイルをすべてのノードにコピーします。
     </para>
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      CTDBリソースをクラスタに追加します。
     </para>
@@ -188,7 +192,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ctdb-after-fs inf: fs-clone ctdb-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      クラスタ対応のIPアドレスを追加します。
     </para>
@@ -199,7 +203,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ip-after-ctdb inf: ctdb-clone ip-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      結果を確認します。
     </para>
@@ -216,19 +220,19 @@ Clone Set: dlm-clone
      ip:0       (ocf::heartbeat:IPaddr2):       Started hex-13
      ip:1       (ocf::heartbeat:IPaddr2):       Started hex-14</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>クライアントコンピュータからテストを行います。Linuxクライアントで、Sambaアクセス用のユーザを追加します。
     </para>
     <screen><prompt role="root">root # </prompt><command>smbpasswd</command> <option>-a</option> <replaceable>USERNAME</replaceable></screen>
    </step>
-   <step performance="required"><para>新しいユーザのホームディレクトリにアクセスできるかどうかをテストします。</para>
+   <step><para>新しいユーザのホームディレクトリにアクセスできるかどうかをテストします。</para>
     <screen><prompt role="root">root # </prompt>smbclient -u <replaceable>USERNAME</replaceable>//192.168.2.222/<replaceable>USERNAME</replaceable></screen>
    </step>
 
 
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-ad">
+ </section>
+ <section xml:id="sec-ha-samba-ad">
   <title>Active Directoryドメインへの追加</title>
 
   
@@ -242,7 +246,7 @@ Clone Set: dlm-clone
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      Active Directoryドメインのセットアップ方法については、Windows Serverのマニュアルを参照してください。この例では、次のパラメータを使用します。
     </para>
@@ -284,12 +288,12 @@ Clone Set: dlm-clone
     </informaltable>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-ctdb"/>
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-join-ad"/>
     </para>
@@ -300,20 +304,20 @@ Clone Set: dlm-clone
    次のステップは、CTDBの設定です。
   </para>
 
-  <procedure id="pro-ha-samba-config-ctdb">
+  <procedure xml:id="pro-ha-samba-config-ctdb">
    <title>CTDBの設定</title>
-   <step performance="required">
+   <step>
     <para>
      クラスタが、<xref linkend="sec-ha-samba-basicconf"/>に示されているとおり設定されていることを確かめます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      1つのノードでCTDBリソースを停止します。
     </para>
 <screen><prompt role="root">root # </prompt> crm resource stop ctdb-clone</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <filename>/etc/samba/smb.conf</filename>設定ファイルを開き、NetBIOS名を追加して、ファイルを閉じます。
     </para>
@@ -323,13 +327,13 @@ Clone Set: dlm-clone
      セキュリティやワークグループなどのその他の設定は、YaSTウィザードで追加されます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      すべてのノードで<filename>/etc/samba.conf</filename>ファイルを更新します。
     </para>
 <screen><prompt role="root">root # </prompt>csync2 -xv</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      CTDBリソースをリスタートします。
     </para>
@@ -341,9 +345,9 @@ Clone Set: dlm-clone
    最後に、クラスタをActive Directoryサーバに参加させます。
   </para>
 
-  <procedure id="pro-ha-samba-config-join-ad">
+  <procedure xml:id="pro-ha-samba-config-join-ad">
    <title>Active Directoryへの参加</title>
-   <step performance="required">
+   <step>
     <para>
      次のファイルが、すべてのクラスタホストにインストールされるように、Csync2設定に含まれていることを確認します。
     </para>
@@ -357,24 +361,24 @@ Clone Set: dlm-clone
      この作業には、YaSTの<guimenu>Csync2の設定</guimenu>モジュールをっ使用することもできます。<xref linkend="sec-ha-installation-setup-csync2"/>を参照してください。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-basicconf"/>の説明に従って、CTDBリソースを作成します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      YaSTを実行し、<guimenu>ネットワークサービス</guimenu>エントリから<guimenu>Windowsドメインメンバーシップ</guimenu>モジュールを開きます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      ドメインまたはワークグループの設定を入力して、<guimenu>OK</guimenu>をクリックして終了します。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-testing">
+ </section>
+ <section xml:id="sec-ha-samba-testing">
   <title>クラスタ対応Sambaのデバッグとテスト</title>
 
   <para>
@@ -416,7 +420,7 @@ Clone Set: dlm-clone
     </term>
     <listitem>
      <para>
-      <command>ping_pong</command>では、ファイルシステムがCTDBに適合しているかどうかチェックできます。このコマンドは、クラスタファイルシステムの一定のテスト(コヒーレンスやパフォーマンスなどのテスト)を実行して(<ulink url="http://wiki.samba.org/index.php/Ping_pong"/>参照)、高負荷の状況下におけるクラスタの動作を示す情報を提供します。
+      <command>ping_pong</command>では、ファイルシステムがCTDBに適合しているかどうかチェックできます。このコマンドは、クラスタファイルシステムの一定のテスト(コヒーレンスやパフォーマンスなどのテスト)を実行して(<link xlink:href="http://wiki.samba.org/index.php/Ping_pong"/>参照)、高負荷の状況下におけるクラスタの動作を示す情報を提供します。
      </para>
     </listitem>
    </varlistentry>
@@ -428,7 +432,7 @@ Clone Set: dlm-clone
       <systemitem class="resource">SendArp</systemitem>リソースエージェントは、<filename>/usr/lib/heartbeat/send_arp</filename>(または<filename>/usr/lib64/heartbeat/send_arp</filename>)にあります。<command>send_arp</command>ツールはGratuitous ARP (余計なアドレス解決プロトコル)パケットを送信し、他のマシンのARPテーブルを更新するために使用できます。これは、フェールオーバープロセス後の通信問題の識別に役立ちます。Sambaのクラスタ化されたIPアドレスを表示しているのにも関わらず、ノードに接続またはpingできない場合は、<command>send_arp</command>コマンドを使用して、ノードはARPテーブルの更新のみが必要であるのかをテストします。
      </para>
      <para>
-      詳細については、<ulink url="http://wiki.wireshark.org/Gratuitous_ARP"/>を参照してください。
+      詳細については、<link xlink:href="http://wiki.wireshark.org/Gratuitous_ARP"/>を参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -440,7 +444,7 @@ Clone Set: dlm-clone
 
   <procedure>
    <title>クラスタファイルシステムのコヒーレンスとパフォーマンスをテストする</title>
-   <step performance="required">
+   <step>
     <para>
      1つのノードで<command>ping_pong</command>コマンドを開始します。プレースホルダ<replaceable>N</replaceable>はノード数+1で置き換えます。共有ストレージでは<filename><replaceable>ABSPATH</replaceable>/data.txt</filename>ファイルが使用可能で、すべてのノード上でアクセスできます(<replaceable>ABSPATH</replaceable>は絶対パスを示しています)。
     </para>
@@ -449,7 +453,7 @@ Clone Set: dlm-clone
      1つのノードでだけ実行しているので、ロッキングレートは非常に高いと予想してください。プログラムがロッキングレートを出力しない場合は、クラスタファイルシステムを置き換えます。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      同じパラメータを使用して、別のノードで<command>ping_pong</command>の2つ目のコピーを開始します。
     </para>
@@ -474,42 +478,42 @@ Clone Set: dlm-clone
      </listitem>
     </itemizedlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>ping_pong</command>の3つ目のコピーを開始します。もう1つノードを追加し、ロッキングレートの変化に注目します。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <command>ping_pong</command>コマンドを1つずつ終了させます。単一ノードの状態に戻るまで、ロッキングレートの増加が観察されるはずです。予想したような振る舞いが見られなかった場合には、<xref linkend="cha-ha-ocfs2"/>に記されている詳細を参照してください。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-moreinfo">
+ </section>
+ <section xml:id="sec-ha-samba-moreinfo">
   <title>その他の情報</title>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
+     <link xlink:href="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/CTDB_Setup"/>
+     <link xlink:href="http://wiki.samba.org/index.php/CTDB_Setup"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://ctdb.samba.org"/>
+     <link xlink:href="http://ctdb.samba.org"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
+     <link xlink:href="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_storage_protection.xml
+++ b/ja/xml/ha_storage_protection.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_storage_protection.xml" id="cha-ha-storage-protect">
- <title>ストレージ保護</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_storage_protection.xml" xml:id="cha-ha-storage-protect"><title>ストレージ保護</title><info><abstract>
 
   <para>
    High Availabilityクラスタスタックでは、データの整合性の保護が最優先されます。これは、データストレージへの未調整の同時アクセスを防止することによって達成されます。たとえば、Ext3ファイルシステムは、クラスタに一回だけマウントされ、OCFS2ボリュームは、他のクラスタノードとの調整が可能になるまでマウントされません。正常に機能するクラスタでは、Pacemakerによって、リソースがそれらの同時並行性の制限を超えてアクティブであるかどうかが検出され、復元が開始されます。さらに、そのポリシーエンジンがそれらの制限を超えることは決してありません。
@@ -24,15 +26,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    この章では、ストレージ自体を活用するIOフェンシングについて説明し、次に、排他的ストレージアクセスを確保する追加保護レイヤについて説明します。これら2つのメカニズムを組み合わせると、より高度な保護を実現できます。
   </para>
- </abstract>
- <sect1 id="sec-ha-storage-protect-fencing">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-storage-protect-fencing">
   <title>ストレージベースのフェンシング</title>
 
   <para>
    1つ以上のSTONITHブロックデバイス(SBD)、<literal>watchdog</literal>サポート、<literal>external/sbd</literal> STONITHエージェントを使用することで、スプリットブレインシナリオを確実に回避することができます。
   </para>
 
-  <sect2 id="sec-ha-storage-protect-fencing-oview">
+  <section xml:id="sec-ha-storage-protect-fencing-oview">
    <title>概要</title>
    <para>
     すべてのノードが共有ストレージへのアクセスを持つ環境で、デバイスの小さなパーティションをSBDで使用できるようにフォーマットします。パーティションのサイズは、使用されるディスクのブロックサイズによって異なります(512バイトのブロックサイズの標準SCSIディスクには1MB、4KBブロックサイズのDASDディスクには4MB必要です)。SBDは、そのデーモンの設定後、クラスタスタックの他のコンポーネントが起動される前に各ノードでオンラインになります。SBDデーモンは、他のすべてのクラスタコンポーネントがシャットダウンされた後で終了されます。したがって、クラスタリソースがSBDの監督なしでアクティブになることはありません。
@@ -49,11 +53,11 @@ Please see LICENSE.txt for this document's license.
    <para>
     Pacemaker統合が有効になっている場合、デバイスの過半数が失われてもSBDはセルフフェンスを行いません。たとえば、クラスタにA、B、Cの3つのノードが含まれており、ネットワーク分割によってAには自分自身しか表示できず、BとCはまだ通信可能な状態であるとします。この場合、2つのクラスタパーティションが存在し、1つは過半数(B、C)であるためにクォーラムがあり、もう1つにはクォーラムがない(A)ことになります。過半数のフェンシングデバイスに到達できないときにこれが発生した場合、ノードAはすぐに自らダウンしますが、BとCは引き続き実行されます。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-storage-protect-fencing-number">
+  <section xml:id="sec-ha-storage-protect-fencing-number">
    <title>SBDデバイスの数</title>
    <para>
     SBDは、1～3台のデバイスの使用をサポートします。
@@ -87,35 +91,35 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-fencing-setup">
+  <section xml:id="sec-ha-storageprotection-fencing-setup">
    <title>ストレージベースの保護のセットアップ</title>
    <para>
     ストレージベースの保護を設定するには、次の手順に従う必要があります。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-create" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-watchdog" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-daemon" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-test" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-fencing" xrefstyle="select:title"/>
      </para>
@@ -145,7 +149,7 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </important>
-   <sect3 id="pro-ha-storage-protect-sbd-create">
+   <section xml:id="pro-ha-storage-protect-sbd-create">
     <title>SBDパーティションの作成</title>
     <para>
      デバイスの起動時に1MBのパーティションを作成することを推奨します。SBDデバイスがマルチパスグループ上にある場合は、MPIOのパスダウン検出によって遅延が発生することがあるので、SBDが使用するタイムアウトを調整する必要があります。<literal>msgwait</literal>タイムアウト後、メッセージがノードに配信されたと想定されます。この時間は、マルチパスの場合、MPIOがパスの障害を検出し、次のパスに切り替えるために必要な時間です。これは、ご使用の環境でテストする必要があるかもしれません。ノード上で実行しているSBDデーモンがウォッチドッグタイマを十分な速さで更新していない場合、ノード自体が終了します。選択したタイムアウトを特定の環境でテストします。1台のSBDデバイスしかないマルチパスストレージを使用する場合は、発生したフェールオーバーの遅延に特別の注意を払ってください。
@@ -163,7 +167,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        次のコマンドで、SBDデバイスを初期化します。
       </para>
@@ -176,12 +180,12 @@ Please see LICENSE.txt for this document's license.
       </para>
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD1</replaceable> -d /dev/<replaceable>SBD2</replaceable> -d /dev/<replaceable>SBD3</replaceable> create</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        SBDデバイスがマルチパスグループ上にある場合は、SBDが使用するタイムアウトを調整します。これは、SBDデバイスの初期化時に指定できます(すべてのタイムアウトは秒単位で指定)。
       </para>
 
-<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co id="co-msgwait"/> -1 90<co id="co-watchdog"/> create</screen>
+<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co xml:id="co-msgwait"/> -1 90<co xml:id="co-watchdog"/> create</screen>
       <calloutlist>
        <callout arearefs="co-msgwait">
         <para>
@@ -195,7 +199,7 @@ Please see LICENSE.txt for this document's license.
        </callout>
       </calloutlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        次のコマンドで、デバイスに何が書き込まれたか確認します。
       </para>
@@ -212,8 +216,8 @@ Timeout (msgwait)  : 10</screen>
     <para>
      ご覧のように、タイムアウトがヘッダにも保存され、それらに関するすべての参加ノードの合意が確保されます。
     </para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-watchdog">
+   </section>
+   <section xml:id="pro-ha-storage-protect-watchdog">
     <title>ソフトウェアウォッチドッグのセットアップ</title>
     <para>ウォッチドッグを他のソフトウェアが使用していない場合は、ウォッチドッグがシステムをSBD障害から保護します。</para>
      
@@ -222,7 +226,7 @@ Timeout (msgwait)  : 10</screen>
      </important>
      
      <para>
-     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>では、カーネル内のウォッチドッグサポートはデフォルトで有効化されています。これは、ハードウェア指定のウォッチドッグドライバを提供する、さまざまなカーネルモジュールを標準装備しています。High Availability Extensionはウォッチドッグに<quote>フィード</quote>するソフトウェアコンポーネントとしてSBDデーモンを使用します。<xref linkend="pro-ha-storage-protect-sbd-daemon"/>で説明されているとおり設定した場合、SBDデーモンは、それぞれのノードが<command>rcopenais <option>start</option></command>でオンラインにする際に自動的に開始します。
+     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase>では、カーネル内のウォッチドッグサポートはデフォルトで有効化されています。これは、ハードウェア指定のウォッチドッグドライバを提供する、さまざまなカーネルモジュールを標準装備しています。High Availability Extensionはウォッチドッグに<quote>フィード</quote>するソフトウェアコンポーネントとしてSBDデーモンを使用します。<xref linkend="pro-ha-storage-protect-sbd-daemon"/>で説明されているとおり設定した場合、SBDデーモンは、それぞれのノードが<command>rcopenais </command> <option>start</option>でオンラインにする際に自動的に開始します。
     </para>
     <para>
      通常、ハードウェアに適したウォッチドッグドライバがシステムブート中に自動的にロードされます。<literal>softdog</literal>が最も一般的なドライバですが、実際のハードウェア統合のあるドライバの使用を推奨します。例:
@@ -252,7 +256,7 @@ Timeout (msgwait)  : 10</screen>
      <para>次の<quote/>式は、これら3つの値の関係を簡潔に示しています。
     </para>
      
-     <example id="ex-ha-storage-protect-sbd-timings">
+     <example xml:id="ex-ha-storage-protect-sbd-timings">
        <title>STONITHデバイスとしてSBDを使用したクラスタのタイミング</title>
        <screen>Timeout (msgwait) = (Timeout (watchdog) * 2)
 stonith-timeout = Timeout (msgwait) + 20%</screen>
@@ -273,15 +277,15 @@ Timeout (loop)     : 1
 Timeout (msgwait)  : 40
 ==Header on disk /dev/sdb is dumped</screen>
      <para>新しいクラスタをセットアップした場合は、先に示した考慮事項を<command>sleha-init</command>コマンドに反映できます。</para>
-    <para>SBDに関連するタイミング変数の詳細については、技術情報文書『<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>』(<ulink url="https://www.suse.com/support/kb/doc.php?id=7011346"/>で入手可能)を参照してください。</para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-daemon">
+    <para>SBDに関連するタイミング変数の詳細については、技術情報文書『<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>』(<link xlink:href="https://www.suse.com/support/kb/doc.php?id=7011346"/>で入手可能)を参照してください。</para>
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-daemon">
     <title>SBDデーモンの起動</title>
     <para>
      SBDデーモンは、クラスタスタックの不可欠なコンポーネントです。このデーモンは、クラスタスタックの実行中はもちろんのこと、クラスタスタックの一部がクラッシュしたときでも、実行されている必要があります。これにより、ノードのフェンシングが可能になります。
     </para>
     <procedure>
-        <step performance="required">
+        <step>
        <para><command>sleha-init</command>を実行します。このスクリプトによりSBDが正しく設定され、設定ファイル<filename>/etc/sysconfig/sbd</filename>が、Csync2で同期される必要のあるファイルのリストに追加されます。 </para>
        <para>SBDを手動で設定する場合は、次の手順を実行します。</para>
             <para> OpenAISのinitスクリプトでSBDを開始および停止するには、ファイル<filename>/etc/sysconfig/sbd</filename>で次の行を探し出し、<replaceable>SBD</replaceable>を、使用しているSBDデバイスに置き換えます。 </para>
@@ -299,17 +303,17 @@ Timeout (msgwait)  : 40
        </para>
       </note>
      </step>     
-     <step performance="required">
+     <step>
       <para>
-       先に進む前に、<command>rcopenais<option> restart</option></command>を実行して、SBDがすべてのノード上で開始しているようにします。
+       先に進む前に、<command>rcopenais</command> <option> restart</option>を実行して、SBDがすべてのノード上で開始しているようにします。
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-test">
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-test">
     <title>SBDのテスト</title>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        次のコマンドを使用すると、ノードスロットとそれらの現在のメッセージがSBDデバイスからダンプされます。
       </para>
@@ -318,14 +322,14 @@ Timeout (msgwait)  : 40
        ここに、SBDとともに起動されたすべてのクラスタノードが一覧され、メッセージスロットには<literal>clear</literal>が表示されるはずです。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        ノードの1つにテストメッセージを送信してみます。
       </para>
       
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD</replaceable> message alice test</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        ノードがシステムログファイルにメッセージの受信を記録します。
       </para>
@@ -335,8 +339,8 @@ Timeout (msgwait)  : 40
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-fencing">
+   </section>
+   <section xml:id="pro-ha-storage-protect-fencing">
     <title>フェンシングリソースの設定</title>
     <para>
      SBDのセットアップを完了するには、SBDをCIB内でSTONITH/フェンシングメカニズムとして設定します。
@@ -347,16 +351,16 @@ Timeout (msgwait)  : 40
      <para>2ノードクラスタ(および<literal>no-quorum-policy</literal>を<literal>ignore</literal>に設定した他のクラスタ)では、タイミングを外したフェンシングが頻繁に発生します。これは、スプリットブレインが発生した状況で、両方のノードが互いをフェンシングしようとするためです。このダブルフェンシングを避けるには、STONITHTリソースの設定に<literal>pcmk_delay_max</literal>パラメータを追加します。これにより、機能しているネットワークカードを備えたサーバが稼動を継続できる可能性が高くなります。</para>
     </tip>
     <procedure>
-     <step performance="required">
+     <step>
       <para>いずれかのノードにログインし、<command>crm configure</command>を使用して対話型crmshを起動します。</para>
      </step>
-     <step performance="required">
+     <step>
       <para>次のように入力します。</para>
       
       <screen><prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-enabled="true"
-<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co id="co-ha-sbd-stonith-timeout"/>
+<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co xml:id="co-ha-sbd-stonith-timeout"/>
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> stonith_sbd stonith:external/sbd \
-   pcmk_delay_max="30" <co id="co-ha-sbd-pcmk-delay-max"/></screen>
+   pcmk_delay_max="30" <co xml:id="co-ha-sbd-pcmk-delay-max"/></screen>
       <para> リソースのクローンを作成する必要はありません。ノードスロットは自動的に割り当てられるので、手動のホストリストを定義する必要はありません。 </para>
       <calloutlist>
        <callout arearefs="co-ha-sbd-stonith-timeout">
@@ -369,11 +373,11 @@ Timeout (msgwait)  : 40
        </callout>
       </calloutlist>
       </step>
-     <step performance="required">
+     <step>
       <para> 変更をコミットします。 </para>
       <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        以前設定した他のフェンシングデバイスを無効にします。現在、この機能にはSBDメカニズムが使用されるからです。
       </para>
@@ -382,16 +386,16 @@ Timeout (msgwait)  : 40
     <para>
      一度リソースが起動すれば、クラスタは共有ストレージフェンシング用に正常に設定されます。クラスタは、ノードのフェンシングが必要になると、この方法を使用します。
     </para>
-   </sect3>
-   <sect3>
+   </section>
+   <section>
     <title>その他の情報</title>
     <para>
-     <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>
+     <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>
     </para>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storageprotection-exstoract">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-storageprotection-exstoract">
   <title>排他的ストレージアクティベーションの確保</title>
 
   <para>
@@ -402,7 +406,7 @@ Timeout (msgwait)  : 40
    設計上、sfexは、同時並行性を必要とするOCFS2のようなワークロードには使用できませんが、従来のフェールオーバー方式のワークロードに対しては保護層として機能できます。これは、実際にはSCSI-2予約と似ていますが、もっと一般的です。
   </para>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-description">
+  <section xml:id="sec-ha-storageprotection-exstoract-description">
    <title>概要</title>
    <para>
     共有ストレージ環境では、ストレージの小さなパーティションが1つ以上のロックの保存用に確保されます。
@@ -413,9 +417,9 @@ Timeout (msgwait)  : 40
    <para>
     ノードのダウンが永続的にロックをブロックせず、他のノードが続行できるように、これらのロックも定期的に更新される必要があります。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-requirements">
+  <section xml:id="sec-ha-storageprotection-exstoract-requirements">
    <title>設定</title>
    <para>
     次に、sfexで使用する共有パーティションの作成方法と、CIBでsfexロック用にリソースを設定する方法を説明します。1つのsfexパーティションは任意の数のロックを保持できますが、デフォルトは1に設定されています。ロックごとに1KBのストレージスペースを割り当てる必要があります。
@@ -442,18 +446,18 @@ Timeout (msgwait)  : 40
    </important>
    <procedure>
     <title>sfexパーティションを作成する</title>
-    <step performance="required">
+    <step>
      <para>
       sfexで使用する共有パーティションを作成します。このパーティションの名前を書き留め、以降の手順の<filename>/dev/sfex</filename>をこの名前で置き換えます。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       次のコマンドで、sfexメタデータを作成します。
      </para>
 <screen><prompt role="root">root # </prompt><command>sfex_init</command> -n 1 /dev/sfex</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       メタデータが正しく作成されたかどうか検証します。
      </para>
@@ -465,7 +469,7 @@ Timeout (msgwait)  : 40
    </procedure>
    <procedure>
     <title>sfexロック用リソースを設定する</title>
-    <step performance="required">
+    <step>
      <para>
       sfexロックは、CIB内のリソースを介して表現され、次のように設定されます。
      </para>
@@ -474,27 +478,27 @@ Timeout (msgwait)  : 40
       lock_timeout="70" monitor_interval="10" \
 #	op monitor interval="10s" timeout="30s" on_fail="fence"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       sfexロックによってリソースを保護するには、保護対象とsfexリソース間の必須の順序付けと配置の制約を作成します。保護対象のリソースが<literal>filesystem1</literal>というIDを持つ場合は、次のようになります。
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> order-sfex-1 inf: sfex_1 filesystem1
 <prompt role="custom">crm(live)configure# </prompt><command>colocation</command> colo-sfex-1 inf: filesystem1 sfex_1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       グループ構文を使用する場合は、sfexリソースを最初のリソースとしてグループに追加します。
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>group</command> LAMP sfex_1 filesystem1 apache ipaddr</screen>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storage-moreinfo">
+  </section>
+ </section>
+ <section xml:id="sec-ha-storage-moreinfo">
   <title>その他の情報</title>
 
   <para>
-   <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>および<command>man sbd</command>を参照してください。
+   <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>および<command>man sbd</command>を参照してください。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/ja/xml/ha_troubleshooting.xml
+++ b/ja/xml/ha_troubleshooting.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_troubleshooting.xml" id="app-ha-troubleshooting">
- <title>トラブルシューティング</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_troubleshooting.xml" xml:id="app-ha-troubleshooting"><title>トラブルシューティング</title><info><abstract>
   <para>
    時として理解しにくい奇妙な問題が発生することがあります。High Availabilityでの実験を開始したときには、特にそうです。それでも、High Availabilityの内部プロセスを詳しく調べるために使用できる、いくつかのユーティリティがあります。この章では、さまざまなソリューションを推奨します。
   </para>
- </abstract>
- <sect1 id="sec-ha-troubleshooting-install">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-troubleshooting-install">
   <title>インストールと最初のステップ</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-log">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-log">
   <title>ログ記録</title>
 
   <variablelist>
@@ -125,11 +129,11 @@ Operations:
       * Node alice:</screen>
      </example>
      <para>
-      『<citetitle> Explained</citetitle> (Pacemaker )』PDF (<ulink url="http://www.clusterlabs.org/doc/"/>から入手可能)では、「How are OCF Return Codes Interpreted?」<citetitle/>セクションで3つの異なる復元タイプを説明しています。
+      『<citetitle> Explained</citetitle> (Pacemaker )』PDF (<link xlink:href="http://www.clusterlabs.org/doc/"/>から入手可能)では、「How are OCF Return Codes Interpreted?」<citetitle/>セクションで3つの異なる復元タイプを説明しています。
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-crm-report">
+   <varlistentry xml:id="vle-ha-crm-report">
     
     <term>すべてのクラスタノードの分析を含むレポートを作成するにはどうしたらよいですか。</term>
     <listitem>
@@ -235,8 +239,8 @@ Operations:
    </varlistentry>
    
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-resource">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-resource">
   <title>リソース</title>
 
   <variablelist>
@@ -304,8 +308,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-stonith">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-stonith">
   <title>STONITHとフェンシング</title>
 
   <variablelist>
@@ -346,8 +350,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-misc">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-misc">
   <title>その他</title>
 
   <variablelist>
@@ -424,12 +428,12 @@ Jan 12 16:04:22 alice modprobe: FATAL: Module ocfs2_stackglue not found.</screen
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-moreinfo">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-moreinfo">
   <title>その他の情報</title>
 
   <para>
-   クラスタリソースの設定、およびHigh Availabilityクラスタの管理とカスタマイズなど、Linuxの高可用性に関するその他の情報については、<ulink url="http://clusterlabs.org/wiki/Documentation"/>を参照してください。
+   クラスタリソースの設定、およびHigh Availabilityクラスタの管理とカスタマイズなど、Linuxの高可用性に関するその他の情報については、<link xlink:href="http://clusterlabs.org/wiki/Documentation"/>を参照してください。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/DC-SLE-ha-all
+++ b/zh_CN/DC-SLE-ha-all
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/zh_CN/DC-SLE-ha-guide
+++ b/zh_CN/DC-SLE-ha-guide
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/zh_CN/xml/MAIN.SLEHA.xml
+++ b/zh_CN/xml/MAIN.SLEHA.xml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<!DOCTYPE set PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE set>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<set lang="zh-cn">
- <title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 文档</title>
- <setinfo>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
- </setinfo>
+<set xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:lang="zh-cn"><title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 文档</title><info><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber></info>
+ 
+ 
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_haguide.xml" parse="xml"/>
+ <xi:include href="book_sle_haguide.xml" parse="xml"/>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_ha_techguides.xml" parse="xml"/>
+ <xi:include href="book_sle_ha_techguides.xml" parse="xml"/>
 </set>

--- a/zh_CN/xml/art_sle_ha_nfs_quick.xml
+++ b/zh_CN/xml/art_sle_ha_nfs_quick.xml
@@ -1,33 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE article PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE article>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<?provo dirname="nfs_quick/"?>
-<article xml:base="art_sle_ha_nfs_quick.xml" lang="en" id="art-ha-quick-nfs">
-<?suse-quickstart columns="no" version="2"?>
-
-
- <title>Highly Available NFS Storage with DRBD and Pacemaker</title>
- <subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle>
- <articleinfo>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productname role="abbrev">SLE HA</productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <authorgroup>
-   <author><firstname>Florian</firstname><surname>Haas</surname>
-   </author>
-   <author><firstname>Tanja</firstname><surname>Roth</surname>
-   </author>
-  </authorgroup>
- </articleinfo>
-
- <abstract>
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="art_sle_ha_nfs_quick.xml" xml:lang="en" xml:id="art-ha-quick-nfs"><?suse-quickstart columns="no" version="2"?><title>Highly Available NFS Storage with DRBD and Pacemaker</title><subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productname role="abbrev">SLE HA</productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><authorgroup>
+   <author><personname><firstname>Florian</firstname><surname>Haas</surname></personname></author>
+   <author><personname><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+  </authorgroup><abstract>
   <para os="sles">
    This document describes how to set up highly available NFS storage in a
    2-node cluster, using the following components that are shipped with
@@ -35,12 +20,20 @@ Please see LICENSE.txt for this document's license.
    (Logical Volume Manager version 2), and Pacemaker, the cluster resource
    management framework.
   </para>
- </abstract>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_intro_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_install_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_use_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_failover_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides_quick.xml" parse="xml"/>
+ </abstract></info>
+
+
+
+ 
+ 
+ 
+
+ 
+ <xi:include href="ha_nfs_quick_intro_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_install_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_config_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_use_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_failover_i.xml" parse="xml"/>
+ <xi:include href="copyright_techguides_quick.xml" parse="xml"/>
 </article>

--- a/zh_CN/xml/book_sle_ha_techguides.xml
+++ b/zh_CN/xml/book_sle_ha_techguides.xml
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml"
-                 title="Profiling step"?>
-<book xml:base="book_sle_ha_techguides.xml" lang="en" id="book-sleha-techguides">
- <bookinfo>
-  <title>Technical Guides</title><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
-<?dbtimestamp format="B d, Y"?></date>
-
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="art_sle_ha_nfs_quick.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_ha_techguides.xml" xml:lang="en" xml:id="book-sleha-techguides"><title>Technical Guides</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
+<?dbtimestamp format="B d, Y"?></date><xi:include href="copyright_techguides.xml" parse="xml"/></info>
+ 
+ <xi:include href="art_sle_ha_nfs_quick.xml" parse="xml"/>
  
 
 </book>

--- a/zh_CN/xml/book_sle_haguide.xml
+++ b/zh_CN/xml/book_sle_haguide.xml
@@ -1,61 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<?provo dirname="ha/"?>
-<book xml:base="book_sle_haguide.xml" lang="zh-cn" id="book-sleha">
- <bookinfo>
-  <title>高可用性指南</title>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_copyright_gfdl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_authors.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_intro.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_haguide.xml" xml:lang="zh-cn" xml:id="book-sleha"><title>高可用性指南</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date><xi:include href="common_copyright_gfdl.xml" parse="xml"/><xi:include href="ha_authors.xml" parse="xml"/></info>
+ 
+ <xi:include href="ha_intro.xml" parse="xml"/>
 
 
 
- <part id="part-install">
-  <title>安装和设置</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_concepts.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_requirements.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_installation.xml" parse="xml"/>
+ <part xml:id="part-install"><title>安装和设置</title><info/>
+  
+  <xi:include href="ha_concepts.xml" parse="xml"/>
+  <xi:include href="ha_requirements.xml" parse="xml"/>
+  <xi:include href="ha_installation.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-config">
-  <title>配置和管理</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_basics.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_hawk.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_gui.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_cli.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_agents.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_fencing.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_acl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_netbonding.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_lvs.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_geocluster.xml" parse="xml"/>
+ <part xml:id="part-config"><title>配置和管理</title><info/>
+  
+  <xi:include href="ha_config_basics.xml" parse="xml"/>
+  <xi:include href="ha_config_hawk.xml" parse="xml"/>
+  <xi:include href="ha_config_gui.xml" parse="xml"/>
+  <xi:include href="ha_config_cli.xml" parse="xml"/>
+  <xi:include href="ha_agents.xml" parse="xml"/>
+  <xi:include href="ha_fencing.xml" parse="xml"/>
+  <xi:include href="ha_acl.xml" parse="xml"/>
+  <xi:include href="ha_netbonding.xml" parse="xml"/>
+  <xi:include href="ha_lvs.xml" parse="xml"/>
+  <xi:include href="ha_geocluster.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-storage">
-  <title>储存和数据复制</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_ocfs2.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_drbd.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_clvm.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_storage_protection.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_samba.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_rear.xml" parse="xml"/>
+ <part xml:id="part-storage"><title>储存和数据复制</title><info/>
+  
+  <xi:include href="ha_ocfs2.xml" parse="xml"/>
+  <xi:include href="ha_drbd.xml" parse="xml"/>
+  <xi:include href="ha_clvm.xml" parse="xml"/>
+  <xi:include href="ha_storage_protection.xml" parse="xml"/>
+  <xi:include href="ha_samba.xml" parse="xml"/>
+  <xi:include href="ha_rear.xml" parse="xml"/>
  </part>
   
   
@@ -63,17 +55,17 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <part id="part-appendix">
-  <title>附录</title>
+ <part xml:id="part-appendix"><title>附录</title><info/>
   
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_troubleshooting.xml" parse="xml"/>
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_naming.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_management.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_migration.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_news.xml" parse="xml"/>
+  
+  <xi:include href="ha_troubleshooting.xml" parse="xml"/>
+   <xi:include href="ha_naming.xml" parse="xml"/>
+  <xi:include href="ha_example.xml" parse="xml"/>
+  <xi:include href="ha_config_example.xml" parse="xml"/>
+  <xi:include href="ha_management.xml" parse="xml"/>
+  <xi:include href="ha_migration.xml" parse="xml"/>
+  <xi:include href="ha_news.xml" parse="xml"/>
  </part>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_glossary.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_legal.xml" parse="xml"/>
+ <xi:include href="ha_glossary.xml" parse="xml"/>
+ <xi:include href="common_legal.xml" parse="xml"/>
 </book>

--- a/zh_CN/xml/common_copyright_gfdl.xml
+++ b/zh_CN/xml/common_copyright_gfdl.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="common_copyright_gfdl.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="common_copyright_gfdl.xml">
  <para>
   版权所有 © 2006–<?dbtimestamp format="Y"?>
 
@@ -16,7 +20,7 @@ Please see LICENSE.txt for this document's license.
   根据 GNU 自由文档许可证 (GNU Free Documentation License) 版本 1.2 或（根据您的选择）版本 1.3 中的条款，在此授予您复制、分发和/或修改本文档的许可权限；本版权声明和许可证附带不可变部分。许可证版本 1.2 的副本包含在题为<quote>GNU 自由文档许可证</quote>的部分。
  </para>
  <para>
-  有关 SUSE 或 Novell 商标，请参见 Novell 商标和服务标记列表 <ulink url="http://www.novell.com/company/legal/trademarks/tmlist.html"/>。所有第三方商标均属其各自所有者的财产。商标符号（®、™ 等）代表 SUSE 或 Novell 商标；星号 (*) 代表第三方商标。
+  有关 SUSE 或 Novell 商标，请参见 Novell 商标和服务标记列表 <link version="5.1" xlink:href="http://www.novell.com/company/legal/trademarks/tmlist.html"/>。所有第三方商标均属其各自所有者的财产。商标符号（®、™ 等）代表 SUSE 或 Novell 商标；星号 (*) 代表第三方商标。
  </para>
  <para>
   本指南力求涵盖所有细节。但这并不确保本指南准确无误。SUSE LLC 及其附属公司、作者和译者对于可能出现的错误或由此造成的后果皆不承担责任。

--- a/zh_CN/xml/common_gfdl1.2_i.xml
+++ b/zh_CN/xml/common_gfdl1.2_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml" 
-                 title="Profiling step"?>
-<sect1 xml:base="common_gfdl1.2_i.xml" role="legal">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_gfdl1.2_i.xml" role="legal">
  <title>GNU Free Documentation License</title>
 
  <para>
@@ -498,7 +499,7 @@ Please see LICENSE.txt for this document's license.
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to
   address new problems or concerns. See
-  <ulink url="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</ulink>.
+  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>
@@ -548,4 +549,4 @@ Please see LICENSE.txt for this document's license.
   software license, such as the GNU General Public License, to permit their
   use in free software.
  </para>
-</sect1>
+</section>

--- a/zh_CN/xml/common_intro_feedback_i.xml
+++ b/zh_CN/xml/common_intro_feedback_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_feedback_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_feedback_i.xml">
  <title>反馈</title>
 
  <para>
@@ -18,10 +22,10 @@ Please see LICENSE.txt for this document's license.
    <term>Bug 和增强请求</term>
    <listitem>
     <para>
-     有关产品可用的服务和支持选项，请参见 <ulink url="http://www.suse.com/support/"/>。
+     有关产品可用的服务和支持选项，请参见 <link xlink:href="http://www.suse.com/support/"/>。
     </para>
     <para>
-     要报告产品组件的 bug，请从 <ulink url="http://www.suse.com/support/"/> 登录 Novell Customer Center，然后选择<menuchoice> <guimenu>我的支持</guimenu> <guimenu>服务请求</guimenu> </menuchoice>。
+     要报告产品组件的 bug，请从 <link xlink:href="http://www.suse.com/support/"/> 登录 Novell Customer Center，然后选择<menuchoice> <guimenu>我的支持</guimenu> <guimenu>服务请求</guimenu> </menuchoice>。
     </para>
    </listitem>
   </varlistentry>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    <term>用户意见</term>
    <listitem>
     <para>
-     我们希望收到您对本手册和本产品中包含的其他文档的意见和建议。请使用联机文档每页底部的“用户注释”功能或转到 <ulink url="http://www.suse.com/doc/feedback.html"/> 并在此处输入注释。
+     我们希望收到您对本手册和本产品中包含的其他文档的意见和建议。请使用联机文档每页底部的“用户注释”功能或转到 <link xlink:href="http://www.suse.com/doc/feedback.html"/> 并在此处输入注释。
 
     </para>
    </listitem>
@@ -43,4 +47,4 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </varlistentry>
  </variablelist>
-</sect1>
+</section>

--- a/zh_CN/xml/common_intro_making_i.xml
+++ b/zh_CN/xml/common_intro_making_i.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_making_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_making_i.xml">
  <title>关于本手册的制作</title>
 
  <para>
-  本书用 Novdoc（DocBook 的子集，请参见 <ulink url="http://www.docbook.org"/>）编写。XML 源文件用 <command>xmllint</command> 校验、用 <command>xsltproc</command> 处理，并用 Norman Walsh 的样式表的自定义版本转换为 XSL-FO。最终的 PDF 由 RenderX 通过 XEP 排版。 
+  本书用 Novdoc（DocBook 的子集，请参见 <link xlink:href="http://www.docbook.org"/>）编写。XML 源文件用 <command>xmllint</command> 校验、用 <command>xsltproc</command> 处理，并用 Norman Walsh 的样式表的自定义版本转换为 XSL-FO。最终的 PDF 由 RenderX 通过 XEP 排版。 
  </para>
-</sect1>
+</section>

--- a/zh_CN/xml/common_intro_typografie_i.xml
+++ b/zh_CN/xml/common_intro_typografie_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_typografie_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_typografie_i.xml">
 
 
  <title>文档约定</title>
@@ -64,4 +68,4 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
-</sect1>
+</section>

--- a/zh_CN/xml/common_legal.xml
+++ b/zh_CN/xml/common_legal.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="common_legal.xml" role="legal">
- <title>GNU 许可证</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_legal.xml" role="legal"><title>GNU 许可证</title><info/>
+ 
  <para>
   此附录包含 GNU 自由文档许可证版本 1.2。
  </para>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_gfdl1.2_i.xml" parse="xml"/>
+ <xi:include href="common_gfdl1.2_i.xml" parse="xml"/>
 </appendix>

--- a/zh_CN/xml/copyright_techguides.xml
+++ b/zh_CN/xml/copyright_techguides.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="copyright_techguides.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="copyright_techguides.xml">
  <para>
   Copyright © 2011 Novell Inc., doc-team@suse.de. Used with
   permission.
@@ -31,12 +35,12 @@ Please see LICENSE.txt for this document's license.
   </para>
  </formalpara>
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link version="5.1" xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
 </legalnotice>

--- a/zh_CN/xml/copyright_techguides_quick.xml
+++ b/zh_CN/xml/copyright_techguides_quick.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="copyright_techguides_quick.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="copyright_techguides_quick.xml">
  <title>Legal Notice</title>
 
  <para>
@@ -37,13 +41,13 @@ Please see LICENSE.txt for this document's license.
  </formalpara>
 
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
 
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
-</sect1>
+</section>

--- a/zh_CN/xml/ha_acl.xml
+++ b/zh_CN/xml/ha_acl.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_acl.xml" id="cha-ha-acl">
- <title>访问控制列表</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_acl.xml" xml:id="cha-ha-acl"><title>访问控制列表</title><info><abstract>
   <para>
    crm 外壳 (crmsh)、Hawk 或 Pacemaker GUI 等群集管理工具可由 <systemitem class="username">root</systemitem> 用户或 <systemitem class="groupname">haclient</systemitem> 组内的任何用户使用。默认情况下，这些用户具有完全读/写访问权。要限制访问权或指派更加细化的访问权限，可以使用<emphasis>访问控制列表</emphasis> (ACL)。
   </para>
@@ -15,14 +17,16 @@ Please see LICENSE.txt for this document's license.
   <para>
    访问控制列表由一组有序的访问规则构成。每个规则针对一部分群集配置赋予用户读取或写入访问权限，或拒绝其访问。规则通常会组合在一起产生特定角色，然后可以为用户指派与其任务匹配的角色。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  
  <note>
   <title>CIB 验证版本和 ACL 的差异</title>
   <para>仅当您的 CIB 是使用 <literal>pacemaker-2.0</literal> 或更高 CIB 语法版本验证的情况下，此 ACL 文档才适用。有关如何查验这一点以及升级 CIB 版本的细节，请参见<xref linkend="note-ha-cib-upgrade"/>。 </para>
-  <para>如果您已从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级并保留了以前的 CIB 版本，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的“<citetitle>访问控制列表</citetitle>”一章。网址：<ulink url="http://www.suse.com/documentation/"/>。</para>
+  <para>如果您已从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级并保留了以前的 CIB 版本，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的“<citetitle>访问控制列表</citetitle>”一章。网址：<link xlink:href="http://www.suse.com/documentation/"/>。</para>
  </note>
- <sect1 id="sec-ha-acl-require">
+ <section xml:id="sec-ha-acl-require">
   <title>要求和先决条件</title>
 
   <para>
@@ -74,10 +78,10 @@ Please see LICENSE.txt for this document's license.
   </important>
 
   <para>
-   要使用 ACL，需要具备一些关于 XPath 的知识。XPath 是在 XML 文档中选择节点所用的语言。请参见 <ulink url="http://en.wikipedia.org/wiki/XPath"/> 或查找位于 <ulink url="http://www.w3.org/TR/xpath/"/> 的规范。
+   要使用 ACL，需要具备一些关于 XPath 的知识。XPath 是在 XML 文档中选择节点所用的语言。请参见 <link xlink:href="http://en.wikipedia.org/wiki/XPath"/> 或查找位于 <link xlink:href="http://www.w3.org/TR/xpath/"/> 的规范。
   </para>
- </sect1>
- <sect1 id="sec-ha-acl-enable">
+ </section>
+ <section xml:id="sec-ha-acl-enable">
   <title>在群集中启用 ACL</title>
 
   <para>
@@ -90,31 +94,31 @@ Please see LICENSE.txt for this document's license.
    也可以根据<xref linkend="pro-ha-acl-enable-hawk"/>中所述使用 Hawk。
   </para>
 
-  <procedure id="pro-ha-acl-enable-hawk">
+  <procedure xml:id="pro-ha-acl-enable-hawk">
    <title>使用 Hawk 启用 ACL</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集属性</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <guimenu>CRM 配置</guimenu>组中，从空下拉框中选择 <guimenu>enable-acl</guimenu> 属性，然后单击加号图标添加该属性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要设置 <literal>enable-acl=true</literal>，请激活 <literal>enable-acl</literal> 旁边的复选框，并确认您所做的更改。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-basics">
+ </section>
+ <section xml:id="sec-ha-acl-basics">
   <title>ACL 的基本原理</title>
 
   <para>
@@ -151,14 +155,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <sect2 id="sec-ha-acl-config-xpath">
+  <section xml:id="sec-ha-acl-config-xpath">
    <title>通过 XPath 表达式设置 ACL 规则</title>
    <para>
     要通过 XPath 管理 ACL 规则，需要知道基础 XML 的结构。可使用以下命令来检索结构（该命令将显示 XML 格式的群集配置，请参见<xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>）：
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure show xml</screen>
    
-   <example id="ex-ha-acl-excerpt">
+   <example xml:id="ex-ha-acl-excerpt">
     <title>XML 格式群集配置摘录</title>
 <screen>&lt;num_updates="59" 
       dc-uuid="175704363"
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     例如，<xref linkend="tab-ha-acl-operator"/>显示了用于创建<quote>操作员</quote>角色的参数（访问类型和 XPath 表达式）。具有此角色的用户只能执行第二列中所述的任务 - 他们既不能重新配置任何资源（例如，更改参数或操作），也不能更改共置约束或顺序约束的配置。
    </para>
-   <table id="tab-ha-acl-operator">
+   <table xml:id="tab-ha-acl-operator">
     <title>Operator 角色 - 访问类型和 XPath 表达式</title>
     <tgroup cols="2">
      <thead>
@@ -305,10 +309,10 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
   
-   <sect2 id="sec-ha-acl-config-tag">
+   <section xml:id="sec-ha-acl-config-tag">
    <title>通过缩写设置 ACL 规则</title>
    <para>
     对于不想使用 XML 结构的用户，有一种更简单的方法。 
@@ -331,51 +335,51 @@ Please see LICENSE.txt for this document's license.
     可以在 crmsh 和 Hawk 中使用缩写语法。CIB 守护程序知道如何将 ACL 规则应用到匹配的对象。
    </para>
    
-   </sect2>
-  </sect1>
- <sect1 id="sec-ha-acl-config-hbgui">
+   </section>
+  </section>
+ <section xml:id="sec-ha-acl-config-hbgui">
   <title>使用 Pacemaker GUI 配置 ACL</title>
 
   <para> 以下过程说明如何通过定义 <literal>monitor</literal> 角色并将其指派给用户，来配置对群集配置的只读访问权。您也可以根据<xref linkend="sec-ha-acl-config-hawk"/>和<xref linkend="pro-ha-acl-crm"/>所述使用 Hawk 或 crmsh 来实现此目的。 </para>
 
-  <procedure id="pro-ha-acl-hbgui">
+  <procedure xml:id="pro-ha-acl-hbgui">
    <title>使用 Pacemaker GUI 添加监视者角色和指派用户</title>
-   <step performance="required">
+   <step>
     <para>
      如<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>配置</guimenu>树中的 <guimenu>ACL</guimenu> 条目。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>添加</guimenu>。将显示一个对话框。选择 <guimenu>ACL 目标</guimenu>或 <guimenu>ACL 角色</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定义 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        选择 <guimenu>ACL 角色</guimenu>。将打开一个窗口，可在其中添加配置选项。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-id" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-id">
       <para>
        在 <guimenu>ID</guimenu> 文本字段中添加唯一标识符，例如 <literal>monitor</literal>。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-add" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-add">
       <para>
        单击<guimenu>添加</guimenu>并选择权限（<guimenu>读</guimenu>、<guimenu>写</guimenu>或<guimenu>拒绝</guimenu>）。本示例中选择<guimenu>读</guimenu>。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-xpath" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-xpath">
       <para>
        在 <guimenu>Xpath</guimenu> 文本字段中输入 XPath 表达式 <literal>/cib</literal>。单击<guimenu>确定</guimenu>继续。
       </para>
@@ -383,34 +387,34 @@ Please see LICENSE.txt for this document's license.
        旁注：如果具有资源或约束，还可使用<xref linkend="sec-ha-acl-config-tag"/>中所述的缩写语法。 
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果有其他条件，请重复步骤（<xref linkend="st-ha-acl-config-hbgui-add"/>和<xref linkend="st-ha-acl-config-hbgui-xpath"/>）。在本例中，并没有其他条件，因此角色完成，可以按<guimenu>确定</guimenu>关闭窗口。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      将角色指派给用户：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        单击<guimenu>添加</guimenu>按钮。一个对话框即会显示，您可在其中选择 <guimenu>ACL 目标</guimenu>或 <guimenu>ACL 角色</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        选择 <guimenu>ACL 目标</guimenu>。将打开一个窗口，可在其中添加配置选项。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 <guimenu>ID</guimenu> 文本字段中输入用户名。确保此用户属于 <systemitem class="groupname">haclient</systemitem> 组。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        单击并使用<xref linkend="st-ha-acl-config-hbgui-id"/>中指定的角色名称。
       </para>
@@ -418,47 +422,47 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-config-hawk">
+ </section>
+ <section xml:id="sec-ha-acl-config-hawk">
   <title>使用 Hawk 配置 ACL</title>
   
   <para>
    以下过程说明如何通过定义 <literal>monitor</literal> 角色并将其指派给用户，来配置对群集配置的只读访问权。您也可以根据<xref linkend="pro-ha-acl-crm"/>中所述使用 crmsh 来实现此目的。
   </para>
   
-  <procedure id="pro-ha-acl-hawk">
+  <procedure xml:id="pro-ha-acl-hawk">
    <title>使用 Hawk 添加 Monitor 角色并指派用户</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>访问控制列表</guimenu>。视图将显示已定义的<guimenu>角色</guimenu>和<guimenu>用户</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定义 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        选择<guimenu>角色</guimenu>类别，然后单击加号图标。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        输入唯一的<guimenu>角色 ID</guimenu>，例如 <literal>monitor</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        本示例是要定义一个 <literal>monitor</literal> 角色，因此请从<guimenu>权限</guimenu>下拉框中选择<literal>读</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 <guimenu>Xpath</guimenu> 文本框中，输入 Xpath 表达式 <literal>/cib</literal> 并单击<guimenu>创建角色</guimenu>。
       </para>
@@ -466,19 +470,19 @@ Please see LICENSE.txt for this document's license.
        这将会创建名为 <literal>monitor</literal> 的新角色，为其设置<literal>读</literal>权限并通过使用 XPath 表达式 <literal>/cib</literal> 将其应用到 CIB 中的所有元素。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果需要，可以通过单击加号图标并指定相应的参数，来添加更多的访问权限和 XPath 自变量。确认更改。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      将角色指派给用户:
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        选择<guimenu>用户</guimenu>类别，然后单击加号图标。
       </para>
@@ -486,12 +490,12 @@ Please see LICENSE.txt for this document's license.
        <guimenu>创建用户</guimenu>视图中会显示可用的角色。此外，该视图中还包含一个附加行用于配置该用户的个别 ACL 规则。在该视图中，您可以向用户指派一个或多个角色，<emphasis>或者</emphasis>为该用户定义一个或多个不同的规则。选择某个角色后各规则对应的行将会消失；取消选择后，该行将会显示。无法同时指派角色和定义各个规则。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        输入唯一的<guimenu>用户 ID</guimenu>，例如 <literal>tux</literal>。确保此用户属于 <systemitem class="groupname">haclient</systemitem> 组。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要将角色指派给用户，请从<guimenu>角色</guimenu>中选择相应的条目。对于本示例，请选择您创建的 <literal>monitor</literal> 角色。
       </para>
@@ -510,12 +514,12 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </figure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果想要定义单个规则，请选择<guimenu>权限</guimenu>并为该规则输入相应的 Xpath 参数。单击加号图标可定义更多规则。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确认您的选择，然后单击<guimenu>创建用户</guimenu>将角色或规则指派给用户。
       </para>
@@ -527,35 +531,35 @@ Please see LICENSE.txt for this document's license.
   <para>
    要配置资源或约束的访问权限，还可使用<xref linkend="sec-ha-acl-config-tag"/>中所述的缩写语法。 
   </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-acl-config-crm">
+ <section xml:id="sec-ha-acl-config-crm">
   <title>使用 crmsh 配置 ACL</title>
 
   <para>
    以下过程说明如何通过定义 <literal>monitor</literal> 角色并将其指派给用户，来配置对群集配置的只读访问权。
   </para>
 
-  <procedure id="pro-ha-acl-crm">
+  <procedure xml:id="pro-ha-acl-crm">
    <title>使用 crmsh 添加 Monitor 角色并指派用户</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身份登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      启动 crmsh 的交互模式：
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure
 <prompt role="custom">crm(live)configure# </prompt></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定义 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        使用 <command>role</command> 命令定义新角色：
       </para>
@@ -564,26 +568,26 @@ Please see LICENSE.txt for this document's license.
        上面的命令会创建名为 <literal>monitor</literal> 的新角色，为其设置<literal>读</literal>权限并通过使用 XPath 表达式 <literal>/cib</literal> 将其应用到 CIB 中的所有元素。如有必要，可添加更多访问权限和 XPath 自变量。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        根据需要添加其他角色。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      将角色指派给一个或多个 ACL 目标，即相应的系统用户。确保这些目标属于 <systemitem class="groupname">haclient</systemitem> 组。
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>acl_target</command> tux monitor</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      检查更改：
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      提交更改：
     </para>
@@ -594,6 +598,6 @@ Please see LICENSE.txt for this document's license.
   <para>
    要配置资源或约束的访问权限，还可使用<xref linkend="sec-ha-acl-config-tag"/>中所述的缩写语法。 
   </para>
- </sect1>
+ </section>
  
 </chapter>

--- a/zh_CN/xml/ha_agents.xml
+++ b/zh_CN/xml/ha_agents.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_agents.xml" id="cha-ha-agents">
- <title>添加或修改资源代理</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_agents.xml" xml:id="cha-ha-agents"><title>添加或修改资源代理</title><info><abstract>
   <para>
    需由群集管理的所有任务都必须可用作资源。在此处需要考虑两个主要组：资源代理和 STONITH 代理。对于这两个类别，您都可以添加自己的代理，根据需要扩展群集的功能。
   </para>
- </abstract>
- <sect1 id="sec-ha-stonithagents">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-stonithagents">
   <title>STONITH 代理</title>
 
   <para>
@@ -33,8 +37,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    目前尚无有关写入 STONITH 代理的文档。如果要写入新的 STONITH 代理，请参见 <systemitem class="resource">cluster-glue</systemitem> 包的源中提供的示例。
   </para>
- </sect1>
- <sect1 id="sec-ha-writingresourceagents">
+ </section>
+ <section xml:id="sec-ha-writingresourceagents">
   <title>写入 OCF 资源代理</title>
 
   <para>
@@ -103,18 +107,18 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      将文件 <filename>/usr/lib/ocf/resource.d/pacemaker/Dummy</filename> 装载为模板。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      为每个新资源代理创建新的子目录，以避免发生命名冲突。例如，如果您的一个资源组 <literal>kitchen</literal> 具有资源 <literal>coffee_machine</literal>，可将此资源添加到目录 <filename>/usr/lib/ocf/resource.d/kitchen/</filename>。要访问此资源代理，请执行命令 <command>crm</command>：
     </para>
 <screen><command>configure</command><command>primitive</command> coffee_1 <emphasis>ocf:coffee_machine:kitchen</emphasis> ...</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      实施其他外壳功能，并用不同名称保存文件。
     </para>
@@ -122,8 +126,8 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
   <para>
-   可在 <ulink url="http://linux-ha.org/wiki/Resource_Agents"/> 中找到有关写入 OCF 资源代理的更多细节。在<xref linkend="cha-ha-concepts"/>中可以找到有关若干概念的特殊信息。
+   可在 <link xlink:href="http://linux-ha.org/wiki/Resource_Agents"/> 中找到有关写入 OCF 资源代理的更多细节。在<xref linkend="cha-ha-concepts"/>中可以找到有关若干概念的特殊信息。
   </para>
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_error_codes.xml" parse="xml"/>
+ </section>
+ <xi:include href="ha_error_codes.xml" parse="xml"/>
 </chapter>

--- a/zh_CN/xml/ha_authors.xml
+++ b/zh_CN/xml/ha_authors.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE authorgroup PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE authorgroup>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<authorgroup xml:base="ha_authors.xml">
- <author><firstname>Tanja</firstname><surname>Roth</surname>
- </author>
- <author><firstname>Thomas</firstname><surname>Schraitle</surname>
- </author>
+<authorgroup xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="ha_authors.xml">
+ <author><personname version="5.1"><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+ <author><personname version="5.1"><firstname>Thomas</firstname><surname>Schraitle</surname></personname></author>
 </authorgroup>

--- a/zh_CN/xml/ha_clvm.xml
+++ b/zh_CN/xml/ha_clvm.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_clvm.xml" id="cha-ha-clvm">
- <title>群集式逻辑卷管理器 (cLVM)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_clvm.xml" xml:id="cha-ha-clvm"><title>群集式逻辑卷管理器 (cLVM)</title><info><abstract>
   <para>
    当管理群集上的共享储存区时，所有节点必须收到有关对储存子系统所做更改的通知。Linux 卷管理器 2 (LVM2) 广泛用于管理本地储存，已扩展为支持对整个群集中的卷组进行透明管理。可使用与本地储存相同的命令来管理群集卷组。
   </para>
- </abstract>
- <sect1 id="sec-ha-clvm-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-clvm-overview">
   <title>概念概述</title>
 
 
@@ -47,8 +51,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-clvm-config">
+ </section>
+ <section xml:id="sec-ha-clvm-config">
   <title>cLVM 配置</title>
 
   <para>
@@ -117,7 +121,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect2 id="sec-ha-clvm-config-cmirrord">
+  <section xml:id="sec-ha-clvm-config-cmirrord">
    <title>配置 Cmirrord</title>
 
    <para>
@@ -127,12 +131,12 @@ Please see LICENSE.txt for this document's license.
     假定 <filename>/dev/sda</filename> 和 <filename>/dev/sdb</filename> 是共享储存设备。必要时请使用您自己的设备名称替换上述名称。按如下所示继续：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       创建一个至少包含两个节点的群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       配置群集以运行 <command>dlm</command>、<command>clvmd</command> 和 STONITH：
      </para>
@@ -150,12 +154,12 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>clone</command> base-clone base-group \
         meta interleave="true"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>exit</command> 退出 crmsh 并提交更改。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       创建群集卷组 (VG)：
 
@@ -163,45 +167,45 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> -cy vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在群集中创建镜像日志逻辑卷 (LV)：
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> -nlv -m1 -l10%VG vg --mirrorlog mirrored</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>lvs</command> 显示进度。如果百分数已达到 100%，则表示镜像磁盘已成功同步。
      </para>
     </step>
-    <step id="st-ha-clvm-config-cmirrord-test" performance="required">
+    <step xml:id="st-ha-clvm-config-cmirrord-test">
      <para>
       要测试群集卷 <filename>/dev/vg/lv</filename>，请执行下列步骤：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         读取或写入到 <filename>/dev/vg/lv</filename>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvchange</command> <option>-an</option> 停用 LV。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvchange</command> <option>-ay</option> 激活 LV。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvconvert</command> 将镜像日志转换为磁盘日志。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在其他群集 VG 中创建镜像日志 LV。此卷组与先前的卷组不同。
      </para>
@@ -216,20 +220,20 @@ Please see LICENSE.txt for this document's license.
    </para>
    <procedure>
 
-    <step performance="required">
+    <step>
      <para>
       创建卷组 (VG)：
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       打开文件 <filename>/etc/lvm/lvm.conf</filename> 并转到 <literal>allocation</literal> 部分。设置下列行并保存文件：
      </para>
 <screen>mirror_legs_require_separate_pvs = 1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       将标记添加到 PV：
      </para>
@@ -239,7 +243,7 @@ Please see LICENSE.txt for this document's license.
       标记是无序的关键字或指派给储存对象元数据的术语。使用标记功能可以采用您认为有用的方式将无序的标记列表附加到 LVM 储存对象元数据，从而对储存对象集合进行分类。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       列出标记：
      </para>
@@ -253,11 +257,11 @@ Please see LICENSE.txt for this document's license.
     </step>
    </procedure>
    <para>
-    如需有关 LVM 的更多信息，请参见《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>储存管理指南</citetitle>》中的“<citetitle>LVM 配置</citetitle>”一章，网址：<ulink url="http://www.suse.com/documentation/"/>。
+    如需有关 LVM 的更多信息，请参见《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>储存管理指南</citetitle>》中的“<citetitle>LVM 配置</citetitle>”一章，网址：<link xlink:href="http://www.suse.com/documentation/"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-config-resources">
+  <section xml:id="sec-ha-clvm-config-resources">
    <title>创建群集资源</title>
    <para>
     准备群集以便使用 cLVM 包括以下基本步骤：
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-clvm-dlmresource">
+   <procedure xml:id="pro-ha-clvm-dlmresource">
     <title>创建 DLM 资源</title>
 
     <note>
@@ -283,22 +287,22 @@ Please see LICENSE.txt for this document's license.
       cLVM 和 OCFS2 都需要一个在群集中的所有节点上运行的 DLM 资源，因而通常配置为一个克隆。如果设置既包括 OCFS2 也包括 cLVM，则为 OCFS2 和 cLVM 配置<emphasis>一个</emphasis> DLM 资源就足够了。
      </para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份启动外壳并登录。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      运行 <command>crm <option>configure</option></command>。
+      运行 <command>crm</command> <option>configure</option>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>show</command> 检查群集资源的当前配置。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果已经配置 DLM 资源（及相应的基本组和基本克隆），则继续<xref linkend="pro-ha-clvm-lvmresources"/>。
      </para>
@@ -306,25 +310,25 @@ Please see LICENSE.txt for this document's license.
       否则，如<xref linkend="pro-ocfs2-resources"/>中所述配置 DLM 资源和相应的基本组和基本克隆。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>exit</command> 保留 crm 当前配置。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-clvm-lvmresources">
+   <procedure xml:id="pro-ha-clvm-lvmresources">
     <title>创建 LVM 和 cLVM 资源</title>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份启动外壳并登录。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      运行 <command>crm <option>configure</option></command>。
+      运行 <command>crm</command> <option>configure</option>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如下所示配置 cLVM 资源：
      </para>
@@ -333,7 +337,7 @@ Please see LICENSE.txt for this document's license.
 
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       如下所示为卷组配置 LVM 资源：
      </para>
@@ -341,7 +345,7 @@ Please see LICENSE.txt for this document's license.
       params volgrpname="cluster-vg" \
       op monitor interval="60" timeout="60"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果希望仅在<emphasis>一个</emphasis>节点上激活卷组，则如下所述配置 LVM 资源并忽略<xref linkend="step-ha-clvm-lvmresources-group"/>：
      </para>
@@ -352,18 +356,18 @@ Please see LICENSE.txt for this document's license.
       在这种情况下，cLVM 将保护 VG 内的所有逻辑卷，防止它们在多个节点上激活，这也是非群集应用程序的一种附加保护措施。
      </para>
     </step>
-    <step id="step-ha-clvm-lvmresources-group" performance="required">
+    <step xml:id="step-ha-clvm-lvmresources-group">
      <para>
       要确保在群集范围内激活 cLVM 和 LVM 资源，请向在<xref linkend="pro-ocfs2-resources"/>中创建的基本组添加这两个原始资源：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         输入
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>edit</command> base-group</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在打开的 vi 编辑器中，如下所示修改组并保存更改：
        </para>
@@ -377,25 +381,25 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>show</command> 复查更改。要检查是否配置了所有需要的资源，另请参考<xref linkend="cha-ha-config-example"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果全部都正确，则使用 <command>commit</command> 提交更改，并使用 <command>exit</command> 退出 crm 当前配置。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-scenario-iscsi">
+  <section xml:id="sec-ha-clvm-scenario-iscsi">
    <title>方案：iSCSI 在 SAN 上的 cLVM</title>
    <para>
     以下方案使用两个 SAN 盒，将其 iSCSI 目标导出到多个客户端。大致想法如<xref linkend="fig-ha-clvm-scenario-iscsi"/>所示。
    </para>
-   <figure id="fig-ha-clvm-scenario-iscsi">
+   <figure xml:id="fig-ha-clvm-scenario-iscsi">
     <title>设置使用 cLVM 的 iSCSI</title>
     <mediaobject>
      <imageobject role="fo">
@@ -416,80 +420,80 @@ Please see LICENSE.txt for this document's license.
     首先只配置一个 SAN 盒。每个 SAN Box 都需要导出自己的 iSCSI 目标。按如下所示继续：
    </para>
 
-   <procedure id="pro-ha-clvm-scenario-iscsi-targets">
+   <procedure xml:id="pro-ha-clvm-scenario-iscsi-targets">
     <title>配置 iSCSI 目标 (SAN)</title>
-    <step performance="required">
+    <step>
      <para>
       运行 YaST，然后单击<menuchoice> <guimenu>网络服务</guimenu> <guimenu>iSCSI 目标</guimenu> </menuchoice>以启动 iSCSI 服务器模块。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要在计算机引导时启动 iSCSI 目标，请选择<guimenu>引导时</guimenu>，否则请选择<guimenu>手动</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果正在运行防火墙，请启用<guimenu>打开防火墙中的端口</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切换到<guimenu>全局</guimenu>选项卡。如果需要身份验证，请启用进来的和/或出去的身份验证。在本例中，我们选择<guimenu>无身份验证</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       添加新的 iSCSI 目标：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         切换到<guimenu>目标</guimenu>选项卡。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         单击<guimenu>添加</guimenu>。
        </para>
       </step>
-      <step id="st-ha-clvm-iscsi-iqn" performance="required">
+      <step xml:id="st-ha-clvm-iscsi-iqn">
        <para>
         输入目标名称。名称需要采用如下所示的格式：
        </para>
 <screen>iqn.<replaceable>DATE</replaceable>.<replaceable>DOMAIN</replaceable></screen>
        <para>
-        有关格式的更多信息，请参见 <citetitle>3.2.6.3.1. Type "iqn." (iSCSI Qualified Name)</citetitle>（3.2.6.3.1.“iqn.”（iSCSI 限定名称）类型）一节，网址：<ulink url="http://www.ietf.org/rfc/rfc3720.txt"/>。
+        有关格式的更多信息，请参见 <citetitle>3.2.6.3.1. Type "iqn." (iSCSI Qualified Name)</citetitle>（3.2.6.3.1.“iqn.”（iSCSI 限定名称）类型）一节，网址：<link xlink:href="http://www.ietf.org/rfc/rfc3720.txt"/>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果需要描述性更强的名称，可以进行更改，但要确保不同目标之间的标识符是唯一的。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         单击<guimenu>添加</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>路径</guimenu>中输入设备名，并使用 <guimenu>Scsiid</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         单击<guimenu>下一步</guimenu>两次。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       出现警告框时单击<guimenu>是</guimenu>进行确认。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       打开配置文件 <filename>/etc/iscsi/iscsi.conf</filename>，并将参数 <literal>node.startup</literal> 更改为 <literal>automatic</literal>。
      </para>
@@ -498,71 +502,71 @@ Please see LICENSE.txt for this document's license.
    <para>
     现在按如下方式设置 iSCSI 发起程序：
    </para>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-initiator">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-initiator">
     <title>配置 iSCSI 发起程序</title>
-    <step performance="required">
+    <step>
      <para>
       运行 YaST，然后单击<menuchoice> <guimenu>网络服务</guimenu> <guimenu>iSCSI 发起程序</guimenu> </menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要在计算机引导时启动 iSCSI 发起程序，请选择<guimenu>引导时</guimenu>，否则请将其设置为<guimenu>手动</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切换到<guimenu>发现</guimenu>选项卡并单击<guimenu>发现</guimenu>按钮。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       添加 iSCSI 目标的 IP 地址和端口（请参见<xref linkend="pro-ha-clvm-scenario-iscsi-targets"/>）。通常，可以保留端口并使用其默认值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用身份验证，请插入进来的和出去的用户名和口令，否则请激活<guimenu>无身份验证</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择<guimenu>下一步</guimenu>。找到的连接随即显示在列表中。
      </para>
     </step>
     
-    <step performance="required">
+    <step>
      <para>要测试 iSCSI 发起程序是否已成功启动，请选择显示的目标之一，然后单击<guimenu>登录</guimenu>。</para>
     </step>
 
    </procedure>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-lvm">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-lvm">
     <title>创建 LVM 卷组</title>
-    <step performance="required">
+    <step>
      <para>
       打开已按<xref linkend="pro-ha-clvm-scenarios-iscsi-initiator"/>运行 iSCSI 发起程序的一个节点上的 <systemitem class="username">root</systemitem> 外壳。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用命令 <command>pvcreate</command> 在磁盘 <filename>/dev/sdd</filename> 和 <filename>/dev/sde</filename> 上准备 LVM 的物理卷：
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sdd
 <prompt role="root">root # </prompt><command>pvcreate</command> /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在这两个磁盘上创建群集感知卷组：
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y clustervg /dev/sdd /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根据需要创建逻辑卷：
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> --name clusterlv --size 500M clustervg</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>pvdisplay</command> 检查物理卷：
      </para>
@@ -588,7 +592,7 @@ Please see LICENSE.txt for this document's license.
       Allocated PE          0
       PV UUID               Ouj3Xm-AI58-lxB1-mWm2-xn51-agM2-0UuHFC</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>vgdisplay</command> 检查卷组：
      </para>
@@ -621,28 +625,28 @@ Please see LICENSE.txt for this document's license.
    </para>
 
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-clvm-scenario-drbd">
+  <section xml:id="sec-ha-clvm-scenario-drbd">
    <title>方案：使用 DRBD 的 cLVM</title>
    <para>
     如果数据中心位于城市、国家/地区或大洲的不同区域，则可使用以下方案。
    </para>
-   <procedure id="pro-ha-clvm-withdrbd">
+   <procedure xml:id="pro-ha-clvm-withdrbd">
     <title>创建使用 DRBD 的群集感知卷组</title>
-    <step performance="required">
+    <step>
      <para>
       创建主/主 DRBD 资源：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         首先，按<xref linkend="step-drbd-configure"/>中所述将 DRBD 设备设置为主/从模式。确保两个节点上的磁盘状态均为 <literal>up-to-date</literal>。使用 <command>cat</command> <option>/proc/drbd</option> 或 <command>rcdrbd</command> <option>status</option> 检查情况是否如此。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         将以下选项添加到配置文件（通常类似 <filename>/etc/drbd.d/r0.res</filename>）：
        </para>
@@ -657,13 +661,13 @@ Please see LICENSE.txt for this document's license.
   ...
 }</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         将更改的配置文件复制到另一个节点，例如：
        </para>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.d/r0.res venus:/etc/drbd.d/</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<emphasis>两个</emphasis>节点上运行以下命令：
        </para>
@@ -671,7 +675,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="root">root # </prompt><command>drbdadm</command> connect r0
 <prompt role="root">root # </prompt><command>drbdadm</command> primary r0</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         检查节点的状态：
        </para>
@@ -681,24 +685,24 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       将 clvmd 资源作为克隆品包含在 Pacemaker 配置中，并让它依赖于 DLM 克隆资源。有关详细指示信息，请参见<xref linkend="pro-ha-clvm-dlmresource"/>。继续之前，请确认这些资源已在群集上成功启动。可以使用 <command>crm_mon</command> 或 Web 界面检查正在运行的服务。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用命令 <command>pvcreate</command> 准备 LVM 的物理卷。例如，在设备 <filename>/dev/drbd_r0</filename> 上，命令应类似于：
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       创建群集感知卷组：
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y myclusterfs /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根据需要创建逻辑卷。您可能想要更改逻辑卷的大小。例如，使用以下命令创建 4 GB 的逻辑卷：
      </para>
@@ -706,7 +710,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       
       现在 VG 内的逻辑卷可作为文件系统装入或原始用法提供。确保使用逻辑卷的服务具备适当的依赖性，以便在激活 VG 后对它们进行共置和排序。
@@ -716,9 +720,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     完成这些配置步骤后，即可像在任何独立工作站中一样进行 LVM2 配置。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-clvm-drbd">
+  </section>
+ </section>
+ <section xml:id="sec-ha-clvm-drbd">
   <title>显式配置合格的 LVM2 设备</title>
 
   <para>
@@ -734,17 +738,17 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      编辑文件 <filename>/etc/lvm/lvm.conf</filename> 并搜索以 <literal>filter</literal> 开头的行。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      其中的模式作为正则表达式来处理。前面的<quote>a</quote>表示接受扫描的设备模式，前面的<quote>r</quote>表示拒绝遵守该设备模式的设备。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要删除名为 <filename>/dev/sdb1</filename> 的设备，请向过滤规则添加以下表达式：
     </para>
@@ -759,22 +763,22 @@ Please see LICENSE.txt for this document's license.
 <screen>filter = [ "a|/dev/drbd.*|", "a|/dev/.*/by-id/dm-uuid-mpath-.*|", "r/.*/" ]</screen>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      编写配置文件并将它复制到所有群集节点。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-clvm-more">
+ </section>
+ <section xml:id="sec-ha-clvm-more">
   <title>更多信息</title>
 
   <para>
-   可从 <ulink url="http://www.clusterlabs.org/wiki/Help:Contents"/> 处的 pacemaker 邮件列表中获取完整信息。
+   可从 <link xlink:href="http://www.clusterlabs.org/wiki/Help:Contents"/> 处的 pacemaker 邮件列表中获取完整信息。
   </para>
 
   <para>
-   官方 cLVM 常见问题可在以下网址中找到：<ulink url="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/>。
+   官方 cLVM 常见问题可在以下网址中找到：<link xlink:href="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/>。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_concepts.xml
+++ b/zh_CN/xml/ha_concepts.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_concepts.xml" id="cha-ha-concepts">
- <title>产品概述</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_concepts.xml" xml:id="cha-ha-concepts"><title>产品概述</title><info><abstract>
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 是一个开放源代码群集技术的集成套件，可让您实现高度可用的物理和虚拟 Linux 群集，并排除单一故障点。它可确保关键网络资源的高可用性和可管理性，这些网络资源包括数据、应用程序和服务。因此，它有助于维持业务连续性、保护数据完整性及减少 Linux 关键任务工作负荷的计划外停机时间。
   </para>
@@ -23,21 +25,23 @@ Please see LICENSE.txt for this document's license.
   <para>
    有关 High Availability 群集环境中使用的一些通用术语的解释，请参见<xref linkend="gl-heartb"/>。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-availability">
+ 
+ 
+ <section xml:id="sec-ha-availability">
   <title>作为外接式附件/扩展提供</title>
   <para>High Availability Extension 是以 SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 的外接式附件的形式提供的。对于地理位置分散的群集（地域群集）的支持将作为 High Availability Extension 的独立扩展提供，即 Geo Clustering for SUSE Linux Enterprise High Availability Extension。 </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-features">
+ <section xml:id="sec-ha-features">
   <title>主要特征</title>
 
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 可帮助您保障和管理网络资源的可用性。以下各节重点说明一些关键功能：
   </para>
 
-  <sect2 id="sec-ha-features-scenarios">
+  <section xml:id="sec-ha-features-scenarios">
    <title>各种群集方案</title>
    <para>
     High Availability Extension 支持下列方案：
@@ -77,30 +81,30 @@ Please see LICENSE.txt for this document's license.
    <para>
     群集最多可包含 32 个 Linux 服务器。如果群集内的一台服务器发生故障，则群集内的任何其他服务器均可重启动此服务器上的资源（应用程序、服务、IP 地址和文件系统）。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-flexibility">
+  <section xml:id="sec-ha-features-flexibility">
    <title>灵活性</title>
    <para>
     High Availability Extension 附带了 Corosync/OpenAIS 讯息交换和成员资格层以及 Pacemaker 群集资源管理器。使用 Pacemaker，管理员可以持续监视其资源的运行状况和状态、管理依赖性以及根据高度可配置的规则和策略自动停止和启动服务。High Availability Extension 允许您根据适合您组织的特定应用程序和硬件基础体系结构对群集进行定制。基于时间的配置使服务可以在特定时间自动迁移回已修复的节点。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-storage">
+  <section xml:id="sec-ha-features-storage">
    <title>储存和数据复制</title>
    <para>
     借助 High Availability Extension，您可以根据需要动态地指派和重指派服务器储存。它支持光纤通道或 iSCSI 储存区域网络 (SAN)。它还支持共享磁盘系统，但这不是必需的。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 还附带有群集感知文件系统、卷管理器 (OCFS2) 和群集式逻辑卷管理器 (cLVM)。如需复制数据，可使用 DRBD* 将高可用性服务的数据从群集的活动节点镜像到其备用节点。此外，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 还支持 CTDB（Clustered Trivial Database，群集普通数据库），这是一种 Samba 群集技术。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-virtualized">
+  <section xml:id="sec-ha-features-virtualized">
    <title>支持虚拟环境</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 支持物理和虚拟 Linux 服务器的混合群集。SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 附带了 Xen（开放源代码虚拟化超级管理程序）和 KVM（基于内核的虚拟机，是适用于 Linux 的基于硬件虚拟化扩展的虚拟化软件）。High Availability Extension 中的群集资源管理器能够识别、监视和管理正在虚拟服务器上运行的服务以及正在物理服务器上运行的服务。Guest 系统可作为服务由群集管理。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-geo">
+  <section xml:id="sec-ha-features-geo">
    <title>支持本地、城域和地域群集</title>
    <para> <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 已扩展，可以支持下列不同的地理方案。对于地理位置分散的群集（地域群集）的支持将作为 High Availability Extension 的独立扩展提供，即 Geo Clustering for SUSE Linux Enterprise High Availability Extension。 </para>
    <variablelist>
@@ -132,16 +136,16 @@ Please see LICENSE.txt for this document's license.
    <para>
     各个群集节点之间的地理距离越大，可能影响群集所提供服务的高可用性的因素就越多。网络延迟、有限带宽以及对储存的访问权是远距离群集面临的主要难题。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-ra">
+  <section xml:id="sec-ha-features-ra">
    <title>资源代理</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 包含大量资源代理来管理资源，如 Apache、IPv4 和 IPv6 等。它还为通用的第三方应用程序（例如 IBM WebSphere Application Server）提供了资源代理。如需产品随附的 Open Cluster Framework (OCF) 资源代理的概述，请根据<xref linkend="sec-ha-manual-config-ocf"/>中所述使用 <command>crm ra</command> 命令。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-tools">
+  <section xml:id="sec-ha-features-tools">
    <title>用户友好的管理工具</title>
    <para>
     High Availability Extension 附带了一组功能强大的工具，可用于群集的基本安装和设置及其有效配置和管理：
@@ -198,9 +202,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-benefits">
+  </section>
+ </section>
+ <section xml:id="sec-ha-benefits">
   <title>优势</title>
 
   <para>
@@ -358,8 +362,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    例如，您可以手动将网站 A 或网站 B 从 Web 服务器 1 移至群集内的其他任何一台服务器。此操作的用例包括，对 Web 服务器 1 进行升级或定期维护，或者提高网站的性能或可访问性。
   </para>
- </sect1>
- <sect1 id="sec-ha-clusterconfig">
+ </section>
+ <section xml:id="sec-ha-clusterconfig">
   <title>群集配置：储存</title>
 
   <para>
@@ -420,20 +424,20 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect1>
- <sect1 id="sec-ha-architecture">
+ </section>
+ <section xml:id="sec-ha-architecture">
   <title>体系结构</title>
 
   <para>
    本部分简要介绍 High Availability Extension 的体系结构。它提供了有关体系结构组件的信息，并描述了这些组件是如何协同工作的。
   </para>
 
-  <sect2 id="sec-ha-architecture-layers">
+  <section xml:id="sec-ha-architecture-layers">
    <title>体系结构层</title>
    <para>
     High Availability Extension 采用分层式体系结构。<xref linkend="fig-ha-architecture" xrefstyle="FigureXRef"/>说明了不同的层及其相关的组件。
    </para>
-   <figure id="fig-ha-architecture">
+   <figure xml:id="fig-ha-architecture">
     <title>体系结构</title>
     <mediaobject>
      <imageobject role="fo">
@@ -444,19 +448,19 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-   <sect3 id="sec-ha-architecture-layers-messaging">
+   <section xml:id="sec-ha-architecture-layers-messaging">
     <title>消息交换和基础结构层</title>
     <para>
      主层或第一层是讯息交换/基础结构层，也称为 Corosync/OpenAIS 层。此层包含了发送含有<quote>我在线</quote>信号的消息及其他信息的组件。High Availability Extension 的程序即位于此讯息交换/基础结构层。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-allocation">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-allocation">
     <title>资源分配层</title>
     <para>
      下一层是资源分配层。此层最复杂，它包含以下组件：
     </para>
     <variablelist>
-     <varlistentry id="vle-crm">
+     <varlistentry xml:id="vle-crm">
       <term>群集资源管理器 (CRM)</term>
       <listitem>
        <para>
@@ -464,7 +468,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-cib">
+     <varlistentry xml:id="vle-cib">
       <term>群集信息库 (CIB)</term>
       <listitem>
        <para>
@@ -472,7 +476,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-dc">
+     <varlistentry xml:id="vle-dc">
       <term>指定协调器 (DC)</term>
       <listitem>
        <para>
@@ -480,7 +484,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-pe-and-te">
+     <varlistentry xml:id="vle-pe-and-te">
       <term>策略引擎 (PE)</term>
       <listitem>
        <para>
@@ -488,7 +492,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-lrm">
+     <varlistentry xml:id="vle-lrm">
       <term>本地资源管理器 (LRM)</term>
       <listitem>
        <para>
@@ -498,16 +502,16 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-resources">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-resources">
     <title>资源层</title>
     <para>
      最高层是资源层。资源层包括一个或多个资源代理 (RA)。资源代理是已写入的用来启动、停止和监视某种服务（资源）的程序（通常是外壳脚本）。资源代理仅由 LRM 调用。第三方可将他们自己的代理放在文件系统中定义的位置，这样就为各自的软件提供了现成群集集成。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-architecture-processflow">
+  <section xml:id="sec-ha-architecture-processflow">
    <title>处理流程</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 将 Pacemaker 用作 CRM。CRM 作为守护程序执行 (<literal>crmd</literal>)，它在每个群集节点上都有一个实例。Pacemaker 通过选出一个 crmd 实例来充当主实例，实现所有群集决策制定的集中化。如果选定的 crmd 过程（或它所在的节点）出现故障，则将建立一个新的过程。
@@ -530,6 +534,6 @@ Please see LICENSE.txt for this document's license.
    <para>
     在某些情况下，可能需要关闭节点以保护共享数据或完成资源恢复。为此，Pacemaker 附带了一个屏蔽子系统，stonithd。STONITH 是 <quote>Shoot The Other Node In The Head</quote> 的首字母缩写，通常通过一个远程电源开关实施。在 Pacemaker 中，STONITH 设备已建模为资源（并在 CIB 中配置），以便轻松监视这些设备是否出现故障。而 stonithd 则负责了解 STONITH 拓扑，以便其客户端只需请求受屏蔽的节点，由它来执行其余操作。
    </para>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_config_basics.xml
+++ b/zh_CN/xml/ha_config_basics.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_basics.xml" id="cha-ha-config-basics">
- <title>配置和管理基础</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_basics.xml" xml:id="cha-ha-config-basics"><title>配置和管理基础</title><info><abstract>
   <para>
    HA 群集的主要目的是管理用户服务。Apache Web 服务器或数据库便是一种典型的用户服务。从用户角度来看，服务就是在客户的要求下执行某些操作。但对群集来说，服务只是可以启动或停止的资源，其本质与群集无关。
   </para>
@@ -15,18 +17,20 @@ Please see LICENSE.txt for this document's license.
   <para>
    在本章中，我们将介绍一些配置资源和管理群集时需要了解的基本概念。以下章节介绍如何使用 High Availability Extension 提供的每种管理工具执行主配置和管理任务。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-basics-global">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-basics-global">
   <title>全局群集选项</title>
 
   <para>
    全局群集选项控制群集在遇到特定情况时的行为方式。它们被分组成若干集合，可以使用 Hawk 和 <command>crm</command> 外壳之类的群集管理工具进行查看和修改。
   </para>
 
-  <sect2 id="sec-ha-config-basics-global-all">
+  <section xml:id="sec-ha-config-basics-global-all">
    <title>概述</title>
    <para>
-    有关所有全局群集选项及其默认值的概述，请参见 <ulink url="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Available Cluster Options”</citetitle>（可用的群集选项）一节。
+    有关所有全局群集选项及其默认值的概述，请参见 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Available Cluster Options”</citetitle>（可用的群集选项）一节。
    </para>
    <para>
     通常可保留预定义值。但为了使群集的关键功能正常工作，需要在进行基本群集设置后调整以下参数：
@@ -65,9 +69,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
-  <sect2 id="sec-ha-config-basics-global-quorum">
+  <section xml:id="sec-ha-config-basics-global-quorum">
    <title>选项 <literal>no-quorum-policy</literal></title>
    <para>
     此全局选项定义在群集分区不具有法定票数（分区不具有多数节点投票）时应执行的操作。
@@ -133,9 +137,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-global-stonith">
+  <section xml:id="sec-ha-config-basics-global-stonith">
    <title>选项 <literal>stonith-enabled</literal></title>
    <para>
     此全局选项定义是否要应用屏蔽，以允许 STONITH 设备关闭故障节点以及无法停止其资源的节点。默认情况下，此全局选项设置为 <literal>true</literal>，因为对于常规的群集操作，有必要使用 STONITH 设备。根据默认值，如果未定义 STONITH 资源，则群集将拒绝启动任何资源。
@@ -150,16 +154,16 @@ Please see LICENSE.txt for this document's license.
      不支持无 STONITH 资源的群集。
     </para>
    </important>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-resources">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-resources">
   <title>群集资源</title>
 
   <para>
    作为群集管理员，您需要在群集中为服务器上运行的每个资源或应用程序创建群集资源。群集资源可以包括网站、电子邮件服务器、数据库、文件系统、虚拟机和任何其他基于服务器的应用程序或在任意时间对用户都可用的服务。
   </para>
 
-  <sect2 id="sec-ha-config-basics-resources-management">
+  <section xml:id="sec-ha-config-basics-resources-management">
    <title>资源管理</title>
 
    <para>
@@ -197,9 +201,9 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-raclasses">
+  <section xml:id="sec-ha-config-basics-raclasses">
    <title>支持的资源代理类</title>
    <para>
     对于添加的每个群集资源，需要定义资源代理需遵守的标准。资源代理提取它们提供的服务并显示群集的确切状态，以使群集对其管理的资源不作确答。群集依赖于资源代理在收到启动、停止或监视命令时作出相应反应。
@@ -212,18 +216,18 @@ Please see LICENSE.txt for this document's license.
      <term>Linux Standards Base (LSB) 脚本</term>
      <listitem>
       <para>
-       LSB 资源代理一般由操作系统/分发包提供，并可在 <filename>/etc/init.d</filename> 中找到。要用于群集，它们必须遵守 LSB init 脚本规范。例如，它们必须实施了多个操作，至少包括 <literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal> 和 <literal>status</literal>。有关详细信息，请参见 <ulink url="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>。
+       LSB 资源代理一般由操作系统/分发包提供，并可在 <filename>/etc/init.d</filename> 中找到。要用于群集，它们必须遵守 LSB init 脚本规范。例如，它们必须实施了多个操作，至少包括 <literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal> 和 <literal>status</literal>。有关详细信息，请参见 <link xlink:href="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>。
       </para>
       <para>
        这些服务的配置没有标准化。如果要将 LSB 脚本用于 High Availability，请确保您了解如何配置相关脚本。通常，您可以在 <filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename> 中的相关包文档中找到配置此类脚本的信息。
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-resources-ocf-ra">
+    <varlistentry xml:id="vle-ha-resources-ocf-ra">
      <term>Open Cluster Framework (OCF) 资源代理</term>
      <listitem>
       <para>
-       OCF RA 代理最适合用于高可用性，特别是当您需要多状态资源或特殊监视功能时。这些代理通常位于 <filename>/usr/lib/ocf/resource.d/<replaceable>provider</replaceable>/</filename> 中。其功能与 LSB 脚本的功能相似。但是，始终使用环境变量进行配置，这样可轻松接受和处理参数。OCF 规范（由于它与资源代理相关）可在 <ulink url="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/> 中找到。OCF 规范有严格的定义，其中包括操作必须返回退出码，请参见<xref linkend="sec-ha-errorcodes"/>。群集严格遵循这些规范。 
+       OCF RA 代理最适合用于高可用性，特别是当您需要多状态资源或特殊监视功能时。这些代理通常位于 <filename>/usr/lib/ocf/resource.d/<replaceable>provider</replaceable>/</filename> 中。其功能与 LSB 脚本的功能相似。但是，始终使用环境变量进行配置，这样可轻松接受和处理参数。OCF 规范（由于它与资源代理相关）可在 <link xlink:href="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/> 中找到。OCF 规范有严格的定义，其中包括操作必须返回退出码，请参见<xref linkend="sec-ha-errorcodes"/>。群集严格遵循这些规范。 
       </para>
 
 
@@ -251,9 +255,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     随 High Availability Extension 提供的代理已写入 OCF 规范。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-types">
+  <section xml:id="sec-ha-config-basics-resources-types">
    <title>资源类型</title>
    <para>
     可创建以下类型的资源：
@@ -312,9 +316,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-templates">
+  <section xml:id="sec-ha-config-basics-resources-templates">
    <title>资源模板</title>
    <para>
     如果希望创建具有类似配置的多个资源，则定义资源模板是最简单的方式。定义后，就可以在基元资源或特定类型的约束中引用该模板，请参见<xref linkend="sec-ha-config-basics-constraints-templates"/>。
@@ -338,19 +342,19 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-advanced">
+  <section xml:id="sec-ha-config-basics-resources-advanced">
    <title>高级资源类型</title>
    <para>
     基元资源是最简单的一种资源，易于配置，不过对于群集配置，您可能还需要更多高级资源类型，如组、克隆资源或多状态资源。
    </para>
-   <sect3 id="sec-ha-config-basics-resources-advanced-groups">
+   <section xml:id="sec-ha-config-basics-resources-advanced-groups">
     <title>组</title>
     <para>
      某些群集资源依赖于其他组件或资源，它们要求每个组件或资源都按特定顺序启动并在同一服务器上与它所依赖的资源一起运行。要简化此配置，可以使用群集资源组。
     </para>
-    <example id="ex-ha-config-resource-group">
+    <example xml:id="ex-ha-config-resource-group">
      <title>Web 服务器的资源组</title>
      <para>
       资源组示例可以是需要 IP 地址和文件系统的 Web 服务器。在本例中，每个组件都是组成群集资源组的一个单独资源。资源组将在一台或多台服务器上运行。在发生软件或硬件故障时，资源组会将故障转移到群集中的另一台服务器，这一点与单个群集资源类似。
@@ -442,8 +446,8 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-clones">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-clones">
     <title>克隆资源</title>
     <para>
      您可能希望某些资源在群集的多个节点上同时运行。为此，必须将资源配置为克隆资源。可以配置为克隆资源的资源示例包括 STONITH 和群集文件系统（如 OCFS2）。可以克隆提供的任何资源。资源的资源代理支持此操作。克隆资源的配置甚至也有不同，具体取决于资源驻留的节点。
@@ -481,7 +485,7 @@ Please see LICENSE.txt for this document's license.
      克隆资源必须正好包含一组或一个常规资源。
     </para>
     <para>
-     配置资源监视或约束时，克隆资源与简单资源具有不同的要求。有关细节，请参见 <ulink url="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Clones - Resources That Get Active on Multiple Hosts”</citetitle>（克隆资源 - 在多个主机上处于活动状态的资源）一节。
+     配置资源监视或约束时，克隆资源与简单资源具有不同的要求。有关细节，请参见 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Clones - Resources That Get Active on Multiple Hosts”</citetitle>（克隆资源 - 在多个主机上处于活动状态的资源）一节。
     </para>
     <para>
      了解如何使用首选群集管理工具创建克隆资源：
@@ -503,24 +507,24 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-masters">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-masters">
     <title>多状态资源</title>
     <para>
      多状态资源是克隆的特殊形式。它们允许实例处于两种操作模式中的一种（即 <literal>master</literal> 或 <literal>slave</literal>，不过您也可以按照自己的想法来命名这些模式）。多状态资源只能包含一个组或一个常规资源。
     </para>
     <para>
-     配置资源监视或约束时，多状态资源与简单资源具有不同的要求。有关细节，请参见 <ulink url="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Multi-state - Resources That Have Multiple Modes”</citetitle>（多状态 - 具有多个节点的资源）一节。
+     配置资源监视或约束时，多状态资源与简单资源具有不同的要求。有关细节，请参见 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明）。请参见<citetitle>“Multi-state - Resources That Have Multiple Modes”</citetitle>（多状态 - 具有多个节点的资源）一节。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-meta-attr">
+  <section xml:id="sec-ha-config-basics-meta-attr">
    <title>资源选项（元属性）</title>
    <para>
     您可以为添加的每个资源定义选项。群集使用这些选项来决定资源的行为方式，它们会告知 CRM 如何对待特定的资源。可以使用 <command>crm_resource --meta</command> 命令或按照<xref linkend="pro-ha-config-gui-parameters"/>中所述使用 Pacemaker GUI 来设置资源选项。或者使用 Hawk：<xref linkend="pro-ha-config-hawk-primitives"/>。
    </para>
-   <table id="tab-ha-basics-meta">
+   <table xml:id="tab-ha-basics-meta">
     <title>原始资源选项</title>
     <tgroup cols="3">
      <thead>
@@ -775,9 +779,9 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-inst-attr">
+  <section xml:id="sec-ha-config-basics-inst-attr">
    <title>实例属性（参数）</title>
 
 
@@ -869,9 +873,9 @@ monitor_0     interval=5s timeout=20s</screen>
      请注意，组、克隆和多状态资源没有实例属性。但是，任何实例属性集都将由组、克隆或多状态资源的子级继承。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-operations">
+  <section xml:id="sec-ha-config-basics-operations">
    <title>资源操作</title>
    <para>
     默认情况下，群集将不会确保您的资源一直正常。要指示群集执行此操作，需要将监视操作添加到资源定义中。可为所有类或资源代理添加监视操作。有关更多信息，请参见<xref linkend="sec-ha-config-basics-monitoring"/>。
@@ -1050,9 +1054,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-timeouts">
+  <section xml:id="sec-ha-config-basics-timeouts">
    <title>超时值</title>
    <para>
     资源的超时值会受以下参数的影响：
@@ -1112,38 +1116,38 @@ monitor_0     interval=5s timeout=20s</screen>
    </para>
    <procedure>
     <title>确定超时值</title>
-    <step performance="required">
+    <step>
      <para>
       检查资源启动和停止（在负载状况下）所需的时间。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，请添加 <varname>op_defaults</varname> 参数并相应地设置（默认）超时值：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         例如，将 <literal>default-action-timeout</literal> 设置为 <literal>60</literal> 秒：
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt> op_defaults timeout=60</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         对于需要更长时间期限的资源，则定义单独的超时值。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为资源配置操作时，添加单独的 <literal>start</literal> 和 <literal>stop</literal> 操作。使用 Hawk 配置操作时，它会针对这些操作提供有用的超时建议。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitoring">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitoring">
   <title>资源监视</title>
 
   <para>
@@ -1211,15 +1215,15 @@ monitor_0     interval=5s timeout=20s</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-config-basics-constraints">
+ </section>
+ <section xml:id="sec-ha-config-basics-constraints">
   <title>资源约束</title>
 
   <para>
    配置好所有资源只是完成了该任务的一部分。即便群集熟悉所有必需资源，它可能还无法进行正确处理。资源约束允许您指定在哪些群集节点上运行资源、以何种顺序装载资源，以及特定资源依赖于哪些其他资源。
   </para>
 
-  <sect2 id="sec-ha-config-basics-constraints-types">
+  <section xml:id="sec-ha-config-basics-constraints-types">
    <title>约束类型</title>
    <para>
     提供三种不同的约束：
@@ -1251,16 +1255,16 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-   <sect3 id="sec-ha-config-basics-constraints-rscset">
+   <section xml:id="sec-ha-config-basics-constraints-rscset">
     <title>资源集</title>
 
     <para/>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints">
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints">
      <title>使用资源集定义约束</title>
      <para>
       可以使用<literal>资源集</literal>作为定义位置、共置或顺序约束的备用格式，在资源集中，基元资源已被全部分组到一个集合中。以前，为了实现此目的，用户可以定义一个资源组（不一定总能准确表达设计意图），也可以将每种关系定义为单个约束。随着资源和组合数目的增加，后面这种做法会导致约束过度膨胀。通过资源集进行配置并不一定会减少复杂程度，但更易于理解和维护，如以下示例中所示。
      </para>
-     <example id="ex-config-basic-resourceset-loc">
+     <example xml:id="ex-config-basic-resourceset-loc">
       <title>用于位置约束的资源集</title>
       <para>
        例如，可以在 crmsh 中使用资源集 (<varname>loc-alice</varname>) 的以下配置，将两个虚拟 IP（<varname>vip1</varname> 和 <varname>vip2</varname>）置于同一个节点  <varname>alice</varname>：
@@ -1323,8 +1327,8 @@ monitor_0     interval=5s timeout=20s</screen>
      <para>
       资源集可以是有序的 (<literal>sequential=true</literal>)，也可以是无序的 (<literal>sequential=false</literal>)。此外，可以使用 <literal>require-all</literal> 属性在 <literal>AND</literal> 与 <literal>OR</literal> 逻辑之间切换。
      </para>
-    </sect4>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints-dep">
+    </section>
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints-dep">
      <title>不带依赖性的共置约束的资源集</title>
 
      <para>
@@ -1342,9 +1346,9 @@ monitor_0     interval=5s timeout=20s</screen>
        </para>
       </listitem>
      </itemizedlist>
-    </sect4>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-constraints-more">
+    </section>
+   </section>
+   <section xml:id="sec-ha-config-basics-constraints-more">
     <title>更多信息</title>
     <para>
      了解如何使用首选群集管理工具添加各种约束：
@@ -1362,7 +1366,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </itemizedlist>
     <para>
-     有关配置约束的更多信息以及顺序和共置基本概念的详细背景信息，请参见以下文档。可以从 <ulink url="http://www.clusterlabs.org/doc/"/> 访问这些文档：
+     有关配置约束的更多信息以及顺序和共置基本概念的详细背景信息，请参见以下文档。可以从 <link xlink:href="http://www.clusterlabs.org/doc/"/> 访问这些文档：
     </para>
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
@@ -1381,10 +1385,10 @@ monitor_0     interval=5s timeout=20s</screen>
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-scores">
+  <section xml:id="sec-ha-config-basics-constraints-scores">
    <title>分数和无限值</title>
    <para>
     定义约束时，还需要指定分数。各种分数是群集工作方式的重要组成部分。其实，从迁移资源到决定在已降级群集中停止哪些资源的整个过程是通过以某种方式操纵分数来实现的。分数按每个资源来计算，资源分数为负的任何节点都无法运行该资源。计算资源的分数后，群集会选择分数最高的节点。
@@ -1412,9 +1416,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     定义资源约束时，需为每个约束指定一个分数。分数表示您指派给此资源约束的值。分数较高的约束先应用，分数较低的约束后应用。通过使用不同的分数为既定资源创建更多位置约束，可以指定资源要故障转移至的目标节点的顺序。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-templates">
+  <section xml:id="sec-ha-config-basics-constraints-templates">
    <title>资源模板和约束</title>
    <para>
     如果定义了资源模板（请参见<xref linkend="sec-ha-config-basics-resources-templates"/>），则可在以下类型的约束中引用该模板：
@@ -1443,9 +1447,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     在约束中引用的资源模板代表派生自该模板的所有原始资源。这意味着，约束将应用于引用资源模板的所有原始资源。在约束中引用资源模板是资源集的备用方式，它可以显著简化群集配置。有关资源集的细节，请参见<xref linkend="pro-ha-config-hawk-constraints-sets"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failover">
+  <section xml:id="sec-ha-config-basics-failover">
    <title>故障转移节点</title>
    <para>
     资源在出现故障时会自动重启动。如果在当前节点上无法实现此操作，或者此操作在当前节点上失败了 <literal>N</literal> 次，它将尝试故障转移到其他节点。每次资源失败时，其失败计数都会增加。您可以多次定义资源的故障次数（<literal>migration-threshold</literal>），在该值之后资源会迁移到新节点。如果群集中存在两个以上的节点，则特定资源故障转移的节点由 High Availability 软件选择。
@@ -1473,7 +1477,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-   <example id="ex-ha-config-basics-failover">
+   <example xml:id="ex-ha-config-basics-failover">
     <title>迁移阈值 - 流程</title>
     <para>
      例如，假设您已经为 <literal>rsc1</literal> 资源配制了一个首选在 <literal>alice</literal> 节点上运行的位置约束。如果那里失败了，系统会检查 <literal>migration-threshold</literal> 并与故障计数进行比较。如果故障计数 &gt;= migration-threshold，会将资源迁移到下一个自选节点。
@@ -1523,9 +1527,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failback">
+  <section xml:id="sec-ha-config-basics-failback">
    <title>故障回复节点</title>
    <para>
     当原始节点恢复联机并位于群集中时，资源可能会故障回复到该节点。如果要防止资源故障回复到之前运行的节点，或者想为该资源指定故障回复到的其他节点，请更改其 <literal>resource stickiness</literal> 值。可以在创建资源时指定资源粘性或稍后指定。
@@ -1575,9 +1579,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-utilization">
+  <section xml:id="sec-ha-config-basics-utilization">
    <title>根据资源负载影响放置资源</title>
    <para>
     并非所有资源都相等。某些资源（如 Xen guest）需要托管它们的节点满足其容量要求。如果所放置资源的总需求超过了提供的容量，则资源性能将降低（或甚至失败）。
@@ -1696,7 +1700,7 @@ monitor_0     interval=5s timeout=20s</screen>
      可用的放置策略是最佳方法 - 它们不使用复杂的启发式解析程序即可始终实现最佳分配结果。确保正确设置资源优先级，以便首选调度最重要的资源。
     </para>
    </note>
-   <example id="ex-ha-config-basics-utilization">
+   <example xml:id="ex-ha-config-basics-utilization">
     <title>负载平衡放置配置示例</title>
     <para>
      以下示例演示了配有四台虚拟机、节点数相等的三节点群集。
@@ -1724,9 +1728,9 @@ property placement-strategy="minimal"</screen>
      如果一个节点出现故障，可用的总内存将不足以托管所有资源。将确保分配 <literal>xenA</literal>，<literal>xenD</literal> 同样如此。但是，只能再放置剩余资源 <literal>xenB</literal> 和 <literal>xenC</literal> 中的一个。由于它们的优先级相同，结果未定。要解决这种不确定性，需要为其中一个资源设置更高的优先级。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-tags">
+  <section xml:id="sec-ha-config-basics-tags">
    <title>使用标记分组资源</title>
 
    <para>
@@ -1747,9 +1751,9 @@ property placement-strategy="minimal"</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-remote">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-remote">
   <title>管理远程主机上的服务</title>
 
 
@@ -1758,7 +1762,7 @@ property placement-strategy="minimal"</screen>
    在最近几年中，是否能够监视和管理远程主机上的服务已变得越来越重要。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 可让用户通过监视插件来密切监视远程主机上的服务。最近添加的 <literal>pacemaker_remote</literal> 服务现在允许 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 全面管理和监视远程主机上的资源，就如同这些资源是真实的群集节点一样，并且无需用户在远程计算机上安装群集堆栈。
   </para>
 
-  <sect2 id="sec-ha-config-basics-remote-nagios">
+  <section xml:id="sec-ha-config-basics-remote-nagios">
    <title>使用 Nagios 插件监视远程主机上的服务</title>
    <para>
     虚拟机的监视可以通过 VM 代理来完成（只有在超级管理程序中出现 guest 时才可选择 VM 代理），或者通过从 VirtualDomain 或 Xen 代理调用外部脚本来完成。直到现在为止，仍只有通过在虚拟机中对高可用性堆栈进行完全设置才能实现更细化的监视。
@@ -1790,7 +1794,7 @@ property placement-strategy="minimal"</screen>
    <para>
     将 Nagios 插件配置为属于资源容器的资源（通常是 VM）便是其中一个典型案例。如果容器中有任何资源发生故障，则将重启该容器。有关配置示例，请参见<xref linkend="ex-ha-nagios-config"/>。或者，如果想使用 Nagios 资源代理通过网络监视主机或服务，还可将这些代理配置为普通资源。
    </para>
-   <example id="ex-ha-nagios-config">
+   <example xml:id="ex-ha-nagios-config">
     <title>为 Nagios 插件配置资源</title>
 <screen>primitive vm1 ocf:heartbeat:VirtualDomain \
   params hypervisor="qemu:///system" config="/etc/libvirt/qemu/vm1.xml" \
@@ -1798,11 +1802,11 @@ property placement-strategy="minimal"</screen>
      op stop interval="0" timeout="90" \
      op monitor interval="10" timeout="30"
   primitive vm1-sshd nagios:check_tcp \
-     params hostname="vm1" port="22" \<co id="co-nagios-hostname"/>
-     op start interval="0" timeout="120" \<co id="co-nagios-startinterval"/>
+     params hostname="vm1" port="22" \<co xml:id="co-nagios-hostname"/>
+     op start interval="0" timeout="120" \<co xml:id="co-nagios-startinterval"/>
      op monitor interval="10"
   group g-vm1-and-services vm1 vm1-sshd \
-     meta container="vm1"<co id="co-nagios-container"/></screen>
+     meta container="vm1"<co xml:id="co-nagios-container"/></screen>
     <calloutlist>
      <callout arearefs="co-nagios-hostname">
       <para>
@@ -1836,9 +1840,9 @@ property placement-strategy="minimal"</screen>
      在考虑 VM 的 migration-threshold 时，会将服务的故障计数考虑在内。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-remote-pace-remote">
+  <section xml:id="sec-ha-config-basics-remote-pace-remote">
    <title>使用 <literal>pacemaker_remote</literal> 管理远程节点上的服务</title>
    <para>
     使用 <literal>pacemaker_remote</literal> 服务可将高可用性群集扩展到虚拟节点或远程裸机计算机。这些虚拟节点或远程裸机无需运行群集堆栈就能成为群集的成员。
@@ -1887,11 +1891,11 @@ property placement-strategy="minimal"</screen>
     </listitem>
    </itemizedlist>
    <para>
-    您可以在 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>》（Pacemaker 远程 - 将高可用性扩展到虚拟节点）中找到有关 <literal>remote_pacemaker</literal> 服务的更多信息，包括多个用例和详细的设置说明。
+    您可以在 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>》（Pacemaker 远程 - 将高可用性扩展到虚拟节点）中找到有关 <literal>remote_pacemaker</literal> 服务的更多信息，包括多个用例和详细的设置说明。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitor-health">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitor-health">
   <title>监视系统运行状况</title>
 
 
@@ -1909,19 +1913,19 @@ property placement-strategy="minimal"</screen>
 
 
 
-  <procedure id="pro-ha-health-monitor">
+  <procedure xml:id="pro-ha-health-monitor">
    <title>配置系统运行状况监视</title>
    <para>
     要在某个节点耗尽磁盘空间时从该节点自动移除资源，请执行以下操作：
    </para>
-   <step performance="required">
+   <step>
     <para>
      配置 <systemitem>ocf:pacemaker:SysInfo</systemitem> 资源：
     </para>
 <screen><?dbsuse-fo font-size="0.71em"?>
 
 primitive sysinfo ocf:pacemaker:SysInfo \ 
-     params disks="/tmp /var"<co id="co-disks"/> min_disk_free="100M"<co id="co-min-disk-free"/> disk_unit="M"<co id="co-disk-unit"/> \ 
+     params disks="/tmp /var"<co xml:id="co-disks"/> min_disk_free="100M"<co xml:id="co-min-disk-free"/> disk_unit="M"<co xml:id="co-disk-unit"/> \ 
      op monitor interval="15s"</screen>
     <calloutlist>
      <callout arearefs="co-disks">
@@ -1948,12 +1952,12 @@ primitive sysinfo ocf:pacemaker:SysInfo \
 
     </calloutlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要完成资源配置，请创建 <systemitem>ocf:pacemaker:SysInfo</systemitem> 的克隆并在每个群集节点上启动此克隆。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      将 <systemitem>node-health-strategy</systemitem> 设置为 <literal>migrate-on-red</literal>：
     </para>
@@ -1991,8 +1995,8 @@ primitive sysinfo ocf:pacemaker:SysInfo \
   <para>
    该节点将恢复服务并可再次运行资源。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-basics-maint-mode">
+ </section>
+ <section xml:id="sec-ha-config-basics-maint-mode">
   <title>维护模式</title>
 
 
@@ -2057,14 +2061,14 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-basics-more">
+ <section xml:id="sec-ha-config-basics-more">
   <title>更多信息</title>
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/"/>
+    <term><link xlink:href="http://crmsh.github.io/"/>
     </term>
     <listitem>
      <para>
@@ -2073,16 +2077,16 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/documentation"/>
+    <term><link xlink:href="http://crmsh.github.io/documentation"/>
     </term>
     <listitem>
      <para>
-      提供有关 crm 外壳的多份文档，包括使用 crmsh 完成基本群集设置的<citetitle>入门</citetitle>教程，以及 crm 外壳的综合性<citetitle>手册</citetitle>。后者可在 <ulink url="http://crmsh.github.io/man-2.0/"/> 上访问。<ulink url="http://crmsh.github.io/start-guide/"/> 上提供了相关教程。
+      提供有关 crm 外壳的多份文档，包括使用 crmsh 完成基本群集设置的<citetitle>入门</citetitle>教程，以及 crm 外壳的综合性<citetitle>手册</citetitle>。后者可在 <link xlink:href="http://crmsh.github.io/man-2.0/"/> 上访问。<link xlink:href="http://crmsh.github.io/start-guide/"/> 上提供了相关教程。
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://clusterlabs.org/"/>
+    <term><link xlink:href="http://clusterlabs.org/"/>
     </term>
     <listitem>
      <para>
@@ -2091,7 +2095,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/> 
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/> 
     </term>
     <listitem>
      <para>
@@ -2122,7 +2126,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://linux-ha.org"/>
+    <term><link xlink:href="http://linux-ha.org"/>
     </term>
     <listitem>
      <para>
@@ -2131,5 +2135,5 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_config_cli.xml
+++ b/zh_CN/xml/ha_config_cli.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_cli.xml" id="cha-ha-manual-config">
- <title>配置和管理群集资源（命令行）</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_cli.xml" xml:id="cha-ha-manual-config"><title>配置和管理群集资源（命令行）</title><info><abstract>
   <para>
    要配置和管理群集资源，可使用图形用户界面 (Pacemaker GUI) 或 <command>crm</command> 命令行实用程序。有关 GUI 方法，请参见<xref linkend="cha-ha-configuration-gui"/>。
   </para>
@@ -15,7 +17,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章介绍了命令行工具 <command>crm</command>，并包含此工具的概述以及如何使用模板，主要介绍如何配置和管理群集资源：创建基本和高级类型的资源（组和克隆资源）、配置约束、指定故障转移节点和故障回复节点、配置资源监视以及手动启动、清理、删除和迁移资源。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <note>
   <title>用户特权</title>
   <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    请注意，您需要将 <filename>/etc/sudoers</filename> 设置为 <command>sudo</command> 不要求提供密码。
   </para>
  </note>
- <sect1 id="sec-ha-manual-config-crm">
+ <section xml:id="sec-ha-manual-config-crm">
   <title>crmsh - 概述</title>
 
   <para>
@@ -61,7 +65,7 @@ Please see LICENSE.txt for this document's license.
    </itemizedlist>
   </tip>
 
-  <sect2 id="sec-ha-manual-config-crm-help">
+  <section xml:id="sec-ha-manual-config-crm-help">
    <title>获得帮助</title>
    <para>
     可通过以下方式之一访问帮助：
@@ -105,15 +109,15 @@ Please see LICENSE.txt for this document's license.
    <para>
     几乎所有 <command>help</command> 子命令（请不要与 <option>--help</option> 选项混淆）的输出都会打开文本编辑器。此文本编辑器允许您向上/向下滚动，以便更加方便地阅读帮助文本。要退出文本编辑器，请按 <keycap>Q</keycap> 键。
    </para>
-   <tip id="tip-crm-tabcompletion">
+   <tip xml:id="tip-crm-tabcompletion">
     <title>在 Bash 和交互式外壳中使用 Tab 键补全</title>
     <para>
      crmsh 不仅为交互式外壳提供 Tab 键补全，还全面支持在 Bash 中直接使用此功能。例如，键入 <literal>crm help config</literal><keycap function="tab"/> 会补全文字（就像在交互式外壳中一样）。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-crm-run">
+  <section xml:id="sec-ha-manual-config-crm-run">
    <title>执行 crmsh 的子命令</title>
    <para>
     <command>crm</command> 命令本身可按以下方式使用：
@@ -177,9 +181,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以下小节概述了 <command>crm</command> 工具的一些重要方面。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-ocf">
+  <section xml:id="sec-ha-manual-config-ocf">
    <title>显示有关 OCF 资源代理的信息</title>
    <para>
     由于在群集配置中一直需要处理资源代理，<command>crm</command> 工具包含了 <command>ra</command> 命令。使用该命令可以显示有关资源代理的信息并对其进行管理（如需其他信息，另请参见<xref linkend="sec-ha-config-basics-raclasses"/>）：
@@ -242,9 +246,9 @@ Operations' defaults (advisory minimum):
      在之前的示例中，我们使用了 <command>crm</command> 命令的内壳。但是您不一定非要使用它。将相应子命令添加到 <command>crm</command> 中也可获得相同的结果。例如，在外壳中输入 <command>crm</command> <option>ra list ocf</option> 可以列出所有 OCF 资源代理。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-template">
+  <section xml:id="sec-ha-manual-config-template">
    <title>使用配置模板</title>
 
    <para>
@@ -256,32 +260,32 @@ Operations' defaults (advisory minimum):
    <para>
     以下步骤显示了如何创建简单有效的 Apache 配置：
    </para>
-   <procedure id="pro-ha-manual-config-template">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-template">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       从配置模板创建一个新配置：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         切换到 <command>template</command> 子命令：
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>template</command></screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         列出可用的配置模板：
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command> templates
 gfs2-base   filesystem  virtual-ip  apache   clvm     ocfs2    gfs2</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         确定需要的配置模板。由于我们需要 Apache 配置，因此选择了 <literal>apache</literal> 模板并将其命名为 <literal>g-intranet</literal>：
        </para>
@@ -291,19 +295,19 @@ INFO: pulling in template virtual-ip</screen>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定义参数：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         列出您创建的配置：
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command>
 g-intranet</screen>
       </step>
-      <step id="st-config-cli-show" performance="required">
+      <step xml:id="st-config-cli-show">
        <para>
         显示需要由您填充的最少的必要更改：
        </para>
@@ -312,7 +316,7 @@ ERROR: 23: required parameter ip not set
 ERROR: 61: required parameter id not set
 ERROR: 65: required parameter configfile not set</screen>
       </step>
-      <step id="st-config-cli-edit" performance="required">
+      <step xml:id="st-config-cli-edit">
        <para>
         调用首选的文本编辑器，填写显示为错误（如<xref linkend="st-config-cli-show"/> 中所示）的所有行：
        </para>
@@ -321,7 +325,7 @@ ERROR: 65: required parameter configfile not set</screen>
 
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       显示配置并检查配置是否有效（粗体文本取决于您在<xref linkend="st-config-cli-edit" xrefstyle="select:label"/> 中进入的配置）：
      </para>
@@ -334,7 +338,7 @@ primitive apache ocf:heartbeat:apache \
 group <emphasis role="strong">g-intranet</emphasis> \
     apache virtual-ip</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       应用配置：
      </para>
@@ -342,7 +346,7 @@ group <emphasis role="strong">g-intranet</emphasis> \
 <prompt role="custom">crm(live)configure# </prompt><command>cd ..</command>
 <prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       将更改提交到 CIB：
      </para>
@@ -363,9 +367,9 @@ group <emphasis role="strong">g-intranet</emphasis> \
    <para>
     但是，前一条命令仅会从配置模板创建其配置。它不会将其应用或提交到 CIB。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-shadowconfig">
+  <section xml:id="sec-ha-manual-config-shadowconfig">
    <title>使用阴影配置进行测试</title>
    <para>
     阴影配置可用于测试不同的配置方案。如果创建了多个阴影配置，则可逐一测试这些配置，以查看更改的影响。
@@ -374,13 +378,13 @@ group <emphasis role="strong">g-intranet</emphasis> \
     一般的流程显示如下：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       创建新的阴影配置：
      </para>
@@ -390,7 +394,7 @@ INFO: myNewConfig shadow CIB created</screen>
       如果省略阴影 CIB 的名称，则会创建临时名称 <literal>@tmp@</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要将当前的活动配置复制到阴影配置中，可使用以下命令，否则请跳过此步骤：
      </para>
@@ -399,13 +403,13 @@ INFO: myNewConfig shadow CIB created</screen>
       使用上面的命令便于稍后修改现有资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       照常进行更改。创建阴影配置后，会应用所有更改。要保存所有更改，请使用以下命令：
      </para>
 <screen>crm(myNewConfig)# <command>commit</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果再次需要活动群集配置，可使用以下命令切换回此配置：
      </para>
@@ -413,9 +417,9 @@ INFO: myNewConfig shadow CIB created</screen>
 <prompt role="custom">crm(live)# </prompt></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-debugging">
+  <section xml:id="sec-ha-manual-config-debugging">
    <title>调试配置更改</title>
    <para>
     将配置更改装载回群集之前，建议使用 <command>ptest</command> 复查更改。使用 <command>ptest</command> 命令可显示提交更改后产生的操作图。需要 <systemitem>graphviz</systemitem> 包才能显示这些图。以下示例是一个抄本，添加了监视操作：
@@ -431,9 +435,9 @@ primitive fence-bob stonith:apcsmart \
         op monitor interval="120m" timeout="60s"
 <prompt role="custom">crm(live)configure# </prompt><emphasis role="strong">ptest</emphasis>
 <prompt role="custom">crm(live)configure# </prompt>commit</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-diagram">
+  <section xml:id="sec-ha-manual-config-diagram">
    <title>群集图表</title>
    <para>
     要输出如<xref linkend="fig-ha-cluster-diagram"/>中所示的群集图表，请使用命令 <command>crm</command> <command>configure graph</command>。它会在当前的窗口上显示当前配置，因此需要配备 X11。
@@ -442,10 +446,10 @@ primitive fence-bob stonith:apcsmart \
     如果您希望使用可缩放矢量图 (SVG)，请使用以下命令：
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure graph dot config.svg svg</screen>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 
- <sect1 id="sec-ha-config-crm-global">
+ <section xml:id="sec-ha-config-crm-global">
   <title>配置全局群集选项</title>
 
   <para>
@@ -454,13 +458,13 @@ primitive fence-bob stonith:apcsmart \
 
   <procedure>
    <title>使用 <command>crm</command> 修改全局群集选项</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 工具：
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用以下命令可以仅为两个节点的群集设置选项：
     </para>
@@ -473,7 +477,7 @@ primitive fence-bob stonith:apcsmart \
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      显示更改：
     </para>
@@ -485,7 +489,7 @@ property $id="cib-bootstrap-options" \
    no-quorum-policy="ignore" \
    stonith-enabled="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      提交更改并退出：
     </para>
@@ -493,8 +497,8 @@ property $id="cib-bootstrap-options" \
 <prompt role="custom">crm(live)configure# </prompt><command>exit</command></screen>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-config-crm-resources">
+ </section>
+ <section xml:id="sec-ha-config-crm-resources">
   <title>配置群集资源</title>
 
   <para>
@@ -505,19 +509,19 @@ property $id="cib-bootstrap-options" \
    有关可创建的资源类型的概述，请参见<xref linkend="sec-ha-config-basics-resources-types"/>。
   </para>
 
-  <sect2 id="sec-ha-manual-config-create">
+  <section xml:id="sec-ha-manual-config-create">
    <title>创建群集资源</title>
    <para>
     有三种 RA（资源代理）类型可用于群集（有关背景信息，请参见<xref linkend="sec-ha-config-basics-raclasses"/>）。要将新资源添加到群集，请按如下操作：
    </para>
-   <procedure id="pro-ha-manual-config-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-create">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 工具：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       配置原始 IP 地址：
      </para>
@@ -527,13 +531,13 @@ property $id="cib-bootstrap-options" \
       上一命令配置了名称为 <literal>myIP</literal> 的<quote>原始资源</quote>。需要选择一个类（此处为 <literal>ocf</literal>）、提供程序 (<literal>heartbeat</literal>) 和类型 (<literal>IPaddr</literal>)。此外，此原始资源还需要其他参数，如 IP 地址。根据设置更改地址。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       显示您所做的更改并进行复查：
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       提交更改使其生效：
      </para>
@@ -541,11 +545,11 @@ property $id="cib-bootstrap-options" \
     </step>
    </procedure>
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-config-rsc-template">
+  <section xml:id="sec-ha-manual-config-rsc-template">
    <title>创建资源模板</title>
    <para>
     如果希望使用类似的配置创建多个资源，则资源模板可以简化此项任务。有关一些基本背景信息，另请参见<xref linkend="sec-ha-config-basics-constraints-templates"/>。不要将它们与<xref linkend="sec-ha-manual-config-template"/>中的<quote>常规</quote>模板相混淆。使用 <command>rsc_template</command> 命令可以熟悉其语法：
@@ -588,23 +592,23 @@ usage: rsc_template &lt;name&gt; [&lt;class&gt;:[&lt;provider&gt;:]]&lt;type&gt;
    <para>
     资源模板可以在约束中引用，以表示所有原始资源都派生自该模板。这有助于生成更加清晰明了的群集配置。除了位置约束外，允许在所有约束中进行资源模板引用。共置约束不能包含多次模板引用。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-create-stonith">
+  <section xml:id="sec-ha-manual-create-stonith">
    <title>创建 STONITH 资源</title>
    <para>
     就 <command>crm</command> 而言，STONITH 设备只是另一种资源。要创建 STONITH 资源，请执行以下操作：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用以下命令获取所有 STONITH 类型的列表：
      </para>
@@ -622,7 +626,7 @@ ipmilan                    meatware                   nw_rpc100s
 rcd_serial                 rps10                      suicide
 wti_mpc                    wti_nps</screen>
     </step>
-    <step id="st-ha-manual-create-stonith-type" performance="required">
+    <step xml:id="st-ha-manual-create-stonith-type">
      <para>
       从以上列表中选择 STONITH 类型并查看可用的选项列表。使用以下命令：
      </para>
@@ -641,7 +645,7 @@ hostname (string): Hostname
     The name of the host to be managed by this STONITH device.
 ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <literal>stonith</literal> 类（您在<xref linkend="st-ha-manual-create-stonith-type" xrefstyle="select:label nopage"/>中选择的类型）和相应的参数（如果需要）创建 STONITH 资源，例如：
      </para>
@@ -653,9 +657,9 @@ hostname (string): Hostname
     op monitor interval=60m timeout=120s  </screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-constraints">
+  <section xml:id="sec-ha-manual-config-constraints">
    <title>配置资源约束</title>
    <para>
     配置所有资源只是任务的一部分。即使群集了解所有需要的资源，它仍然不能正确处理它们。例如，尽量不要在 DRBD 的从属节点上装入文件系统（事实上，这将导致 DRBD 出现故障）。定义约束以使这些信息可用于群集。
@@ -663,7 +667,7 @@ hostname (string): Hostname
    <para>
     有关约束的更多信息，请参见<xref linkend="sec-ha-config-basics-constraints"/>。
    </para>
-   <sect3 id="sec-ha-manual-config-constraints-locational">
+   <section xml:id="sec-ha-manual-config-constraints-locational">
     <title>位置约束</title>
     <para>
      <command>location</command> 命令定义资源可以、不可以或首选在哪些节点上运行。
@@ -696,8 +700,8 @@ hostname (string): Hostname
      在某些情况下，为 <command>location</command> 命令使用资源模式会有效且方便得多。资源模式是用两个斜杠括起的正则表达式。例如，可以使用以下命令全部匹配上述虚拟 IP 地址：
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>location</command>  loc-alice /vip.*/ inf: alice</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-collocational">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-collocational">
     <title>共置约束</title>
     <para>
      <command>colocation</command> 命令用于定义哪些资源应在相同主机上运行，哪些资源应在不同主机上运行。
@@ -713,8 +717,8 @@ hostname (string): Hostname
     <para>
      对于主从属配置，除在本地运行资源以外，还有必要了解当前节点是否为主节点。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-weak-bond">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-weak-bond">
     <title>共置没有依赖性的资源集</title>
 
     <para>
@@ -727,8 +731,8 @@ hostname (string): Hostname
     <para>
      <command>weak-bond</command> 的实施将使用给定的资源自动创建虚设资源和共置约束。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-ordering">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-ordering">
     <title>顺序约束</title>
     <para>
      <command>order</command> 命令定义操作顺序。
@@ -741,8 +745,8 @@ hostname (string): Hostname
     </para>
 
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> nfs_after_filesystem mandatory: filesystem_resource nfs_group</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-example">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-example">
     <title>示例配置约束</title>
     <para>
      本节中使用的示例必须与其他约束结合使用。其中最基本的就是让所有资源与 DRBD 资源的主资源在同一台计算机上运行。在启动其他资源前，DRBD 资源必须是主资源。在 DRBD 设备不是主资源时尝试装入 DRBD 只会失败。必须实现以下约束：
@@ -777,10 +781,10 @@ hostname (string): Hostname
     drbd_resource:promote filesystem_resource:start</screen>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failover">
+  <section xml:id="sec-ha-manual-config-failover">
    <title>指定资源故障转移节点</title>
    <para>
     要确定资源故障转移，可使用元属性 migration-threshold。如果所有节点上的故障计数超过 migration-threshold，资源将处于停止状态。例如：
@@ -796,9 +800,9 @@ hostname (string): Hostname
    <para>
     有关概述，请参见<xref linkend="sec-ha-config-basics-failover"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failback">
+  <section xml:id="sec-ha-manual-config-failback">
    <title>指定资源故障回复节点（资源黏性）</title>
      <para>
     当原始节点恢复联机并位于群集中时，资源可能会故障回复到该节点。如果要防止资源故障回复到之前运行的节点，或者想为该资源指定故障回复到的其他节点，请更改其 <literal>resource stickiness</literal> 值。可以在创建资源时指定资源粘性或稍后指定。
@@ -806,9 +810,9 @@ hostname (string): Hostname
    <para>
     有关概述，请参见<xref linkend="sec-ha-config-basics-failback"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-utilization">
+  <section xml:id="sec-ha-manual-config-utilization">
    <title>根据负载影响配置资源放置</title>
    <para>
     某些资源可能具有特定的容量要求，如最低内存量。如果无法满足要求，资源可能无法完全启动或运行时性能下降。
@@ -846,13 +850,13 @@ hostname (string): Hostname
    </para>
    <procedure>
     <title>使用 <command>crm</command> 添加或修改利用率属性</title>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要指定节点<emphasis>提供</emphasis>的容量，请使用以下命令并将占位符 <replaceable>NODE_1</replaceable> 替换为节点名称：
      </para>
@@ -862,7 +866,7 @@ hostname (string): Hostname
       上例中的这些值将假定 <replaceable>NODE_1</replaceable> 向资源提供 16 GB 内存和 8 个 CPU 核心。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要指定资源<emphasis>需要</emphasis>的容量，请使用：
      </para>
@@ -872,7 +876,7 @@ hostname (string): Hostname
       这会使资源消耗 nodeA 的 4096 个内存单元以及 4 个 CPU 单元。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>property</command> 命令配置放置策略：
      </para>
@@ -924,7 +928,7 @@ hostname (string): Hostname
     </para>
    </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       退出 crmsh 之前提交更改：
      </para>
@@ -956,9 +960,9 @@ hostname (string): Hostname
    <para>
     如果一个节点出现故障，可用的总内存将不足以托管所有资源。将确保分配 xenA，xenD 也同样如此。但是，只能再分配 xenB 和 xenC 中的一个，由于它们的优先级相同，结果不确定。要解决这种不确定性，需要为其中一个资源设置更高的优先级。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-monitor">
+  <section xml:id="sec-ha-manual-config-monitor">
    <title>配置资源监视</title>
 
    <para>
@@ -976,21 +980,21 @@ hostname (string): Hostname
    <para>
     有关概述，请参见<xref linkend="sec-ha-config-basics-monitoring"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-group">
+  <section xml:id="sec-ha-manual-config-group">
    <title>配置群集资源组</title>
 
    <para>
     群集的一个最常见元素是需要放置在一起的一组资源。按顺序启动，并按相反顺序停止。为了简化此配置，我们支持组的概念。以下示例创建了两个原始资源（一个 IP 地址和一个电子邮件资源）：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以系统管理员的身份运行 <command>crm</command> 命令。提示符更改为 <literal>crm(live)</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       配置这两个原始资源：
      </para>
@@ -1000,7 +1004,7 @@ hostname (string): Hostname
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Email lsb:exim \
    params id=p.lsb-exim</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       以正确顺序按其相关标识符对原始资源进行分组：
      </para>
@@ -1019,9 +1023,9 @@ hostname (string): Hostname
    <para>
     有关概述，请参见<xref linkend="sec-ha-config-basics-resources-advanced-groups"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-clone">
+  <section xml:id="sec-ha-manual-config-clone">
    <title>配置克隆资源</title>
 
    <para>
@@ -1031,46 +1035,46 @@ hostname (string): Hostname
    <para>
     要了解有关克隆资源的更多信息，请参见<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>。
    </para>
-   <sect3 id="sec-ha-manual-config-clone-anonymous">
+   <section xml:id="sec-ha-manual-config-clone-anonymous">
     <title>创建匿名克隆资源</title>
     <para>
      要创建匿名克隆资源，首先要创建一个原始资源，然后使用 <command>clone</command> 命令来引用它。执行下列操作：
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        配置原始资源，例如：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Apache lsb:apache</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        克隆原始资源：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>clone</command> cl-apache Apache </screen>
      </step>
     </procedure>
-   </sect3>
+   </section>
 
-   <sect3 id="sec-ha-manual-config-clone-stateful">
+   <section xml:id="sec-ha-manual-config-clone-stateful">
     <title>创建有状态/多状态克隆资源</title>
     <para>
      要创建有状态的克隆资源，首先要创建一个基元资源，然后再创建多状态资源。多状态资源必须至少支持升级和降级操作。
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        配置原始资源。必要时更改时间间隔：
       </para>
@@ -1078,62 +1082,62 @@ hostname (string): Hostname
     op monitor interval=60 \
     op monitor interval=61 role=Master</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        创建多状态资源：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>ms</command> ms-rsc my-rsc</screen>
      </step>
     </procedure>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-crm">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-crm">
   <title>管理群集资源</title>
 
   <para>
    除可用于配置群集资源外，<command>crm</command> 工具还可用于管理现有资源。以下小节进行了概述。
   </para>
 
-  <sect2 id="sec-ha-manual-config-start">
+  <section xml:id="sec-ha-manual-config-start">
    <title>启动新的群集资源</title>
    <para>
     要启动新的群集资源，您需要相应的标识符。按如下所示继续：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切换到资源级别：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>resource</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>start</command> 启动资源，然后按 <keycap function="tab"/> 键显示所有已知资源：
      </para>
 <screen><prompt role="custom">crm(live)resource# </prompt><command>start</command> <replaceable>ID</replaceable></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cleanup">
+  <section xml:id="sec-ha-manual-config-cleanup">
    <title>清理资源</title>
    <para>
     如果资源失败，它会自动重启动，但每次失败都会增加资源的失败计数。如果已为此资源设置 <literal>migration-threshold</literal>，那么一旦失败计数达到迁移阈值，节点将不再能运行此资源。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       打开外壳并以 <systemitem class="username">root</systemitem> 用户身份登录。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       获取所有资源的列表。
      </para>
@@ -1144,28 +1148,28 @@ Resource Group: dlm-clvm:1
          clvm:1 (ocf::lvm2:clvmd) Started
          cmirrord:1     (ocf::lvm2:cmirrord) Started</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       例如，要清理资源 <literal>dlm</literal>，请执行以下操作：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource cleanup dlm</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-remove">
+  <section xml:id="sec-ha-manual-config-remove">
    <title>删除群集资源</title>
    <para>
     请按如下操作以删除群集资源：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 用户身份登录，然后启动 <command>crm</command> 交互式外壳：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       运行以下命令来获取您的资源列表：
      </para>
@@ -1175,22 +1179,22 @@ Resource Group: dlm-clvm:1
      </para>
 <screen>myIP    (ocf::IPaddr:heartbeat) ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       删除具有相关标识符的资源（也暗指 <command>commit</command>）：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> delete <replaceable>YOUR_ID</replaceable></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       提交更改：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-migrate">
+  <section xml:id="sec-ha-manual-config-migrate">
    <title>迁移群集资源</title>
    <para>
     虽然资源已配置为在发生硬件或软件故障时自动故障转移（或迁移）到群集的其他节点，但您也可以使用 Pacemaker GUI 或命令行将资源手动迁移到群集中的其他节点。
@@ -1200,9 +1204,9 @@ Resource Group: dlm-clvm:1
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource
 <prompt role="custom">crm(live)resource# </prompt><command>migrate</command> ipaddress1 bob</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-tag">
+  <section xml:id="sec-ha-manual-config-tag">
    <title>分组/标记资源</title>
 
    <para>
@@ -1223,9 +1227,9 @@ Resource Group: dlm-clvm:1
     <para>标记（用于对资源分组）和某些 ACL 功能仅适用于 <literal>pacemaker-2.0</literal> 或更高的 CIB 语法版本。有关如何查验这一点以及升级 CIB 版本的细节，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>高可用性指南</citetitle>》中“<citetitle>从 SLE HA 11 SP3 升级到 SLE HA 11 SP4</citetitle>”一节所述的指导。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cli-maint-mode">
+  <section xml:id="sec-ha-manual-config-cli-maint-mode">
    <title>使用维护模式</title>
 
    
@@ -1287,10 +1291,10 @@ Resource Group: dlm-clvm:1
    <para>
     有关处于维护模式的资源和群集的行为的细节，请参见<xref linkend="sec-ha-config-basics-maint-mode"/>。
    </para>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
- <sect1 id="sec-ha-config-crm-setpwd">
+ <section xml:id="sec-ha-config-crm-setpwd">
   <title>设置独立于 <filename>cib.xml</filename> 的密码</title>
 
   <para>
@@ -1322,9 +1326,9 @@ linux</screen>
   <para>
    请注意，节点之间需要同步参数，使用 <command>crm resource secret</command> 命令可以帮助您处理好同步问题。强烈建议仅使用此命令管理机密参数。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-crm-history">
+ <section xml:id="sec-ha-config-crm-history">
   <title>检索历史记录信息</title>
 
   <para>
@@ -1381,7 +1385,7 @@ linux</screen>
 
 
   <para>
-   要查找更多示例以及如何创建时间段的信息，请访问 <ulink url="http://labix.org/python-dateutil"/>。
+   要查找更多示例以及如何创建时间段的信息，请访问 <link xlink:href="http://labix.org/python-dateutil"/>。
   </para>
 
   <para>
@@ -1429,8 +1433,8 @@ INFO: fetching new logs, please wait ...</screen>
   </para>
 
 <screen><prompt role="custom">crm(live)history# </prompt><command>transition</command> -1 nograph</screen>
- </sect1>
- <sect1 id="sec-ha-config-crm-more">
+ </section>
+ <section xml:id="sec-ha-config-crm-more">
   <title>更多信息</title>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -1441,7 +1445,7 @@ INFO: fetching new logs, please wait ...</screen>
    </listitem>
    <listitem>
     <para>
-     访问 <ulink url="http://crmsh.github.io/documentation"/> 中的上游项目文档。
+     访问 <link xlink:href="http://crmsh.github.io/documentation"/> 中的上游项目文档。
     </para>
    </listitem>
    <listitem>
@@ -1450,5 +1454,5 @@ INFO: fetching new logs, please wait ...</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_config_example.xml
+++ b/zh_CN/xml/ha_config_example.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_config_example.xml" id="cha-ha-config-example">
- <title>OCFS2 和 cLVM 的示例配置</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_example.xml" xml:id="cha-ha-config-example"><title>OCFS2 和 cLVM 的示例配置</title><info/>
+ 
  <para>
   下面是可帮助您设置资源以便使用 OCFS2 和/或 cLVM 的示例配置。下面的配置并不是完整群集配置，只是摘录，其中包括 OCFS2 和 cLVM 需要的所有资源，并忽略您可能需要的任何其他资源。属性和属性值可能需要根据特定设置调整。
  </para>
- <example id="ex-ha-config-ocfs2-clvm">
+ <example xml:id="ex-ha-config-ocfs2-clvm">
   <title>OCFS2 和 cLVM 的群集配置</title>
 
 <screen>primitive clvm ocf:lvm2:clvmd \

--- a/zh_CN/xml/ha_config_gui.xml
+++ b/zh_CN/xml/ha_config_gui.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_gui.xml" id="cha-ha-configuration-gui">
- <title>配置和管理群集资源 (GUI)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_gui.xml" xml:id="cha-ha-configuration-gui"><?dbfo-need height="20em"?><?dbfo-need height="20em"?><title>配置和管理群集资源 (GUI)</title><info><abstract>
   <para>
    本章介绍了 Pacemaker GUI，并包含配置和管理群集资源时所需的基本任务：修改全局群集选项、创建基本和高级类型的资源（组和克隆）、配置约束、指定故障转移节点和故障回复节点、配置资源监视以及手动启动、清理、删除和迁移资源。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <para>
   通过以下两个包提供 GUI 支持：<systemitem class="resource">pacemaker-mgmt</systemitem> 包，它包含 GUI 后端（<systemitem class="daemon">mgmtd</systemitem> 守护程序）。它必须安装在要使用 GUI 连接到的所有群集节点上。在要运行 GUI 的任何计算机上，安装 <systemitem class="resource">pacemaker-mgmt-client</systemitem> 包。
  </para>
@@ -27,17 +31,17 @@ Please see LICENSE.txt for this document's license.
    在要使用 Pacemaker GUI 连接到的所有节点上执行此操作。
   </para>
  </note>
-<?dbfo-need height="20em"?>
 
 
- <sect1 id="sec-ha-configuration-gui-intro">
+
+ <section xml:id="sec-ha-configuration-gui-intro">
   <title>Pacemaker GUI - 概述</title>
 
   <para>
    要启动 Pacemaker GUI，请在命令行输入 <command>crm_gui</command>。要访问配置和管理选项，需要登录到群集。
   </para>
 
-  <sect2 id="sec-ha-configuration-gui-intro-connect">
+  <section xml:id="sec-ha-configuration-gui-intro-connect">
    <title>登录到群集</title>
    <para>
     要连接到群集，请选择 <menuchoice> <guimenu>连接</guimenu><guimenu>登录</guimenu> </menuchoice>。默认情况下，<guimenu>Server</guimenu>（服务器）字段会显示本地主机的 IP 地址，<guimenu>User Name</guimenu>（用户名）字段会显示 <systemitem>hacluster</systemitem>。输入该用户的密码以继续。
@@ -56,13 +60,13 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果是远程运行 Pacemaker GUI，请为<guimenu>服务器</guimenu>字段输入群集节点的 IP 地址。对于<guimenu>用户名</guimenu>，您还可以使用属于 <systemitem>haclient</systemitem> 组的任何其他用户连接到群集。
    </para>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-gui-intro-main">
+  <section xml:id="sec-ha-configuration-gui-intro-main">
    <title>主窗口</title>
    <para>
     连接后，系统会打开主窗口：
@@ -134,9 +138,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以下各节将指导您完成配置群集选项和资源时需要执行的主要任务，并介绍如何使用 Pacemaker GUI 管理资源。除非另有说明，否则逐步指示信息反映了在简单模式下执行的过程。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-global">
   <title>配置全局群集选项</title>
 
   <para>
@@ -156,29 +160,29 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-gui-global">
+  <procedure xml:id="pro-ha-config-gui-global">
    <title>修改全局群集选项</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<menuchoice> <guimenu>视图</guimenu> <guimenu>简单模式</guimenu> </menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左窗格中，选择 <guimenu>CRM 配置</guimenu>可查看全局群集选项及其当前值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根据群集要求，将<guimenu>无仲裁人数策略</guimenu>设置为适当值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果由于某些原因需要禁用屏蔽，请取消选择 <guimenu>stonith 已启用</guimenu>。
     </para>
@@ -189,7 +193,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>应用</guimenu>确认更改。
     </para>
@@ -199,11 +203,11 @@ Please see LICENSE.txt for this document's license.
   <para>
    通过在左窗格中选择 <guimenu>CRM 配置</guimenu>并单击<guimenu>默认值</guimenu>可随时切换回所有选项的默认值。
   </para>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-config-gui-resources">
+
+ <section xml:id="sec-ha-config-gui-resources">
   <title>配置群集资源</title>
 
   <para>
@@ -214,44 +218,44 @@ Please see LICENSE.txt for this document's license.
    有关可创建的资源类型的概述，请参见<xref linkend="sec-ha-config-basics-resources-types"/>。
   </para>
 
-  <sect2 id="sec-ha-configuration-create">
+  <section xml:id="sec-ha-configuration-create">
    <title>创建简单群集资源</title>
    <para>
     要创建最基本的资源类型，请按如下操作：
    </para>
-   <procedure id="pro-ha-config-gui-primitives">
+   <procedure xml:id="pro-ha-config-gui-primitives">
     <title>添加原始资源</title>
-    <step id="st-ha-configuration-create-start" performance="required">
+    <step xml:id="st-ha-configuration-create-start">
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择<guimenu>资源</guimenu>并单击<menuchoice> <guimenu>添加</guimenu> <guimenu>Primitive</guimenu></menuchoice>（原始）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个对话框中，为资源设置以下参数：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         为资源输入唯一的 <guimenu>ID</guimenu>。
        </para>
       </step>
-      <step id="step-ha-config-gui-primitives-start" performance="required">
+      <step xml:id="step-ha-config-gui-primitives-start">
        <para>
         从<guimenu>类</guimenu>列表中，选择要用于该资源的资源代理类：<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>service</guimenu> 或 <guimenu>stonith</guimenu>。有关详细信息，请参见 <xref linkend="sec-ha-config-basics-raclasses"/>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果选择了 <guimenu>ocf</guimenu> 作为类，请同时指定 OCF 资源代理的<guimenu>提供程序</guimenu>。OCF 规范允许多个供应商供应相同的资源代理。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         从 <guimenu>Type</guimenu>（类型）列表中，选择要使用的资源代理（例如 <guimenu>IPaddr</guimenu> 或 <guimenu>Filesystem</guimenu>）。该资源代理的简短描述显示在下方。
        </para>
@@ -259,12 +263,12 @@ Please see LICENSE.txt for this document's license.
         <guimenu>Type</guimenu>（类型）列表中提供的选项取决于您选择的 <guimenu>Class</guimenu>（类）（对于 OCF 资源还取决于 <guimenu>Provider</guimenu>（提供程序）中选择的内容）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在 <guimenu>Options</guimenu>（选项）下面，设置 <guimenu>Initial state of resource</guimenu>（资源的初始状态）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果希望群集监视资源状况是否仍然正常，请激活 <guimenu>Add monitor operation</guimenu>（添加监视操作）。
        </para>
@@ -281,12 +285,12 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>Forward</guimenu>（前进）。下一个窗口将显示已为该资源定义的参数摘要。系统会列出该资源的所有必需的 <guimenu>Instance Attributes</guimenu>（实例属性）。若要设置相应的值，需要对实例属性进行编辑。可能还需要添加更多的属性，具体取决于您的部署和设置。有关如何操作的细节，请参考<xref linkend="pro-ha-config-gui-parameters"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击<guimenu>应用</guimenu>完成该资源的配置。配置对话框关闭，主窗口显示新添加的资源。
      </para>
@@ -312,14 +316,14 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-config-gui-parameters">
+   <procedure xml:id="pro-ha-config-gui-parameters">
     <title>添加或修改元属性和实例属性</title>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主窗口中，单击左窗格中的<guimenu>资源</guimenu>可查看已为群集配置的资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中，选择要修改的资源并单击 <guimenu>Edit</guimenu>（编辑）（或双击资源）。下一个窗口将显示已为该资源定义的基本资源参数和 <guimenu>Meta Attributes</guimenu>（元属性）、<guimenu>Instance Attributes</guimenu>（实例属性）或 <guimenu>Operations</guimenu>（操作）。
      </para>
@@ -334,27 +338,27 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要添加新的元属性或实例属性，请选择相应的选项卡并单击 <guimenu>Add</guimenu>（添加）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择要添加的属性<guimenu>名称</guimenu>。将显示简短的<guimenu>描述</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，请指定属性<guimenu>值</guimenu>。否则，使用该属性的默认值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>OK</guimenu>（确定）确认更改。新添加或新修改的属性便显示在选项卡上。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成该资源的配置。配置对话框关闭，主窗口显示已修改的资源。
      </para>
@@ -372,9 +376,9 @@ Please see LICENSE.txt for this document's license.
      编辑器将显示 XML 代码，允许您 <guimenu>Import</guimenu>（导入）或 <guimenu>Export</guimenu>（导出）XML 元素或手动编辑 XML 代码。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-stonith">
+  <section xml:id="sec-ha-configuration-stonith">
    <title>创建 STONITH 资源</title>
    <important>
     <title>无 STONITH 资源不受支持</title>
@@ -385,56 +389,56 @@ Please see LICENSE.txt for this document's license.
    <para>
     默认情况下，全局群集选项 <literal>stonith-enabled</literal> 设置为 <literal>true</literal>：如果未定义任何 STONITH 资源，群集将拒绝启动任何资源。要完成 STONITH 设置，需要配置一个或多个 STONITH 资源。虽然 STONITH 资源的配置过程与其他资源类似，但它们的行为在某些方面有所不同。有关细节，请参见<xref linkend="sec-ha-fencing-config"/>。
    </para>
-   <procedure id="pro-ha-config-gui-stonith">
+   <procedure xml:id="pro-ha-config-gui-stonith">
     <title>添加 STONITH 资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择<guimenu>资源</guimenu>并单击<menuchoice> <guimenu>添加</guimenu> <guimenu>Primitive</guimenu></menuchoice>（原始）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个对话框中，为资源设置以下参数：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         为资源输入唯一的 <guimenu>ID</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         从 <guimenu>Class</guimenu>（类）列表，选择资源代理类 <guimenu>stonith</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         从<guimenu>类型</guimenu>列表中，选择 用于控制 STONITH 设备的 STONITH 插件。该插件的简短描述显示在下方。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在 <guimenu>Options</guimenu>（选项）下面，设置 <guimenu>Initial state of resource</guimenu>（资源的初始状态）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果希望群集监视屏蔽设备，请激活 <guimenu>Add monitor operation</guimenu>（添加监视操作）。有关更多信息，请参考<xref linkend="sec-ha-fencing-monitor"/>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>Forward</guimenu>（前进）。下一个窗口将显示已为该资源定义的参数摘要。系统会针对所选 STONITH 插件列出所有必需的<guimenu>实例属性</guimenu>。若要设置相应的值，需要对实例属性进行编辑。可能还需要添加更多的属性或监视操作，具体取决于您的部署和设置。有关如何操作的细节，请参考<xref linkend="pro-ha-config-gui-parameters"/>和<xref linkend="sec-ha-configuration-monitor"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>Apply</guimenu>（应用）完成该资源的配置。配置对话框关闭，主窗口显示新添加的资源。
      </para>
@@ -443,90 +447,90 @@ Please see LICENSE.txt for this document's license.
    <para>
     要完成屏蔽配置，请添加约束和/或使用克隆。有关详细信息，请参见<xref linkend="cha-ha-fencing"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-gui-templates">
+  <section xml:id="sec-ha-config-gui-templates">
    <title>使用资源模板</title>
    <para>
     如果希望创建具有类似配置的多个资源，则定义资源模板是最简单的方式。定义后，就可在原始资源或特定类型的约束中引用它。有关功能及使用资源模板的详细信息，请参考<xref linkend="sec-ha-config-basics-constraints-templates"/>。
    </para>
-   <procedure id="pro-ha-config-gui-templates-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-templates-create">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择<guimenu>资源</guimenu>，然后单击<menuchoice> <guimenu>添加</guimenu> <guimenu>模板</guimenu> </menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为模板输入唯一的 <guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       像指定原始资源一样指定资源模板。遵循<xref linkend="pro-ha-config-gui-primitives" xrefstyle="select:label title nopage"/>操作，从<xref linkend="step-ha-config-gui-primitives-start" xrefstyle="select:label"/>开始。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击<guimenu>应用</guimenu>完成资源模板的配置。配置对话框关闭，主窗口显示新添加的资源模板。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-templates-use">
+   <procedure xml:id="pro-ha-config-gui-templates-use">
     <title>引用资源模板</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要在原始资源中引用新创建的资源模板，请遵循以下步骤：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左窗格中，选择<guimenu>资源</guimenu>并单击<menuchoice> <guimenu>添加</guimenu> <guimenu>Primitive</guimenu></menuchoice>（原始）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         输入唯一的 <guimenu>ID</guimenu>，并指定<guimenu>类</guimenu>、<guimenu>提供程序</guimenu>和<guimenu>类型</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         选择要引用的<guimenu>模板</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果要设置派生自该模板的特定实例属性、操作或元属性，请继续按<xref linkend="pro-ha-config-gui-primitives"/>中所述配置资源。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要在共置或顺序约束中引用新创建的资源模板：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         分别按<xref linkend="pro-ha-config-gui-constraints-collocation"/>或<xref linkend="pro-ha-config-gui-constraints-order"/>中所述配置约束。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         对于共置约束，<guimenu>资源</guimenu>下拉列表将显示已配置的所有资源和资源模板的 ID。从此列表中选择要引用的模板。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         类似地，对于顺序约束，<guimenu>首先</guimenu>和<guimenu>然后</guimenu>下拉列表将显示资源和资源列表。从这些列表中选择要引用的模板。
        </para>
@@ -534,9 +538,9 @@ Please see LICENSE.txt for this document's license.
      </substeps>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-constraints">
+  <section xml:id="sec-ha-configuration-constraints">
    <title>配置资源约束</title>
    <para>
     配置好所有资源只是完成了该任务的一部分。即便群集熟悉所有必需资源，它可能还无法进行正确处理。资源约束允许您指定在哪些群集节点上运行资源、以何种顺序装载资源，以及特定资源依赖于哪些其他资源。
@@ -550,45 +554,45 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-constraints-location">
+   <procedure xml:id="pro-ha-config-gui-constraints-location">
     <title>添加或修改位置约束</title>
-    <step id="step-ha-configuration-constraints-start" performance="required">
+    <step xml:id="step-ha-configuration-constraints-start">
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主窗口中，单击左窗格中的<guimenu>约束</guimenu>以查看已为群集配置的约束。
      </para>
     </step>
-    <step id="step-ha-configuration-constraints-stop" performance="required">
+    <step xml:id="step-ha-configuration-constraints-stop">
      <para>
       在左窗格中，选择 <guimenu>Constraints</guimenu>（约束）并单击 <guimenu>Add</guimenu>（添加）。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择 <guimenu>Resource Location</guimenu>（资源位置）并单击 <guimenu>OK</guimenu>（确定）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为约束输入唯一的 <guimenu>ID</guimenu>。修改现有约束时，ID 已经定义并显示在配置对话框中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择要定义约束的<guimenu>资源</guimenu>。列表中显示群集已配置的所有资源的 ID。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       设置约束的<guimenu>分数</guimenu>。正值表示资源可以在以下指定的<guimenu>节点</guimenu>上运行。负值表示它不应在该节点上运行。将分数设置为 <literal>INFINITY</literal> 将强制资源在该节点上运行。将其设置为 <literal>-INFINITY</literal> 则表示资源不得在该节点上运行。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择约束的<guimenu>节点</guimenu>。
      </para>
@@ -603,47 +607,47 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       如果将 <guimenu>Node</guimenu>（节点）和 <guimenu>Score</guimenu>（分数）字段留为空白，也可以通过单击<menuchoice> <guimenu>Add</guimenu><guimenu>Rule</guimenu></menuchoice>（添加 &gt; 规则）来添加规则。要添加有效期，只需单击 <menuchoice> <guimenu>Add</guimenu> <guimenu>Lifetime</guimenu></menuchoice>（添加&gt;有效期）即可。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成约束配置。配置对话框关闭，主窗口显示新添加或新修改的约束。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-collocation">
+   <procedure xml:id="pro-ha-config-gui-constraints-collocation">
     <title>添加或修改共置约束</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主窗口中，单击左窗格中的<guimenu>约束</guimenu>以查看已为群集配置的约束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择 <guimenu>Constraints</guimenu>（约束）并单击 <guimenu>Add</guimenu>（添加）。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择<guimenu>资源共置</guimenu>，然后单击<guimenu>确定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为约束输入唯一的 <guimenu>ID</guimenu>。修改现有约束时，ID 已经定义并显示在配置对话框中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择要充当共置源的<guimenu>资源</guimenu>。此列表显示已为群集配置的所有资源和资源模板的 ID。
      </para>
@@ -651,23 +655,23 @@ Please see LICENSE.txt for this document's license.
       如果约束无法满足，群集可以决定根本不允许运行资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       如果将 <guimenu>Resource</guimenu>（资源）和 <guimenu>With Resource</guimenu>（排列资源）字段都保留为空，也可以通过单击<menuchoice> <guimenu>Add</guimenu> <guimenu>Resource Set</guimenu></menuchoice>（添加 &gt; 资源集）来添加资源集。要添加有效期，只需单击 <menuchoice> <guimenu>Add</guimenu><guimenu>Lifetime</guimenu></menuchoice>（添加 &gt; 有效期）即可。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>共置资源</guimenu>中，定义共置目标。群集先决定将此资源放置在什么位置，再决定将此资源放置在 <guimenu>Resource</guimenu>（资源）字段的什么位置。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定义 <guimenu>Score</guimenu>（分数）可确定两个资源的位置关系。正值表示两个资源应在相同的节点上运行。负值表示两个资源不应在相同的节点上运行。将分数设置为 <literal>INFINITY</literal> 将强制资源在同一个节点上运行。将其设置为 <literal>-INFINITY</literal> 则表示资源不得在同一个节点上运行。分数将与其他因数结合使用，以确定放置资源的位置。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，请指定进一步参数，如 <guimenu>Resource Role</guimenu>（资源角色）。
      </para>
@@ -675,46 +679,46 @@ Please see LICENSE.txt for this document's license.
       根据选择的参数和选项，显示简短<guimenu>描述</guimenu>，解释您正在配置的共置约束的效果。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成约束配置。配置对话框关闭，主窗口显示新添加或新修改的约束。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-order">
+   <procedure xml:id="pro-ha-config-gui-constraints-order">
     <title>添加或修改顺序约束</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主窗口中，单击左窗格中的<guimenu>约束</guimenu>以查看已为群集配置的约束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择 <guimenu>Constraints</guimenu>（约束）并单击 <guimenu>Add</guimenu>（添加）。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择 <guimenu>Resource Order</guimenu>（资源顺序）并单击 <guimenu>OK</guimenu>（确定）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为约束输入唯一的 <guimenu>ID</guimenu>。修改现有约束时，ID 已经定义并显示在配置对话框中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用<guimenu>首先</guimenu>定义必须先于使用<guimenu>然后</guimenu>指定的资源启动的资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <guimenu>Then</guimenu>（然后）定义必须后于 <guimenu>First</guimenu>（首先）资源启动的资源。
      </para>
@@ -722,24 +726,24 @@ Please see LICENSE.txt for this document's license.
       根据选择的参数和选项，显示简短<guimenu>描述</guimenu>，解释您正在配置的顺序约束的效果。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，定义更多参数，例如：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         指定<guimenu>分数</guimenu>。如果分数大于零，则约束为强制性的，否则只是建议。默认值为 <literal>INFINITY</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         为<guimenu>对称</guimenu>指定值。如果为 <literal>true</literal>，则资源将按相反顺序停止。默认值为 <literal>true</literal>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成约束配置。配置对话框关闭，主窗口显示新添加或新修改的约束。
      </para>
@@ -759,9 +763,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failover">
+  <section xml:id="sec-ha-configuration-failover">
    <title>指定资源故障转移节点</title>
    <para>
     资源在出现故障时会自动重启动。如果在当前节点上无法实现重启动，或如果在当前节点上发生 N 次故障，则资源会试图故障转移到其他节点。您可以多次定义资源的故障次数（<literal>migration-threshold</literal>），在该值之后资源会迁移到新节点。如果群集中存在两个以上的节点，则特定资源故障转移的节点由 High Availability 软件选择。
@@ -769,24 +773,24 @@ Please see LICENSE.txt for this document's license.
    <para>
     但您可以按如下操作指定资源将故障转移到的节点：
    </para>
-   <procedure id="pro-ha-config-gui-failover">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-failover">
+    <step>
      <para>
       按<xref linkend="pro-ha-config-gui-constraints-location"/>中所述，为该资源配置位置约束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="pro-ha-config-gui-parameters"/>中所述，为该资源添加 <literal>migration-threshold</literal> 元属性，并输入迁移阈值的<guimenu>值</guimenu>。值应该是小于 INFINITY 的正值。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果希望资源的故障计数自动失效，请按<xref linkend="pro-ha-config-gui-parameters"/>中所述为该资源添加 <literal>failure-timeout</literal> 元属性，并输入故障超时的<guimenu>值</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果希望为资源指定更多的首选故障转移节点，请创建更多的位置约束。
      </para>
@@ -798,9 +802,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     您可以随时手动清理资源的失败计数，而不是让资源的失败计数自动失效。有关细节，请参见<xref linkend="sec-ha-configuration-cleanup"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failback">
+  <section xml:id="sec-ha-configuration-failback">
    <title>指定资源故障回复节点（资源黏性）</title>
    <para>
     当原始节点恢复联机并位于群集中时，资源可能会故障回复到该节点。如果要防止资源在故障转移前故障回复到之前运行的节点，或者要指定此资源故障回复到的其他节点，必须更改其资源粘性值。可以在创建资源时指定资源粘性或稍后指定。
@@ -811,9 +815,9 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-stickiness">
+   <procedure xml:id="pro-ha-config-gui-stickiness">
     <title>指定资源黏性</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="pro-ha-config-gui-parameters"/>中所述为资源添加 <literal>resource-stickiness</literal> 元属性。
      </para>
@@ -828,15 +832,15 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在资源黏性<guimenu>值</guimenu>中，指定介于 <literal>-INFINITY</literal> 和 <literal>INFINITY</literal> 之间的值。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-utilization">
+  <section xml:id="sec-ha-configuration-utilization">
    <title>根据负载影响配置资源放置</title>
    <para>
     并非所有资源都相等。某些资源（如 Xen guest）需要托管它们的节点满足其容量要求。如果所放置资源的总需求超过了提供的容量，则资源性能将降低（或甚至失败）。
@@ -867,66 +871,66 @@ Please see LICENSE.txt for this document's license.
    <para>
     要手动配置资源要求和节点提供的容量，请按<xref linkend="pro-ha-config-gui-capacity"/>中所述继续。可根据个人喜好命名利用率属性，并根据配置需要定义多个名称/值对。
    </para>
-   <procedure id="pro-ha-config-gui-capacity">
+   <procedure xml:id="pro-ha-config-gui-capacity">
     <title>添加或修改利用率属性</title>
     <para>
      在下例中，我们假定您已有群集节点和资源的基本配置，现在想要配置特定节点提供的容量以及特定资源需要的容量。添加利用率属性的过程基本相同，仅<xref linkend="step-ha-config-gui-capacity-node"/>和<xref linkend="step-ha-config-gui-capacity-resource"/>有所不同。
     </para>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-node" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-node">
      <para>
       指定节点<emphasis>提供</emphasis>的容量：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左窗格中，单击<guimenu>节点</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在右窗格中，选择要配置其容量的节点，然后单击<guimenu>编辑</guimenu>。
        </para>
       </step>
      </substeps>
     </step>
-    <step id="step-ha-config-gui-capacity-resource" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-resource">
      <para>
       指定资源<emphasis>需要</emphasis>的容量：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左窗格中，单击<guimenu>资源</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在右窗格中，选择要配置其容量的资源，然后单击<guimenu>编辑</guimenu>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择<guimenu>利用率</guimenu>选项卡，然后单击<guimenu>添加</guimenu>以添加利用率属性。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-name" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-name">
      <para>
       为新属性输入<guimenu>名称</guimenu>。可以根据个人喜好命名利用率属性。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-value" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-value">
      <para>
       为属性输入<guimenu>值</guimenu>，然后单击<guimenu>确定</guimenu>。属性值必须是整数。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要更多利用率属性，请重复<xref linkend="step-ha-config-gui-capacity-attr-name"/>到<xref linkend="step-ha-config-gui-capacity-attr-value"/>。
      </para>
@@ -934,7 +938,7 @@ Please see LICENSE.txt for this document's license.
       <guimenu>利用率</guimenu>选项卡显示已为此节点或资源定义的利用率属性的摘要。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根据意愿设置所有参数后，单击<guimenu>确定</guimenu>关闭配置对话框。
      </para>
@@ -943,7 +947,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     <xref linkend="fig-ha-config-gui-capacit-node"/>显示了将向运行在此节点上的资源提供 8 个 CPU 单元和 16 GB 内存的节点配置：
    </para>
-   <figure id="fig-ha-config-gui-capacit-node">
+   <figure xml:id="fig-ha-config-gui-capacit-node">
     <title>节点容量配置示例</title>
     <mediaobject>
      <imageobject role="fo">
@@ -957,7 +961,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     需要使用节点 4096 个内存单元和 4 个 CPU 单元的资源的配置示例如下所示：
    </para>
-   <figure id="fig-ha-config-gui-capacit-resource">
+   <figure xml:id="fig-ha-config-gui-capacit-resource">
     <title>资源容量配置示例</title>
     <mediaobject>
      <imageobject role="fo">
@@ -971,68 +975,68 @@ Please see LICENSE.txt for this document's license.
    <para>
     （手动或自动）配置了节点提供的容量和资源需要的容量后，需要设置全局群集选项中的放置策略，否则容量配置将不会生效。可使用多个策略来调度负载：例如，可以将负载集中到尽可能少的节点上，或使其均匀分布在所有可用节点上。有关更多信息，请参见<xref linkend="sec-ha-config-basics-utilization"/>。
    </para>
-   <procedure id="pro-ha-config-gui-placement">
+   <procedure xml:id="pro-ha-config-gui-placement">
     <title>设置放置策略</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择<menuchoice> <guimenu>视图</guimenu> <guimenu>简单模式</guimenu> </menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择 <guimenu>CRM 配置</guimenu>可查看全局群集选项及其当前值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根据要求，将<guimenu>放置策略</guimenu>设置为适当值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果由于某些原因需要禁用屏蔽，请取消选择 <literal>Stonith Enabled</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击<guimenu>应用</guimenu>确认更改。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-monitor">
+  <section xml:id="sec-ha-configuration-monitor">
    <title>配置资源监视</title>
    <para>
     虽然 High Availability Extension 可以检测节点故障，但也能够检测节点上的单个资源何时发生故障。如果要确保资源正在运行，必须为其配置资源监视。资源监视包括指定超时和/或启动延迟值以及间隔。间隔告诉 CRM 检查资源状态的频率。您还可以设置特定参数，如为 <literal>start</literal> 或 <literal>stop</literal> 操作设置 <literal>timeout</literal>。
    </para>
-   <procedure id="pro-ha-config-gui-operations">
+   <procedure xml:id="pro-ha-config-gui-operations">
     <title>添加或修改监视操作</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主窗口中，单击左窗格中的<guimenu>资源</guimenu>可查看已为群集配置的资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中，选择要修改的资源并单击 <guimenu>Edit</guimenu>（编辑）。下一个窗口将显示为该资源定义的基本资源参数、元属性、实例属性和操作。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要添加新的监视操作，请选择各自选项卡并单击 <guimenu>Add</guimenu>（添加）。
      </para>
@@ -1042,7 +1046,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       在 <guimenu>Name</guimenu>（名称）中，选择要执行的操作，例如 <literal>monitor</literal>、<literal>start</literal> 或 <guimenu>stop</guimenu>。
      </para>
@@ -1060,17 +1064,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 <guimenu>timeout</guimenu>（超时）字段中，输入以秒表示的值。在指定的超时期间后，操作会被视为 <literal>failed</literal>。PE 会决定如何做或执行您在监视操作的 <guimenu>On Fail</guimenu>（失败时）字段中指定的操作。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，可展开<guimenu>可选</guimenu>部分并添加参数，如<guimenu>失败时</guimenu>（如果此操作失败将执行什么操作？）或 <guimenu>Requires</guimenu>（要求）（发生此操作前需要满足哪些条件？）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成该资源的配置。配置对话框关闭，主窗口显示已修改的资源。
      </para>
@@ -1093,9 +1097,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-group">
+  <section xml:id="sec-ha-configuration-group">
    <title>配置群集资源组</title>
    <para>
     某些群集资源依赖于其他组件或资源，并且要求每个组件或资源都按特定顺序启动并在同一服务器上一起运行。为了简化此配置，我们支持组的概念。
@@ -1109,39 +1113,39 @@ Please see LICENSE.txt for this document's license.
      组必须包含至少一个资源，否则配置无效。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-group">
+   <procedure xml:id="pro-ha-config-gui-group">
     <title>添加资源组</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择 <guimenu>Resources</guimenu>（资源）并单击 <menuchoice> <guimenu>Add</guimenu> <guimenu>Group</guimenu> </menuchoice>（添加 &gt; 组）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为组输入唯一的 <guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 <guimenu>Options</guimenu>（选项）下面，设置 <guimenu>Initial state of resource</guimenu>（资源的初始状态）并单击 <guimenu>Forward</guimenu>（前进）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个步骤中，可以添加原始资源作为组的子资源。它们的创建方式与<xref linkend="pro-ha-config-gui-primitives"/>中描述的步骤类似。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>Apply</guimenu>（应用）完成原始资源的配置。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个窗口中，可以通过再次选择 <guimenu>Primitive</guimenu>（原始）并单击 <guimenu>OK</guimenu>（确定）来继续为组添加子资源。
      </para>
@@ -1149,12 +1153,12 @@ Please see LICENSE.txt for this document's license.
       当不希望再向组中添加原始资源时，单击 <guimenu>Cancel</guimenu>（取消）。下一个窗口将显示您为该组定义的参数摘要。系统会列出组的 <guimenu>Meta Attributes</guimenu>（元属性）和 <guimenu>Primitives</guimenu>（原始）资源。资源在 <guimenu>Primitive</guimenu>（原始）选项卡上的位置代表资源在群集中的启动顺序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       由于资源在组中的顺序很重要，可使用<guimenu>向上</guimenu>和<guimenu>向下</guimenu>按钮对组中的<guimenu>原始资源</guimenu>进行排序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>OK</guimenu>（确定）完成该组的配置。配置对话框关闭，主窗口显示新创建或新修改的组。
      </para>
@@ -1177,76 +1181,76 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-group-modify">
+   <procedure xml:id="pro-ha-config-gui-group-modify">
     <title>向现有组添加资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，切换到 <guimenu>Resources</guimenu>（资源）视图；在右窗格中，选择要修改的组并单击 <guimenu>Edit</guimenu>（编辑）。下一个窗口将显示为该资源定义的基本组参数以及元属性和原始资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>Primitives</guimenu>（原始）选项卡并单击 <guimenu>Add</guimenu>（添加）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个对话框中，若要将 IP 地址添加为组的子资源，请设置以下参数：
      </para>
      <substeps performance="required">
-      <step id="step-ha-config-gui-group-prim-start" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-start">
        <para>
         输入唯一的 <guimenu>ID</guimenu>（例如，<literal>my_ipaddress</literal>）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         从 <guimenu>Class</guimenu>（类）列表中，选择 <guimenu>ocf</guimenu> 作为资源代理类。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在 OCF 资源代理的 <guimenu>Provider</guimenu>（提供程序）中，选择 <guimenu>heartbeat</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         从 <guimenu>Type</guimenu>（类型）列表中，选择 <guimenu>IPaddr</guimenu> 作为资源代理。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         单击 <guimenu>Forward</guimenu>（前进）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在 <guimenu>Instance Attribute</guimenu>（实例属性）选项卡中，选择 <guimenu>IP </guimenu>条目并单击 <guimenu>Edit</guimenu>（编辑）（或双击 <guimenu>IP</guimenu> 条目）。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>值</guimenu>中输入所需的 IP 地址，例如 <literal>192.168.1.180</literal>。
        </para>
       </step>
-      <step id="step-ha-config-gui-group-prim-stop" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-stop">
        <para>
         单击 <guimenu>OK</guimenu>（确定）并单击 <guimenu>Apply</guimenu>（应用）。组配置对话框将显示新添加的原始资源。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       再次单击 <guimenu>Add</guimenu>（添加）可添加下一个子资源（文件系统和 Web 服务器）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       设置每个子资源各自的参数，其过程类似于从<xref linkend="step-ha-config-gui-group-prim-start"/>到<xref linkend="step-ha-config-gui-group-prim-stop"/>的步骤，直到为组配置完所有子资源为止。
      </para>
@@ -1264,25 +1268,25 @@ Please see LICENSE.txt for this document's license.
       由于已按子资源在群集中所需的启动顺序对子资源进行了配置，所以 <guimenu>Primitives</guimenu>（原始）选项卡上的顺序已是正确的。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要更改组的资源顺序，请使用<guimenu>向上</guimenu>和<guimenu>向下</guimenu>按钮对<guimenu>原始资源</guimenu>选项卡上的资源排序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要从组中删除资源，请在 <guimenu>Primitive</guimenu>（原始）选项卡上选择资源，并单击 <guimenu>Remove</guimenu>（删除）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>OK</guimenu>（确定）完成该组的配置。配置对话框关闭，主窗口显示修改后的组。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-clone">
+  <section xml:id="sec-ha-configuration-clone">
    <title>配置克隆资源</title>
    <para>
     您可能希望某些资源在群集的多个节点上同时运行。为此，必须将资源配置为克隆资源。可以配置为克隆资源的资源示例包括 STONITH 和群集文件系统（如 OCFS2）。可以克隆提供的任何资源。资源的资源代理支持此操作。克隆资源的配置甚至也有不同，具体取决于资源驻留的节点。
@@ -1290,47 +1294,47 @@ Please see LICENSE.txt for this document's license.
    <para>
     有关可用的资源克隆类型的概述，请参见<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>。
    </para>
-   <procedure id="pro-ha-config-gui-clone">
+   <procedure xml:id="pro-ha-config-gui-clone">
     <title>添加或修改克隆</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中，选择 <guimenu>Resources</guimenu>（资源）并单击 <menuchoice> <guimenu>Add</guimenu><guimenu>Clone</guimenu></menuchoice>（添加 &gt; 克隆）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为克隆资源输入唯一的 <guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 <guimenu>Options</guimenu>（选项）下面，设置 <guimenu>Initial state of resource</guimenu>（资源的初始状态）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为克隆资源激活要设置的各个选项，并单击 <guimenu>Forward</guimenu>（前进）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一个步骤中，可以添加 <guimenu>Primitive</guimenu>（原始）或 <guimenu>Group</guimenu>（组）作为克隆资源的子资源。创建方式与<xref linkend="pro-ha-config-gui-primitives"/>或<xref linkend="pro-ha-config-gui-group"/>中描述的过程类似。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有参数都按您的需要进行了设置，请单击 <guimenu>Apply</guimenu>（应用）完成复制配置。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-manage">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-manage">
   <title>管理群集资源</title>
 
   <para>
@@ -1349,7 +1353,7 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <sect2 id="sec-ha-configuration-start">
+  <section xml:id="sec-ha-configuration-start">
    <title>启动资源</title>
    <para>
     启动群集资源之前，应确保资源设置正确。例如，如果要使用 Apache 服务器作为群集资源，请先设置 Apache 服务器并完成 Apache 配置，然后才能启动群集中的相应资源。
@@ -1369,27 +1373,27 @@ Please see LICENSE.txt for this document's license.
    <para>
     在使用 Pacemaker GUI 创建资源的过程中，可以使用 <literal>target-role</literal> 元属性设置资源的初始状态。如果其值已设置为 <literal>stopped</literal>，则资源不会在创建后自动启动。
    </para>
-   <procedure id="pro-ha-config-gui-start">
+   <procedure xml:id="pro-ha-config-gui-start">
     <title>启动新资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中，右键单击资源并从上下文菜单中选择<guimenu>启动</guimenu>（或使用工具栏中的<guimenu>启动资源</guimenu>图标）。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-cleanup">
+  <section xml:id="sec-ha-configuration-cleanup">
    <title>清理资源</title>
    <para>
     如果资源失败，它会自动重启动，但每次失败都会增加资源的失败计数。要使用 Pacemaker GUI 查看资源的失败计数，请在左窗格中单击<guimenu>管理</guimenu>，然后在右窗格中选择该资源。如果资源失败，其<guimenu>失败计数</guimenu>将显示在右窗格中间（<guimenu>迁移阈值</guimenu>项下面）。
@@ -1400,33 +1404,33 @@ Please see LICENSE.txt for this document's license.
    <para>
     可自动重设置资源的失败计数（通过设置资源的 <literal>failure-timeout</literal> 选项），也可如下所述手动重设置。
    </para>
-   <procedure id="pro-ha-config-gui-clean">
+   <procedure xml:id="pro-ha-config-gui-clean">
     <title>清理资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中，右键单击相应资源，然后从上下文菜单中选择<guimenu>清理资源</guimenu>（或使用工具栏中的<guimenu>清理资源</guimenu>图标）。
      </para>
      <para>
-      这将对指定节点上的指定资源执行命令 <command>crm_resource <option>-C</option></command> 和 <command>crm_failcount <option>-D</option></command>。
+      这将对指定节点上的指定资源执行命令 <command>crm_resource </command> <option>-C</option> 和 <command>crm_failcount </command> <option>-D</option>。
      </para>
     </step>
    </procedure>
    <para>
     有关更多信息，请参见手册页 <command>crm_resource</command> 和 <command>crm_failcount</command>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-remove">
+  <section xml:id="sec-ha-configuration-remove">
    <title>删除群集资源</title>
    <para>
     如果需要从群集中删除资源，请遵循以下过程以免出现配置错误：
@@ -1438,59 +1442,59 @@ Please see LICENSE.txt for this document's license.
      如果群集资源的 ID 由任何约束引用，则无法删除该群集资源。如果您无法删除某个资源，请检查引用资源 ID 的位置，然后先从该约束删除资源。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-rm">
+   <procedure xml:id="pro-ha-config-gui-rm">
     <title>删除群集资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中选择相应的资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="pro-ha-config-gui-clean"/>中所述清理所有节点上的资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>停止</guimenu>资源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       删除与资源相关的所有约束，否则将无法删除资源。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-migrate">
+  <section xml:id="sec-ha-configuration-migrate">
    <title>迁移群集资源</title>
    <para>
     如<xref linkend="sec-ha-configuration-failover"/>中所述，如果软件或硬件发生故障，群集会根据可自定义的特定参数（例如，迁移阈值或资源粘性），自动进行资源故障转移（迁移）。除此之外，还可以手动将资源迁移到群集中的其他节点。
    </para>
-   <procedure id="pro-ha-config-gui-migrate">
+   <procedure xml:id="pro-ha-config-gui-migrate">
     <title>手动迁移资源</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中右键单击相应资源，然后选择<guimenu>迁移资源</guimenu>。
      </para>
@@ -1505,17 +1509,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在新窗口的 <guimenu>To Node</guimenu>（目标节点）中，选择资源要移动到的节点。此操作将创建目标节点分数为 <literal>INFINITY</literal> 的位置约束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果只是希望临时迁移资源，请激活 <guimenu>Duration</guimenu>（持续时间）并输入资源迁移到新节点的时间范围。在持续时间到期后，资源<emphasis>可以</emphasis>移回到其原始位置，也可以留在当前位置（取决于资源黏性）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果资源无法迁移（若资源在当前节点上的黏性和约束总分数大于 <literal>INFINITY</literal>），请激活 <guimenu>Force</guimenu>（强制）选项。它通过创建当前位置规则和 <literal>-INFINITY</literal> 的分数强制资源移动。
      </para>
@@ -1525,7 +1529,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>OK</guimenu>（确定）确认迁移。
      </para>
@@ -1534,55 +1538,55 @@ Please see LICENSE.txt for this document's license.
    <para>
     要使资源重新移回，请按如下操作：
    </para>
-   <procedure id="pro-ha-config-gui-migrate-back">
+   <procedure xml:id="pro-ha-config-gui-migrate-back">
     <title>清除迁移约束</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中右键单击相应资源，然后选择<guimenu>清除迁移约束</guimenu>。
      </para>
      <para>
-      这将使用 <command>crm_resource <option>-U</option></command> 命令。资源<emphasis>可以</emphasis>移回到其原始位置，也可以留在当前位置（取决于资源黏性）。
+      这将使用 <command>crm_resource </command> <option>-U</option> 命令。资源<emphasis>可以</emphasis>移回到其原始位置，也可以留在当前位置（取决于资源黏性）。
      </para>
     </step>
    </procedure>
    <para>
-    有关更多信息，请参见 <command>crm_resource</command> 手册页，或<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明），可从 <ulink url="http://www.clusterlabs.org/doc/"/> 获取。请参见<citetitle>“Resource Migration”</citetitle>（资源迁移）一章。
+    有关更多信息，请参见 <command>crm_resource</command> 手册页，或<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明），可从 <link xlink:href="http://www.clusterlabs.org/doc/"/> 获取。请参见<citetitle>“Resource Migration”</citetitle>（资源迁移）一章。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-mgmt-mode">
+  <section xml:id="sec-ha-configuration-mgmt-mode">
    <title>更改资源的管理模式</title>
    <para>
     由群集管理资源时，不得以其他方式（在群集外）处理资源。要维护各个资源，可将相应资源设置为 <literal>unmanaged mode</literal>，在此模式下可在群集外修改资源。
    </para>
    <procedure>
     <title>更改资源的管理模式</title>
-    <step performance="required">
+    <step>
      <para>
       按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左窗格中单击<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右窗格中右键单击相应资源，然后从上下文菜单中选择<guimenu>不受管资源</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       完成此资源的维护任务后，在右窗格中再次右键单击相应资源，然后选择<guimenu>管理资源</guimenu>。
      </para>
@@ -1591,6 +1595,6 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_config_hawk.xml
+++ b/zh_CN/xml/ha_config_hawk.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_hawk.xml" id="cha-ha-config-hawk">
- <title>配置和管理群集资源（Web 界面）</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_hawk.xml" xml:id="cha-ha-config-hawk"><title>配置和管理群集资源（Web 界面）</title><info><abstract>
   <para>
    除了 <command>crm</command> 命令行工具和 Pacemaker GUI 之外，High Availability Extension 还随附 HA Web Konsole (Hawk)，这是一个用于管理任务的基于 Web 的用户界面。它还可用于从非 Linux 计算机监视和管理 Linux 群集。另外，如果系统仅提供很小的图形用户界面，它也会是个理想的解决方案。
   </para>
@@ -15,15 +17,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章介绍了 Hawk，并包含配置和管理群集资源的基本任务：修改全局群集选项、创建基本和高级类型的资源（组和克隆）、配置约束、指定故障转移节点和故障回复节点、配置资源监视以及手动启动、清理、删除和迁移资源。为了对群集状态进行详细分析，Hawk 会生成一个群集报告 (<literal>hb_report</literal>)。可以查看群集历史记录或使用模拟器浏览可能的失败方案。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-hawk-intro">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-hawk-intro">
   <title>Hawk - 概述</title>
 
   <para>
    Hawk 的 Web 界面还可让您从非 Linux 计算机监视和管理 Linux 群集。另外，如果系统仅提供很小的图形用户界面，它也会是个理想的解决方案。
   </para>
 
-  <sect2 id="sec-ha-config-hawk-intro-connect">
+  <section xml:id="sec-ha-config-hawk-intro-connect">
    <title>启动 Hawk 并登录</title>
    <para>
     此 Web 界面包含在 <systemitem class="resource">hawk</systemitem> 包中。它必须安装在要使用 Hawk 连接到的所有群集节点上。在要使用 Hawk 访问群集节点的计算机上，只需启用了 JavaScript 和 Cookie 的（图形）Web 浏览器即可建立连接。
@@ -34,20 +38,20 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果您是使用 <systemitem class="resource">sleha-bootstrap</systemitem> 包中的脚本设置的群集，则此时 Hawk 服务已启动。在这种情况下，请跳过<xref linkend="pro-ha-hawk-service"/>并继续执行<xref linkend="pro-ha-hawk-login"/>。
    </para>
-   <procedure id="pro-ha-hawk-service">
+   <procedure xml:id="pro-ha-hawk-service">
     <title>启动 Hawk 服务</title>
-    <step performance="required">
+    <step>
      <para>
       在要连接到的节点上，打开外壳并以 <systemitem class="username">root</systemitem> 用户身份登录。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       通过输入以下命令，检查服务的状态
      </para>
 <screen><prompt role="root">root # </prompt>rchawk status</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果服务未在运行，请使用以下命令启动服务
      </para>
@@ -70,7 +74,7 @@ Please see LICENSE.txt for this document's license.
      在要使用 Hawk 连接到的所有节点上执行此操作。
     </para>
    </note>
-   <procedure id="pro-ha-hawk-login">
+   <procedure xml:id="pro-ha-hawk-login">
     <title>登录到 Hawk Web 界面</title>
     <para>
      Hawk Web 界面使用 HTTPS 协议和端口 <literal>7630</literal>。
@@ -80,12 +84,12 @@ Please see LICENSE.txt for this document's license.
      <title>通过虚拟 IP 访问 Hawk</title>
      <para>如果您希望即使平时连接的群集节点已关闭，您也能够访问 Hawk，可为 Hawk 配置一个虚拟 IP 地址（<literal>IPaddr</literal> 或 <literal>IPaddr2</literal>）作为群集资源。该地址无需任何特殊配置。</para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       在任何计算机上，启动 Web 浏览器并确保 JavaScript 和 cookie 已启用。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       输入运行 Hawk Web 服务的任何群集节点的 IP 地址或主机名作为 URL。或者，输入群集操作员可能已配置为资源的任何虚拟 IP 地址：
      </para>
@@ -106,12 +110,12 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Hawk 登录屏幕上，输入 <systemitem class="username">hacluster</systemitem> 用户（或属于 <systemitem class="groupname">haclient</systemitem> 组的任何其他用户）的<guimenu>用户名</guimenu>和<guimenu>口令</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击<guimenu>登录</guimenu>。
      </para>
@@ -120,15 +124,15 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-hawk-intro-main">
+  <section xml:id="sec-ha-config-hawk-intro-main">
    <title>主屏幕：群集状态</title>
    
    <para>
     登录后，Hawk 会显示<guimenu>群集状态</guimenu>屏幕。该屏幕显示最重要的全局群集参数以及您的群集节点和资源的状态的摘要信息。以下颜色代码用于显示节点和资源的状态：
    </para>
-   <itemizedlist id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
+   <itemizedlist xml:id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
     <title>Hawk 颜色代码</title>
     <listitem>
      <para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
      <para>
       <guimenu>群集图表</guimenu>。选择此条目以获取通过图形表示的 CIB 中所配置的节点和资源。此图表还会显示资源与节点指派（分数）之间的顺序和共置。
      </para>
-     <figure id="fig-ha-cluster-diagram" pgwide="0">
+     <figure xml:id="fig-ha-cluster-diagram" pgwide="0">
       <title>Hawk - 群集图表</title>
       <mediaobject>
        <imageobject role="fo">
@@ -300,9 +304,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </note>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-hawk-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-hawk-global">
   <title>配置全局群集选项</title>
 
   <para>
@@ -322,14 +326,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-hawk-global">
+  <procedure xml:id="pro-ha-config-hawk-global">
    <title>修改全局群集选项</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集属性</guimenu>可查看全局群集选项及其当前值。Hawk 会显示与 <guimenu>CRM 配置</guimenu>、<guimenu>默认资源</guimenu>和<guimenu>默认操作</guimenu>相关的最重要参数。
 
@@ -346,17 +350,17 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根据群集要求，调整 <guimenu>CRM 配置</guimenu>：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        将 <guimenu>no-quorum-policy</guimenu> 设置为合适的值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果由于某些原因需要禁用屏蔽，请取消选择 <guimenu>stonith 已启用</guimenu>。
       </para>
@@ -367,41 +371,41 @@ Please see LICENSE.txt for this document's license.
        </para>
       </important>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要从 CRM 配置中删除某项属性，请单击该属性旁边的减号图标。如果删除了某项属性，则群集的表现方式就像该属性采有默认值一样。有关默认值的细节，请参见<xref linkend="sec-ha-config-basics-meta-attr"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要为 CRM 配置添加新属性，请从下拉框中选择一个属性，并单击加号。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您需要更改<guimenu>默认资源</guimenu>或<guimenu>默认操作</guimenu>，请执行以下步骤：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        要更改已显示的默认值，请编辑相应输入字段中的值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要添加新的默认资源或默认操作，请从空下拉列表中选择一项，单击加号图标，然后输入值。如果已定义默认值，Hawk 会自动建议这些值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要删除默认资源或默认操作，请单击参数旁边的减号图标。如果没有为<guimenu>默认资源</guimenu>和<guimenu>默认操作</guimenu>指定值，群集会使用默认值，如<xref linkend="sec-ha-config-basics-meta-attr"/>和<xref linkend="sec-ha-config-basics-operations"/>所述。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      确认更改。
     </para>
@@ -409,10 +413,10 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
 
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
- <sect1 id="sec-ha-config-hawk-dashboard">
+ </section>
+ <xi:include href="ha_hawk_rsc_config_i.xml" parse="xml"/>
+ <xi:include href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
+ <section xml:id="sec-ha-config-hawk-dashboard">
 
 
   <title>监视多个群集</title>
@@ -425,7 +429,7 @@ Please see LICENSE.txt for this document's license.
    <guimenu>群集仪表板</guimenu>中显示的群集信息存储在一份永久性 Cookie 中。因此，您需要决定要在<guimenu>群集仪表板</guimenu>上查看哪个 Hawk 实例，并始终使用该实例。这样一来，运行 Hawk 的计算机甚至不需要属于任何群集 - 该计算机可以是不相关的独立系统。
   </para>
 
-  <procedure id="pro-ha-config-hawk-dashboard">
+  <procedure xml:id="pro-ha-config-hawk-dashboard">
    <title>使用 Hawk 监视多个群集</title>
    <itemizedlist mark="bullet" spacing="normal">
     <title>先决条件</title>
@@ -445,18 +449,18 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <step performance="required">
+   <step>
     <para>
      在要用于监视多个群集的计算机上启动 Hawk Web 服务。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      启动 Web 浏览器并输入运行 Hawk 的计算机的 IP 地址或主机名作为 URL：
     </para>
 <screen>https://<replaceable>IPaddress</replaceable>:7630/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 Hawk 登录屏幕上，单击右上角中的<guimenu>仪表板</guimenu>链接。
     </para>
@@ -474,12 +478,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入自定义的<guimenu>群集名称</guimenu>，用于在<guimenu>群集仪表板</guimenu>中标识该群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入其中一个群集节点的<guimenu>主机名</guimenu>，然后确认更改。
     </para>
@@ -487,7 +491,7 @@ Please see LICENSE.txt for this document's license.
      <guimenu>群集仪表板</guimenu>随即会打开并显示您所添加的群集的摘要。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要将更多群集添加至仪表板，请单击加号图标，然后输入下一个群集的细节。
     </para>
@@ -503,12 +507,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要从仪表板中删除群集，请单击群集摘要旁边的 <literal>x</literal> 图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要查看关于群集的更多细节，请单击仪表板上群集框中的某处。
     </para>
@@ -516,7 +520,7 @@ Please see LICENSE.txt for this document's license.
      这会打开一个新的浏览器窗口或新的浏览器选项卡。如果您当前未登录群集，则这会打开 Hawk 登录屏幕。登录之后，Hawk 会在摘要视图中显示该群集的<guimenu>群集状态</guimenu>。从摘要视图中，可以按照常规方式使用 Hawk 来管理群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      因为<guimenu>群集仪表板</guimenu>始终在独立的浏览器窗口或选项卡中打开，所以在 Hawk 中您可以轻松地在仪表板与单个群集管理之间切换。
     </para>
@@ -528,15 +532,15 @@ Please see LICENSE.txt for this document's license.
   </para>
 
 
- </sect1>
- <sect1 id="sec-ha-config-hawk-geo">
+ </section>
+ <section xml:id="sec-ha-config-hawk-geo">
   <title>用于地域群集的 Hawk 功能</title>
 
   <para>
    有关与地理位置分散群集（地域群集）相关的 Hawk 功能的更多细节，请参见《<citetitle>Quick Start Geo Clustering for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></citetitle>》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-hawk-trouble">
+ </section>
+ <section xml:id="sec-ha-config-hawk-trouble">
   <title>查错</title>
 
   <variablelist>
@@ -559,7 +563,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-hawk-certificate">
+   <varlistentry xml:id="vle-ha-hawk-certificate">
     <term>替换自签名证书</term>
     <listitem>
      <para>
@@ -605,5 +609,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_drbd.xml
+++ b/zh_CN/xml/ha_drbd.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_drbd.xml" id="cha-ha-drbd">
- <title>DRBD</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_drbd.xml" xml:id="cha-ha-drbd"><title>DRBD</title><info><abstract>
   <para>
    通过<emphasis>分布式复制块设备</emphasis> (DRBD*)，您可以为位于 IP 网络上两个不同站点的两个块设备创建镜像。当和 OpenAIS 一起使用时，DRBD 支持分布式高可用性 Linux 群集。本章说明如何安装和设置 DRBD。
   </para>
- </abstract>
- <sect1 id="sec-ha-drbd-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-drbd-overview">
   <title>概念概述</title>
 
   <para>
@@ -31,7 +35,7 @@ Please see LICENSE.txt for this document's license.
    DRBD 是 Linux 内核模块，位于下端的 I/O 调度程序与上端的文件系统之间，请参见<xref linkend="fig-ha-drbd-concept"/>。要与 DRBD 通讯，用户需使用高级别命令 <command>drbdadm</command>。为了提供最大的灵活性，DRBD 附带了低级别工具 <command>drbdsetup</command>。
   </para>
 
-  <figure id="fig-ha-drbd-concept">
+  <figure xml:id="fig-ha-drbd-concept">
    <title>DRBD 在 Linux 中的位置</title>
    <mediaobject>
     <imageobject role="fo">
@@ -85,8 +89,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    例如，如果原始设备大小为 1024 MB，则 DRBD 设备仅有 1023 MB 可用于数据存储，而大约保留 70 KB 的隐藏容量用于存储元数据。通过 <filename>/dev/drbd<replaceable>N</replaceable></filename> 访问剩余 KB 的任何尝试都会失败，因为这些 KB 不可用于存储用户数据。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-install">
+ </section>
+ <section xml:id="sec-ha-drbd-install">
   <title>安装 DRBD 服务</title>
 
   <para>
@@ -97,7 +101,7 @@ Please see LICENSE.txt for this document's license.
    如果不需要完整群集堆栈而只需使用 DRBD，请参考<xref linkend="tab-ha-drbd-rpmfiles"/>。它包含用于 DRBD 的所有 RPM 程序包的列表。近来，<systemitem>drbd</systemitem> 包已分为单独的包。
   </para>
 
-  <table id="tab-ha-drbd-rpmfiles">
+  <table xml:id="tab-ha-drbd-rpmfiles">
    <title>DRBD RPM 包</title>
    <tgroup cols="2">
     <thead>
@@ -248,8 +252,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    要将其永久用于 <systemitem class="username">root</systemitem>，请创建或扩展文件 <filename>/root/.bashrc</filename> 并插入上一行。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-configure">
+ </section>
+ <section xml:id="sec-ha-drbd-configure">
   <title>配置 DRBD 服务</title>
 
   <note><title>所需的调整</title>
@@ -268,25 +272,25 @@ Please see LICENSE.txt for this document's license.
    要手动设置 DRBD，请按如下操作：
   </para>
 
-  <procedure id="step-drbd-configure">
+  <procedure xml:id="step-drbd-configure">
    <title>手动配置 DRBD</title>
-   <step performance="required">
+   <step>
      <para>如果群集已在使用 DRBD，请将群集置于维护模式：</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=true</screen> 
      <para>当群集已使用 DRBD 时，如果您跳过此步骤，当前配置中的语法错误会导致服务关闭。</para>
      
    </step>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      更改 DRBD 的配置文件：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        打开文件 <filename>/etc/drbd.conf</filename> 并插入以下行（如果尚不存在）：
       </para>
@@ -296,7 +300,7 @@ include "drbd.d/*.res";</screen>
        从 DRBD 8.3 开始，配置文件分为单独的文件，位于目录 <filename>/etc/drbd.d/</filename> 下。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        打开文件 <filename>/etc/drbd.d/global_common.conf</filename>。它已包含一些预定义值。转到 <literal>startup</literal> 部分并插入以下行：
       </para>
@@ -307,25 +311,25 @@ include "drbd.d/*.res";</screen>
     degr-wfc-timeout 120;
 }</screen>
       <para>
-       这些选项用于在引导时减少超时，有关更多细节，请参见 <ulink url="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>。
+       这些选项用于在引导时减少超时，有关更多细节，请参见 <link xlink:href="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        创建文件 <filename>/etc/drbd.d/r0.res</filename>，根据具体情况更改行，然后保存：
       </para>
-<screen>resource r0 { <co id="co-drbd-config-r0"/>
-  device /dev/drbd0; <co id="co-drbd-config-device"/>
-  disk /dev/sda1; <co id="co-drbd-config-disk"/>
-  meta-disk internal; <co id="co-drbd-config-meta-disk"/>
-  on alice { <co id="co-drbd-config-resname"/>
-    address  192.168.1.10:7788; <co id="co-drbd-config-address"/>
+<screen>resource r0 { <co xml:id="co-drbd-config-r0"/>
+  device /dev/drbd0; <co xml:id="co-drbd-config-device"/>
+  disk /dev/sda1; <co xml:id="co-drbd-config-disk"/>
+  meta-disk internal; <co xml:id="co-drbd-config-meta-disk"/>
+  on alice { <co xml:id="co-drbd-config-resname"/>
+    address  192.168.1.10:7788; <co xml:id="co-drbd-config-address"/>
   }
   on bob { <xref linkend="co-drbd-config-resname" xrefstyle="selec:nopage"/>
     address 192.168.1.11:7788; <xref linkend="co-drbd-config-address" xrefstyle="selec:nopage"/>
   }
   syncer {
-    rate  7M; <co id="co-drbd-config-syncer-rate"/>
+    rate  7M; <co xml:id="co-drbd-config-syncer-rate"/>
   }
 }</screen>
       <calloutlist>
@@ -353,7 +357,7 @@ include "drbd.d/*.res";</screen>
        </callout>
        <callout arearefs="co-drbd-config-meta-disk">
         <para>
-         元磁盘参数通常包含值 <literal>internal</literal>，但可以明确指定一个设备来保存元数据。有关详细信息，请参见<ulink url="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>。
+         元磁盘参数通常包含值 <literal>internal</literal>，但可以明确指定一个设备来保存元数据。有关详细信息，请参见<link xlink:href="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>。
         </para>
        </callout>
        <callout arearefs="co-drbd-config-resname">
@@ -375,13 +379,13 @@ include "drbd.d/*.res";</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      检查配置文件的语法。如果以下命令返回错误，请校验文件：
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> dump all</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您已配置 Csync2（这应该是默认设置），则 DRBD 配置文件已包含在需要同步的文件的列表中。要同步文件，请使用以下命令：
     </para>
@@ -392,7 +396,7 @@ include "drbd.d/*.res";</screen>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在每个节点上输入以下命令，初始化<emphasis>两个</emphasis>系统上的元数据：
     </para>
@@ -403,7 +407,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
 <screen><prompt role="root">root # </prompt> <command>dd</command> if=/dev/zero of=/dev/sda1 count=16 bs=1M</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在每个节点上输入以下命令，监视 DRBD 状态：
     </para>
@@ -416,13 +420,13 @@ m:res  cs         ro                   ds                         p  mounted  fs
 0:r0   Connected  Secondary/Secondary  Inconsistent/Inconsistent  C</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      在所需的主节点（本例中为 alice）上启动重新同步过程：
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> -- --overwrite-data-of-peer primary r0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      再次使用 <command>rcdrbd status</command> 检查状态，将得到：
     </para>
@@ -435,19 +439,19 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      <literal>ds</literal> 行中的状态（磁盘状态）在两个节点上都必须为 UpToDate。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 DRBD 设备上创建文件系统，例如：
     </para>
 <screen><prompt role="root">root # </prompt><command>mkfs.ext3</command> /dev/drbd/by-res/r0/0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      装入文件系统并使用它：
     </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> /dev/drbd /mnt/</screen>
    </step>
-   <step performance="required">
+   <step>
      <para>重设置群集的维护模式标志：</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=false</screen> 
    </step>
@@ -459,20 +463,20 @@ m:res  cs         ro                 ds                 p  mounted  fstype
    或者，要使用 YaST 配置 DRBD，请按照以下操作继续：
   </para>
 
-  <procedure id="pro-drbd-configure-yast">
+  <procedure xml:id="pro-drbd-configure-yast">
    <title>使用 YaST 配置 DRBD</title>
-   <step performance="required">
+   <step>
     <para>
      启动 YaST 并选择配置模块 <menuchoice><guimenu>High Availability</guimenu><guimenu>DRBD</guimenu></menuchoice>。如果您已有 DRBD 配置，YaST 会向您发出警告。YaST 会更改您的配置，并将旧的 DRBD 配置文件另存为 <filename>*.YaSTsave</filename> 文件。
     </para>
      <para>将<menuchoice><guimenu>启动配置</guimenu><guimenu>引导</guimenu></menuchoice>中的引导标志保留原样（默认情况下为 <literal>off</literal>）；请不要更改此项设置，因为 Pacemaker 会管理此服务。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      资源的实际配置可在<guimenu>资源配置</guimenu>中完成（请参见<xref linkend="fig-ha-drbd-yast-resconfig"/>）。
     </para>
     
-    <figure id="fig-ha-drbd-yast-resconfig">
+    <figure xml:id="fig-ha-drbd-yast-resconfig">
      <title>资源配置</title>
      <mediaobject>
       <imageobject role="fo">
@@ -571,7 +575,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      所有这些选项在 <filename>/usr/share/doc/packages/drbd-utils/drbd.conf</filename> 文件的示例和 <command>drbd.conf(5)</command> 的手册页中均有说明。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您已配置 Csync2（这应该是默认设置），则 DRBD 配置文件已包含在需要同步的文件的列表中。要同步文件，请使用以下命令：
     </para>
@@ -582,7 +586,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在每个节点上输入以下命令，初始化并启动两个系统上的 DRBD 服务：
     </para>
@@ -591,13 +595,13 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> create-md r0
 <prompt role="root">root # </prompt><command>rcdrbrd</command> start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在 <filename>alice</filename> 上输入以下命令，将 <filename>alice</filename> 配置为主节点：
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdsetup</command> /dev/drbd0 primary --overwrite-data-of-peer</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在每个节点上输入以下命令，检查 DRBD 服务状态：
     </para>
@@ -606,56 +610,56 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      继续之前，等待两个节点上的块设备完全同步。重复 <command>rcdrbd status</command> 命令以跟踪同步进度。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      两个节点上的块设备都完全同步之后，使用首选文件系统格式化主节点上的 DRBD 设备。可以使用任何 Linux 文件系统。建议使用 <filename>/dev/drbd/by-res/<replaceable>RESOURCE</replaceable></filename> 名称。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-test">
+ </section>
+ <section xml:id="sec-ha-drbd-test">
   <title>测试 DRBD 服务</title>
 
   <para>
    如果安装和配置过程和预期一样，则您就准备好运行 DRBD 功能的基本测试了。此测试还有助于了解该软件的工作原理。
   </para>
 
-  <procedure id="pro-drbd-test">
-   <step performance="required">
+  <procedure xml:id="pro-drbd-test">
+   <step>
     <para>
      在 alice 上测试 DRBD 服务。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        打开终端控制台，然后以 <systemitem>root</systemitem> 用户身份登录。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上创建一个安装点，如 <filename>/srv/r0</filename>：
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        装入 <command>drbd</command> 设备：
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd0 /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        从主节点创建文件：
       </para>
 <screen><prompt role="root">root # </prompt><command>touch</command> /srv/r0/from_alice</screen>
      </step>
-      <step performance="required">
+      <step>
         <para>
           卸载 alice 上的磁盘：
         </para>
         <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
       </step>
-      <step performance="required">
+      <step>
         <para>
           通过在 alice 上键入以下命令，降级 alice 上的 DRBD 服务：
         </para>
@@ -663,41 +667,41 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 bob 上测试 DRBD 服务。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在 bob 上打开终端控制台，然后以 <systemitem>root</systemitem> 身份登录。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上，将 DRBD 服务升级为主服务：
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上，检查 bob 是否为主节点：
       </para>
 <screen><prompt role="root">root # </prompt><command>rcdrbd</command> status</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上，创建一个安装点，如 <filename>/srv/r0mount</filename>：
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上，装入 DRBD 设备：
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd_r0 /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        校验在 alice 上创建的文件是否存在：
       </para>
@@ -708,35 +712,35 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果该服务在两个节点上都运行正常，则 DRBD 安装即已完成。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      再次将 alice 设置为主节点。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        通过在 bob 上键入以下命令，卸下 bob 上的磁盘：
       </para>
 <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        通过在 bob 上键入以下命令，降级 bob 上的 DRBD 服务：
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> secondary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上，将 DRBD 服务升级为主服务：
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上，检查 alice 是否为主节点：
       </para>
@@ -744,14 +748,14 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要使服务在服务器有问题时自动启动并实现故障转移，可以使用 OpenAIS 将 DRBD 设置为高可用性服务。有关为 SUSE Linux Enterprise 11 安装和配置 OpenAIS 的信息，请参见<xref linkend="part-config"/>
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-tuning">
+ </section>
+ <section xml:id="sec-ha-drbd-tuning">
   <title>调整 DRBD</title>
 
   <para>
@@ -789,18 +793,18 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
    </listitem>
     <listitem>
-      <para>根据工作负载启用读平衡。有关详细信息，请参见<ulink url="http://blogs.linbit.com/p/256/read-balancing/"/>。</para>
+      <para>根据工作负载启用读平衡。有关详细信息，请参见<link xlink:href="http://blogs.linbit.com/p/256/read-balancing/"/>。</para>
     </listitem>
   </orderedlist>
- </sect1>
- <sect1 id="sec-ha-drbd-trouble">
+ </section>
+ <section xml:id="sec-ha-drbd-trouble">
   <title>DRBD 查错</title>
 
   <para>
    DRBD 设置涉及很多不同的组件，因此产生问题的来源可能多种多样。以下各部分包括多个常用方案和多种建议解决方案。
   </para>
 
-  <sect2 id="sec-ha-drbd-trouble-config">
+  <section xml:id="sec-ha-drbd-trouble-config">
    <title>配置</title>
    <para>
     如果初始 DRBD 设置不符合预期，说明配置中可能有错误。
@@ -809,12 +813,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     获取关于配置的信息：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       打开终端控制台，然后以 <systemitem class="username">root</systemitem> 用户身份登录。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       通过运行 <command>drbdadm</command>（带 <command>-d</command> 选项），测试配置文件。输入以下命令：
      </para>
@@ -823,12 +827,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       在 <command>adjust</command> 选项的干运行中，<command>drbdadm</command> 将 DRBD 资源的实际配置与您的 DRBD 配置文件进行比较，但它不会执行这些调用。检查输出以确保您了解任何错误的根源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果 <filename>/etc/drbd.d/*</filename> 和 <filename>drbd.conf</filename> 文件中存在错误，请先更正，然后再继续。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果分区和设置正确，请在不使用 <command>-d</command> 的情况下再次运行 <command>drbdadm</command>。
      </para>
@@ -838,9 +842,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-hostnames">
+  <section xml:id="sec-ha-drbd-hostnames">
    <title>主机名</title>
    <para>
     对于 DRBD，主机名区分大小写（<systemitem>Node0</systemitem> 和 <systemitem>node0</systemitem> 是不同的主机），并将与内核中储存的主机名进行比较（参见 <command>uname -n</command> 输出）。
@@ -848,16 +852,16 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    <para>
     如果有多个网络设备，且想要使用专用网络设备，可能不会将主机名解析为所用的 IP 地址。在这种情况下，可使用参数 <literal>disable-ip-verification</literal>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-port">
+  <section xml:id="sec-ha-drbd-port">
    <title>TCP 端口 7788</title>
    <para>
     如果系统无法连接到对等体，说明本地防火墙可能有问题。默认情况下，DRBD 使用 TCP 端口 <literal>7788</literal> 访问另一个节点。确保在两个节点上该端口均可访问。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-trouble-broken">
+  <section xml:id="sec-ha-drbd-trouble-broken">
    <title>DRBD 设备在重引导后损坏</title>
    <para>
     如果 DRBD 不知道哪个实际设备保管了最新数据，它就会变为节点分裂状态。在这种情况下，DRBD 子系统将分别成为次系统，并且互不相连。在这种情况下，可以在日志记录数据中找到以下讯息：
@@ -873,9 +877,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> connect r0</screen>
     <para>通过使用对等体的数据重写一个节点的数据，以此确保两个节点上的视图保持一致，该问题可得到解决。</para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-drbd-more">
+  </section>
+ </section>
+ <section xml:id="sec-ha-drbd-more">
   <title>更多信息</title>
 
   <para>
@@ -885,7 +889,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     项目主页：<ulink url="http://www.drbd.org"/>。
+     项目主页：<link xlink:href="http://www.drbd.org"/>。
     </para>
    </listitem>
    <listitem>
@@ -895,7 +899,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </listitem>
    <listitem>
     <para>
-     Linux Pacemaker 群集堆栈项目的 <ulink url="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>。
+     Linux Pacemaker 群集堆栈项目的 <link xlink:href="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>。
     </para>
    </listitem>
    <listitem>
@@ -909,8 +913,8 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
    </listitem>
     <listitem>
-      <para>此外，为了更方便地在整个群集中进行储存管理，请参见 <ulink url="http://blogs.linbit.com/p/666/drbd-manager"/> 上有关 <citetitle>DRBD-Manager</citetitle> 的最新声明。</para>
+      <para>此外，为了更方便地在整个群集中进行储存管理，请参见 <link xlink:href="http://blogs.linbit.com/p/666/drbd-manager"/> 上有关 <citetitle>DRBD-Manager</citetitle> 的最新声明。</para>
     </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_error_codes.xml
+++ b/zh_CN/xml/ha_error_codes.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_error_codes.xml" id="sec-ha-errorcodes">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_error_codes.xml" xml:id="sec-ha-errorcodes">
  <title>OCF 返回码和故障恢复</title>
 
  <para>
@@ -378,4 +382,4 @@ Please see LICENSE.txt for this document's license.
    </tbody>
   </tgroup>
  </table>
-</sect1>
+</section>

--- a/zh_CN/xml/ha_example.xml
+++ b/zh_CN/xml/ha_example.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_example.xml" id="cha-ha-quickstart">
- <title>设置简单测试资源的示例</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example.xml" xml:id="cha-ha-quickstart"><title>设置简单测试资源的示例</title><info/>
+ 
  <para>
   本章提供了配置简单资源：IP 地址的基本示例。它演示了两种方法来完成资源配置：使用 Pacemaker GUI 或 <command>crm</command> 命令行工具。
  </para>
@@ -25,6 +29,6 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_gui_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_cli_i.xml" parse="xml"/>
+ <xi:include href="ha_example_gui_i.xml" parse="xml"/>
+ <xi:include href="ha_example_cli_i.xml" parse="xml"/>
 </appendix>

--- a/zh_CN/xml/ha_example_cli_i.xml
+++ b/zh_CN/xml/ha_example_cli_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_cli_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_cli_i.xml">
  <title>手动配置资源</title>
 
  <para>
@@ -18,19 +22,19 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <procedure id="proc-ha-quickstart-man">
+ <procedure xml:id="proc-ha-quickstart-man">
   <title>创建 IP 地址群集资源</title>
-  <step performance="required">
+  <step>
    <para>
     打开外壳并转换为<systemitem class="username"> root </systemitem>用户。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     输入 <command>crm</command> <option>configure</option> 打开内壳。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     创建 IP 地址资源：
    </para>
@@ -54,16 +58,16 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>将资源迁移到其他节点</title>
-  <step performance="required">
+  <step>
    <para>
     启动壳层并成为 <systemitem class="username">root</systemitem> 用户。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     将资源 <literal>myip</literal> 迁移到节点 <systemitem>saturn</systemitem>：
    </para>
 <screen><command>crm</command> resource <command>migrate</command> myIP saturn</screen>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/zh_CN/xml/ha_example_gui_i.xml
+++ b/zh_CN/xml/ha_example_gui_i.xml
@@ -1,75 +1,79 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_gui_i.xml" id="sec-ha-quickstart-gui">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_gui_i.xml" xml:id="sec-ha-quickstart-gui">
  <title>使用 GUI 配置资源</title>
 
  <para>
   创建样本群集资源并将它迁移到其他服务器可帮助您进行测试，以确保群集运行正确。要配置和迁移的简单资源就是 IP 地址。
  </para>
 
- <procedure id="proc-ha-quickstart-gui">
+ <procedure xml:id="proc-ha-quickstart-gui">
   <title>创建 IP 地址群集资源</title>
-  <step performance="required">
+  <step>
    <para>
     按<xref linkend="sec-ha-configuration-gui-intro-connect"/>中所述，启动 Pacemaker GUI 并登录到群集。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在左窗格中，切换到 <guimenu>Resources</guimenu>（资源）视图；在右窗格中，选择要修改的组并单击 <guimenu>Edit</guimenu>（编辑）。下一个窗口将显示为该资源定义的基本组参数以及元属性和原始资源。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     单击 <guimenu>Primitives</guimenu>（原始）选项卡并单击 <guimenu>Add</guimenu>（添加）。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在下一个对话框中，若要将 IP 地址添加为组的子资源，请设置以下参数：
    </para>
    <substeps performance="required">
-    <step performance="required">
+    <step>
      <para>
       输入唯一的 <literal>ID</literal>，例如 <literal>myIP</literal>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       从 <guimenu>Class</guimenu>（类）列表中，选择 <guimenu>ocf</guimenu> 作为资源代理类。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 OCF 资源代理的 <guimenu>Provider</guimenu>（提供程序）中，选择 <guimenu>heartbeat</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       从 <guimenu>Type</guimenu>（类型）列表中，选择 <guimenu>IPaddr</guimenu> 作为资源代理。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击 <guimenu>Forward</guimenu>（前进）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>实例属性</guimenu>选项卡中，选择 <guimenu>IP</guimenu> 项并单击<guimenu>编辑</guimenu>（或双击 <guimenu>IP</guimenu> 项）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       输入所需的 IP 地址作为<guimenu>值</guimenu>（例如，<literal>10.10.0.1</literal>）并单击<guimenu>确定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>添加</guimenu>新的实例属性，并将<guimenu>名称</guimenu>指定为 <literal>nic</literal>，将<guimenu>值</guimenu>指定为 <literal>eth0</literal>，然后单击<guimenu>确定</guimenu>。
      </para>
@@ -79,7 +83,7 @@ Please see LICENSE.txt for this document's license.
     </step>
    </substeps>
   </step>
-  <step performance="required">
+  <step>
    <para>
     根据意愿设置所有参数后，请单击<guimenu>确定</guimenu>完成此资源的配置。配置对话框关闭，主窗口显示已修改的资源。
    </para>
@@ -96,25 +100,25 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>将资源迁移到其他节点</title>
-  <step performance="required">
+  <step>
    <para>
     切换到左侧窗格中的<guimenu>管理</guimenu>视图，然后右键单击右侧窗格中的 IP 地址资源，并选择<guimenu>迁移资源</guimenu>。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在新窗口中，从<guimenu>目标节点</guimenu>下拉列表中选择 <literal>saturn</literal> 以将选定的资源移到节点 <literal>saturn</literal> 上。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     如果只想临时迁移资源，请激活<guimenu>持续时间</guimenu>并输入时间范围，在该时间段内资源应迁移到新的节点。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     单击<guimenu>确定</guimenu>确认迁移。
    </para>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/zh_CN/xml/ha_fencing.xml
+++ b/zh_CN/xml/ha_fencing.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_fencing.xml" id="cha-ha-fencing">
- <title>屏障和 STONITH</title>
-
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_fencing.xml" xml:id="cha-ha-fencing"><title>屏障和 STONITH</title><info><abstract>
   <para>
    屏蔽在 HA（高可用性）计算机群集中是一个非常重要的概念。群集有时会检测到某个节点行为异常，需要删除此节点。这称为<emphasis>屏蔽</emphasis>，通常使用 STONITH 资源实现。屏蔽可以定义为一种使 HA 群集具有已知状态的方法。
   </para>
@@ -20,9 +21,12 @@ Please see LICENSE.txt for this document's license.
   <para>
    当节点或资源的状态无法十分肯定地确立时，将进行屏蔽。即使在群集未感知到给定节点上发生的事件时，屏蔽也可确保此节点不会运行任何重要资源。
   </para>
- </abstract>
+ </abstract></info>
  
-   <sect1 id="sec-ha-fencing-classes">
+
+ 
+ 
+   <section xml:id="sec-ha-fencing-classes">
   <title>屏蔽分类</title>
 
   <para>
@@ -51,15 +55,15 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-fencing-nodes">
+ </section>
+ <section xml:id="sec-ha-fencing-nodes">
   <title>节点级别屏蔽</title>
 
   <para>
    在 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 中，屏障实施为 STONITH (Shoot The Other Node In The Head)。它提供节点级屏蔽。High Availability Extension 包括 <command>stonith</command> 命令行工具，一个能远程关闭群集中节点的可扩展界面。有关可用选项的概述，请运行 <command>stonith --help</command> 或参见 <command>stonith</command> 的手册页了解更多信息。
   </para>
 
-  <sect2 id="sec-ha-fencing-nodes-devices">
+  <section xml:id="sec-ha-fencing-nodes-devices">
    <title>STONITH 设备</title>
    <para>
     要使用节点级屏蔽，首先需要有屏蔽设备。要获取 High Availability Extension 所支持的 STONITH 设备的列表，请在任何节点上运行以下命令之一：
@@ -115,9 +119,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     对 STONITH 设备的选择主要取决于您的预算和所用硬件的种类。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-fencing-nodes-implementation">
+  <section xml:id="sec-ha-fencing-nodes-implementation">
    <title>STONITH 实施</title>
    <para>
     <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 的 STONITH 实施由两个组件组成：
@@ -146,9 +150,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-fencing-config">
+  </section>
+ </section>
+ <section xml:id="sec-ha-fencing-config">
   <title>STONITH 资源和配置</title>
 
   <para>
@@ -194,7 +198,7 @@ Please see LICENSE.txt for this document's license.
 
 <screen>stonith -t <replaceable>stonith-device-type</replaceable> -h</screen>
 
-  <sect2 id="sec-ha-fencing-config-examples">
+  <section xml:id="sec-ha-fencing-config-examples">
    <title>STONITH 资源配置示例</title>
    <para>
     在以下部分中，可了解一些用 <command>crm</command> 命令行工具的语法编写的示例配置。要应用这些配置，请将示例放进文本文件（例如 <filename>sample.txt</filename>）并运行：
@@ -229,7 +233,7 @@ commit</screen>
      UPS 类型屏蔽设置的配置类似于上面的示例。此处不作详细介绍。所有 UPS 设备均使用相同的机制屏蔽。访问设备的方式有所不同。旧的 UPS 设备只有一个串行端口，通常使用特殊的串行电缆以 1200 波特的速率进行连接。许多新的 UPS 设备仍有一个串行端口，但它们一般还使用 USB 或以太网接口。可以使用的连接类型取决于插件支持的连接。
     </para>
     <para>
-     例如，通过使用 <command>stonith -t <replaceable>stonith 设备类型</replaceable> -n</command> 命令比较 <literal>apcmaster</literal> 与 <literal>apcsmart</literal> 设备：
+     例如，通过使用 <command>stonith -t</command> <replaceable>stonith 设备类型</replaceable> -n 命令比较 <literal>apcmaster</literal> 与 <literal>apcsmart</literal> 设备：
     </para>
 <screen>stonith -t apcmaster -h</screen>
     <para>
@@ -266,12 +270,12 @@ hostlist</screen>
      第一个插件支持带有一个网络端口的 APC UPS 和 telnet 协议。第二种插件使用通过串行线路的 APC SMART 协议，许多不同的 APC UPS 产品线都支持此协议。
     </para>
    </example>
-   <example id="ex-ha-fencing-kdump">
+   <example xml:id="ex-ha-fencing-kdump">
     <title>Kdump 设备的配置</title>
     <para> 使用 <literal>stonith:fence_kdump</literal> 资源代理（由 <systemitem class="resource">fence-agents</systemitem> 包提供）来监视已启用 kdump 功能的所有节点。下面提供了资源的配置示例：</para>
     <screen>configure
      primitive st-kdump stonith:fence_kdump \
-     params nodename="alice "\ <co id="co-ha-fenc-kdump-nodename"/>
+     params nodename="alice "\ <co xml:id="co-ha-fenc-kdump-nodename"/>
      params pcmk_host_check="dynamic-list" \
      params pcmk_reboot_action="off" \
      params pcmk_monitor_action="metadata" \
@@ -289,11 +293,11 @@ hostlist</screen>
     <screen> /usr/lib64/fence_kdump_send -i <replaceable>INTERVAL</replaceable> -p <replaceable>PORT</replaceable> -c 1 alice bob charly [...]</screen>
     <para> 执行 kdump 的节点将在完成 kdump 后自动重启动。请记得在防火墙中为 <literal>fence_kdump</literal> 资源打开一个端口。默认端口为 <literal>7410</literal>。</para>
    </example>
-  </sect2>
+  </section>
 
   
- </sect1>
- <sect1 id="sec-ha-fencing-monitor">
+ </section>
+ <section xml:id="sec-ha-fencing-monitor">
   <title>监视屏蔽设备</title>
 
   <para>
@@ -320,8 +324,8 @@ hostlist</screen>
   <para>
    有关如何配置监视操作的详细信息，对于 GUI 方法请参见<xref linkend="pro-ha-config-gui-parameters"/>，对于命令行方法请参见<xref linkend="sec-ha-manual-config-monitor"/>。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-special">
+ </section>
+ <section xml:id="sec-ha-fencing-special">
   <title>特殊的屏蔽设备</title>
 
   <para>
@@ -363,7 +367,7 @@ hostlist</screen>
     </term>
     <listitem>
      <para>
-      这是一个自屏蔽设备。它对可以插入共享磁盘的所谓的<quote>毒药</quote>作出反应。当中断共享储存区连接时，它将停止节点运行。要了解如何使用此 STONITH 代理实施基于储存的屏蔽，请参见<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>。有关更多细节，另请参见 <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>。
+      这是一个自屏蔽设备。它对可以插入共享磁盘的所谓的<quote>毒药</quote>作出反应。当中断共享储存区连接时，它将停止节点运行。要了解如何使用此 STONITH 代理实施基于储存的屏蔽，请参见<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>。有关更多细节，另请参见 <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>。
      </para>
 
      <important>
@@ -409,8 +413,8 @@ hostlist</screen>
   <para>
    <literal>suicide</literal> 是<quote>I do not shoot my host</quote>（我自己不关闭我的主机）规则的唯一例外。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-recommend">
+ </section>
+ <section xml:id="sec-ha-fencing-recommend">
   <title>基本建议</title>
 
   <para>
@@ -466,8 +470,8 @@ hostlist</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-fencing-more">
+ </section>
+ <section xml:id="sec-ha-fencing-more">
   <title>更多信息</title>
   <variablelist>
    <varlistentry>
@@ -480,13 +484,13 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-     <term><ulink url="http://www.linux-ha.org/wiki/STONITH"/></term>
+     <term><link xlink:href="http://www.linux-ha.org/wiki/STONITH"/></term>
     <listitem>
      <para> High Availability Linux 项目主页上有关 STONITH 的信息。 </para>
     </listitem>
      </varlistentry>
      <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/>
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/>
     </term>
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
@@ -499,7 +503,7 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
+    <term><link xlink:href="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
     </term>
     <listitem>
      <para>
@@ -508,5 +512,5 @@ hostlist</screen>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_geocluster.xml
+++ b/zh_CN/xml/ha_geocluster.xml
@@ -1,13 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_geocluster.xml" id="cha-ha-geo">
- <title>地域群集（多站点群集）</title>
- <abstract>
-  <para> 除本地群集和城域群集外，<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 还支持地理位置分散的群集（地域群集，有时也称为多站点群集）。这意味着，每个本地群集可以有多个地域分散的站点。这些群集之间的故障转移由更高级的实体、所谓的 <literal>booth</literal> 进行协调。对地域群集的支持是作为 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的一个独立扩展提供。有关如何使用和设置地域群集的细节，请参见《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。可以从 <ulink url="http://www.suse.com/documentation/"/> 或者所安装系统的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到该文档。 </para>
- </abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_geocluster.xml" xml:id="cha-ha-geo"><title>地域群集（多站点群集）</title><info><abstract>
+  <para> 除本地群集和城域群集外，<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 还支持地理位置分散的群集（地域群集，有时也称为多站点群集）。这意味着，每个本地群集可以有多个地域分散的站点。这些群集之间的故障转移由更高级的实体、所谓的 <literal>booth</literal> 进行协调。对地域群集的支持是作为 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的一个独立扩展提供。有关如何使用和设置地域群集的细节，请参见《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。可以从 <link xlink:href="http://www.suse.com/documentation/"/> 或者所安装系统的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到该文档。 </para>
+ </abstract></info>
+ 
+ 
 </chapter>

--- a/zh_CN/xml/ha_glossary.xml
+++ b/zh_CN/xml/ha_glossary.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glossary PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE glossary>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<glossary xml:base="ha_glossary.xml" id="gl-heartb">
- <title>术语</title>
+<glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_glossary.xml" xml:id="gl-heartb"><title>术语</title><info/>
+ 
  <glossentry><glossterm>主动/主动、主动/被动</glossterm>
   <glossdef>
    <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>bindnetaddr</systemitem>（绑定网络地址）</glossterm>
+ <glossentry><glossterm>bindnetaddr（绑定网络地址）</glossterm>
   <glossdef>
    <para>
     Corosync 管理器应绑定的网络地址。 
@@ -43,7 +47,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">boothd</systemitem>（booth 守护程序）</glossterm>
+ <glossentry><glossterm>boothd（booth 守护程序）</glossterm>
   <glossdef>
    <para>
     地域群集中的每个参与群集和仲裁器都会运行一个服务，即 <systemitem class="daemon">boothd</systemitem>。它连接到其他站点上运行的 booth 守护程序，并交换连接性细节。
@@ -99,7 +103,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">crmd</systemitem>（群集资源管理器守护程序）</glossterm>
+ <glossentry><glossterm>crmd（群集资源管理器守护程序）</glossterm>
   <glossdef>
    <para>
     CRM 作为守护程序 crmd 进行实施。每个群集节点上都有一个实例。系统会选出一个 crmd 实例来充当主实例，从而实现所有群集决策制定的集中化。如果选定的 crmd 进程（或它所在的节点）失败，则会建立一个新的进程。
@@ -120,7 +124,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-dc"><glossterm>DC（指定的协调程序）</glossterm>
+ <glossentry xml:id="glos-dc"><glossterm>DC（指定的协调程序）</glossterm>
   <glossdef>
    <para>
     群集中的一个 CRM 会选为指定的协调程序 (DC)。DC 是群集中唯一可以决定需要在整个群集执行更改（例如节点屏蔽或资源移动）的实体。DC 同时也是用于保存 CIB 主副本的节点。所有其他节点都从当前 DC 获取他们的配置和资源分配信息。DC 是在成员资格更改后从群集的所有节点中选出的。
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-failover"><glossterm>故障转移</glossterm>
+ <glossentry xml:id="glo-failover"><glossterm>故障转移</glossterm>
   <glossdef>
    <para>
     指资源或节点在某台服务器上出现故障、受影响的资源在另一个节点上启动的情况。
@@ -203,7 +207,7 @@ Please see LICENSE.txt for this document's license.
 
 
  
-  <glossentry id="glos-lb">
+  <glossentry xml:id="glos-lb">
    <glossterm>负载平衡</glossterm>
    <glossdef>
      <para>能让多个服务器参与同一个服务并执行相同任务。</para>
@@ -224,14 +228,14 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastaddr</systemitem>（多路广播地址）</glossterm>
+ <glossentry><glossterm>mcastaddr（多路广播地址）</glossterm>
   <glossdef>
    <para>
       Corosync 管理器使用 IP 地址进行多路广播。IP 地址可以为 IPv4 或 IPv6。 
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastport</systemitem>（多路广播端口）</glossterm>
+ <glossentry><glossterm>mcastport（多路广播端口）</glossterm>
   <glossdef>
    <para>
       用于群集通讯的端口。
@@ -252,7 +256,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-geo"><glossterm>地域群集</glossterm>
+ <glossentry xml:id="glos-geo"><glossterm>地域群集</glossterm>
   <glossdef>
    <para>
     由多个分布于不同地理位置的站点组成，每个站点一个本地群集。站点通过 IP 通讯。站点之间的故障转移由更高级别的实体 booth 协调。地域群集需要应对有限网络带宽和高延迟问题。储存异步复制。
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="gloss-quorum"><glossterm>法定票数</glossterm>
+ <glossentry xml:id="gloss-quorum"><glossterm>法定票数</glossterm>
   <glossdef>
    <para>
     在群集中，如果群集分区具有多数节点（或投票），则它定义为具有法定票数（是<quote>具有法定票数的</quote>）。法定票数准确地区分了一个分区。它是算法的组成部分，用于防止多个断开的分区或节点继续运行而导致数据和服务损坏（节点分裂）。法定票数是屏蔽的先决条件，而屏蔽随后确保法定票数确实是唯一的。
@@ -326,7 +330,7 @@ Please see LICENSE.txt for this document's license.
   </glossdef>
  </glossentry>
 
- <glossentry id="glos-splitbrain"><glossterm>节点分裂</glossterm>
+ <glossentry xml:id="glos-splitbrain"><glossterm>节点分裂</glossterm>
   <glossdef>
    <para>
     一种将群集节点分为两个或多个互不了解的组的方案（通过软件或硬件故障）。STONITH 防止节点分裂情况对整个群集产生不利影响。也称为<quote>分区的群集</quote>方案。
@@ -343,7 +347,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-stonith"><glossterm>STONITH</glossterm>
+ <glossentry xml:id="glo-stonith"><glossterm>STONITH</glossterm>
   <glossdef>
    <para>
     <quote>Shoot the other node in the head</quote>（关闭其他节点）的首字母缩写。它表示一种关闭行为异常的节点以避免其在群集中制造麻烦的屏蔽机制。

--- a/zh_CN/xml/ha_hawk_rsc_config_i.xml
+++ b/zh_CN/xml/ha_hawk_rsc_config_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_config_i.xml" id="sec-ha-config-hawk-rsc">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_config_i.xml" xml:id="sec-ha-config-hawk-rsc">
  <title>配置群集资源</title>
 
  <para>
@@ -47,29 +51,29 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <sect2 id="sec-ha-config-hawk-wizard">
+ <section xml:id="sec-ha-config-hawk-wizard">
   <title>使用设置向导配置资源</title>
   <para>
-   High Availability Extension 针对一些常用的群集方案（例如，设置高度可用的 NFS 服务器）随附了一组预定义的模板。可在 <systemitem class="resource">hawk-templates</systemitem> 包中找到这些预定义的模板。您也可以自行定义向导模板。有关详细信息，请参见 <ulink url="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>。
+   High Availability Extension 针对一些常用的群集方案（例如，设置高度可用的 NFS 服务器）随附了一组预定义的模板。可在 <systemitem class="resource">hawk-templates</systemitem> 包中找到这些预定义的模板。您也可以自行定义向导模板。有关详细信息，请参见 <link xlink:href="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-wizard">
+  <procedure xml:id="pro-ha-config-hawk-wizard">
    <title>使用设置向导</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>设置向导</guimenu>。<guimenu>群集设置向导</guimenu>将列出可用的资源模板。如果单击其中一项，Hawk 将显示有关该模板的简短帮助文本。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择要配置的资源集并单击<guimenu>下一步</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按照屏幕指导执行操作。如果需要有关某个选项的信息，在 Hawk 中单击它即可显示简短帮助文本。
     </para>
@@ -86,51 +90,51 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-primitives">
+ <section xml:id="sec-ha-config-hawk-primitives">
   <title>创建简单群集资源</title>
   <para>
    要创建最基本类型的资源，请执行以下操作：
   </para>
-  <procedure id="pro-ha-config-hawk-primitives">
+  <procedure xml:id="pro-ha-config-hawk-primitives">
    <title>添加原始资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别。它列出已定义的所有资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<guimenu>原始</guimenu>类别，单击加号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      指定资源：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        输入唯一的<guimenu>资源 ID</guimenu>。
       </para>
      </step>
-     <step id="step-ha-config-hawk-primitives-start" performance="required">
+     <step xml:id="step-ha-config-hawk-primitives-start">
       <para>
        从<guimenu>类</guimenu>列表，选择要用于该资源的资源代理类：<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>service</guimenu> 或 <guimenu>stonith</guimenu>。有关详细信息，请参见<xref linkend="sec-ha-config-basics-raclasses"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果选择了 <guimenu>ocf</guimenu> 作为类，则指定 OCF 资源代理的<guimenu>提供程序</guimenu>。OCF 规范允许多个供应商供应相同的资源代理。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        从 <guimenu>Type</guimenu>（类型）列表中，选择要使用的资源代理（例如 <guimenu>IPaddr</guimenu> 或 <guimenu>Filesystem</guimenu>）。将显示该资源代理的简短描述。
       </para>
@@ -140,7 +144,7 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step id="step-ha-config-hawk-parameters" performance="required">
+   <step xml:id="step-ha-config-hawk-parameters">
     <para>
      Hawk 会自动显示资源的所有必需参数，以及您可以用于指定其他参数的空下拉列表。
     </para>
@@ -148,24 +152,24 @@ Please see LICENSE.txt for this document's license.
      定义资源的<guimenu>参数</guimenu>（实例属性）：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        请为每个必需参数输入值。单击参数旁边的文本框，会显示简短帮助文本。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要完全删除参数，请单击参数旁边的减号图标。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要添加另一个参数，请单击空下拉列表，选择一个参数，并输入参数值。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 会自动显示最重要的资源<guimenu>操作</guimenu>并建议默认值。如果在此处不修改任何设置，Hawk 会在您确认更改后立即添加建议的操作及其默认值。
     </para>
@@ -173,7 +177,7 @@ Please see LICENSE.txt for this document's license.
      有关如何修改、添加或删除操作的细节，请参见<xref linkend="pro-ha-config-hawk-operations"/>。
     </para>
    </step>
-   <step id="step-ha-config-hawk-meta-attr" performance="required">
+   <step xml:id="step-ha-config-hawk-meta-attr">
     <para>
      Hawk 会自动列出资源的最重要元属性，例如 <literal>target-role</literal>。
     </para>
@@ -181,24 +185,24 @@ Please see LICENSE.txt for this document's license.
      修改或添加<guimenu>元属性</guimenu>：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        要为属性设置（其他）值，请从属性旁边的下拉框中选择一个值，或编辑输入字段中的值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要完全删除元属性，请单击属性旁边的减号图标。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要添加另一个元属性，请单击空下拉框，并选择属性。将显示属性的默认值。如果需要，可以按上述步骤更改默认值。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建资源</guimenu>以完成配置。屏幕顶部将会显示一条消息，告知资源是否创建成功。
     </para>
@@ -216,9 +220,9 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-stonith">
+ <section xml:id="sec-ha-config-hawk-stonith">
   <title>创建 STONITH 资源</title>
   <important>
    <title>无 STONITH 资源不受支持</title>
@@ -229,61 +233,61 @@ Please see LICENSE.txt for this document's license.
   <para>
    默认情况下，全局群集选项 <literal>stonith-enabled</literal> 设置为 <literal>true</literal>：如果未定义任何 STONITH 资源，群集将拒绝启动任何资源。配置一个或多个 STONITH 资源以完成 STONITH 设置。虽然 STONITH 资源的配置过程与其他资源类似，但它们的行为在某些方面有所不同。有关细节，请参见<xref linkend="sec-ha-fencing-config"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-stonith">
+  <procedure xml:id="pro-ha-config-hawk-stonith">
    <title>添加 STONITH 资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别并列出所有定义的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<guimenu>原始</guimenu>类别，单击加号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      指定资源：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        输入唯一的<guimenu>资源 ID</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        从 <guimenu>Class</guimenu>（类）列表，选择资源代理类 <guimenu>stonith</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        从<guimenu>类型</guimenu>列表中，选择 用于控制 STONITH 设备的 STONITH 插件。将显示该插件的简短描述。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 会自动显示该资源必需的<guimenu>参数</guimenu>。为每个参数输入值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 会显示最重要的资源<guimenu>操作</guimenu>并建议默认值。如果在此处不修改任何设置，Hawk 会在您确认后立即添加建议的操作及其默认值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果没有任何理由来更改<guimenu>元属性</guimenu>设置，则接受默认值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      确认更改以创建 STONITH 资源。
     </para>
@@ -292,41 +296,41 @@ Please see LICENSE.txt for this document's license.
   <para>
    要完成屏蔽配置，请添加约束和/或使用克隆。有关详细信息，请参见<xref linkend="cha-ha-fencing"/>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-templates">
+ <section xml:id="sec-ha-config-hawk-templates">
   <title>使用资源模板</title>
   <para>
    如果希望创建具有类似配置的多个资源，则定义资源模板是最简单的方式。定义后，便可在基元或特定类型的约束中引用它。有关功能及使用资源模板的详细信息，请参见<xref linkend="sec-ha-config-basics-constraints-templates"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-templates-create">
+  <procedure xml:id="pro-ha-config-hawk-templates-create">
    <title>创建资源模板</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别及<guimenu>模板</guimenu>类别。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<guimenu>模板</guimenu>类别，然后单击加号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入<guimenu>模板 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      像指定原始资源一样指定资源模板。遵循<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>操作，从<xref linkend="step-ha-config-hawk-primitives-start" xrefstyle="select:label"/> 开始。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建资源</guimenu>以完成配置。屏幕顶端将显示一条消息，告知资源模板是否创建成功。
     </para>
@@ -343,54 +347,54 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-templates-use">
+  <procedure xml:id="pro-ha-config-hawk-templates-use">
    <title>引用资源模板</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要在原始资源中引用新创建的资源模板，请遵循以下步骤：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别。它列出所有定义的资源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        选择<guimenu>原始</guimenu>类别，单击加号图标。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        输入唯一的<guimenu>资源 ID</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        激活<guimenu>使用模板</guimenu>，然后从下拉列表中选择要引用的模板。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果需要，则按<xref linkend="pro-ha-config-hawk-primitives"/>中所述指定更多<guimenu>参数</guimenu>、<guimenu>操作</guimenu>或<guimenu>元属性</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要在共置或顺序约束中引用新创建的资源模板，请按<xref linkend="pro-ha-config-hawk-constraints-collocation-order"/>中所述继续操作。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-constraints">
+ <section xml:id="sec-ha-config-hawk-constraints">
   <title>配置资源约束</title>
   <para>
    配置所有资源后，指定群集应如何正确地处理它们。使用资源约束可指定资源可在哪些群集节点上运行、以何种顺序装载资源，以及特定资源依赖于哪些其他资源。
@@ -405,23 +409,23 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-constraints-location">
+  <procedure xml:id="pro-ha-config-hawk-constraints-location">
    <title>添加或修改位置约束</title>
    <para>
     对于位置约束，请指定约束 ID、资源、分数和节点：
    </para>
 
-   <step id="step-ha-config-hawk-constraints-start" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-start">
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>约束</guimenu>。<guimenu>约束</guimenu>屏幕显示所有类型的约束的类别。它列出所有定义的约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要添加新<guimenu>位置</guimenu>约束，请单击相应类别中的加号图标。
     </para>
@@ -429,27 +433,27 @@ Please see LICENSE.txt for this document's license.
      要修改现有约束，请单击约束旁边的扳手图标，然后选择<guimenu>编辑约束</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入唯一的<guimenu>约束 ID</guimenu>。修改现有约束时，ID 已定义。
     </para>
    </step>
-   <step id="step-ha-config-hawk-constraints-stop" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-stop">
     <para>
      选择要定义约束的<guimenu>资源</guimenu>。列表中显示群集已配置的所有资源的 ID。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      设置约束的<guimenu>分数</guimenu>。正值表示资源可以在下一步中指定的<guimenu>节点</guimenu>上运行。负值表示它不应在该节点上运行。将分数设置为 <literal>INFINITY</literal> 将强制资源在该节点上运行。将其设置为 <literal>-INFINITY</literal> 则表示资源不得在该节点上运行。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择约束的<guimenu>节点</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建约束</guimenu>以完成配置。屏幕顶端将显示一条消息，告知约束是否创建成功。
     </para>
@@ -466,22 +470,22 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-constraints-collocation-order">
+  <procedure xml:id="pro-ha-config-hawk-constraints-collocation-order">
    <title>添加或修改共置或顺序约束</title>
    <para>
     对于这两种类型的约束，请指定约束 ID 和分数，然后将资源添加到依赖性链中：
    </para>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>约束</guimenu>。<guimenu>约束</guimenu>屏幕显示所有类型的约束的类别并列出所有定义的约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要添加新<guimenu>共置</guimenu>或<guimenu>顺序</guimenu>约束，请单击相应类别中的加号图标。
     </para>
@@ -489,12 +493,12 @@ Please see LICENSE.txt for this document's license.
      要修改现有约束，请单击约束旁边的扳手图标，然后选择<guimenu>编辑约束</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入唯一的<guimenu>约束 ID</guimenu>。修改现有约束时，ID 已定义。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定义<guimenu>分数</guimenu>。
     </para>
@@ -505,27 +509,27 @@ Please see LICENSE.txt for this document's license.
      对于顺序约束，如果分数大于零则约束是必需的，否则只是建议。默认值为 <literal>INFINITY</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      对于顺序约束，通常可将选项<guimenu>对称</guimenu>保持为启用状态。这指定了资源以相反顺序停止。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要定义约束的资源，请遵循以下步骤：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        从列表<guimenu>向约束添加资源</guimenu>中选择一个资源。此列表显示已为群集配置的所有资源和资源模板的 ID。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要添加选定资源，请单击列表旁边的加号图标。下方将显示一个新列表。从列表中选择下一个资源。由于共置和顺序约束都定义了资源之间的依赖性，因此需要至少两个资源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        从列表<guimenu>向约束添加资源</guimenu>的其余资源中选择一个。单击加号图标添加资源。
       </para>
@@ -539,24 +543,24 @@ Please see LICENSE.txt for this document's license.
        但是，如果定义了共置约束，则资源之间的箭头图标反映其依赖性，而<emphasis>不是</emphasis>其启动顺序。由于最上面的资源依赖于下一个资源，依此类推，因此群集将首先决定最后一个资源的放置位置，然后再根据该决定放置依赖的资源。如果无法满足约束，群集可以决定不允许运行依赖资源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        添加共置或顺序约束所需数量的资源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果要交换两个资源的顺序，则单击资源右侧的双箭头以在依赖性链中交换资源。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，可为每个资源指定更多参数，如角色（<literal>Master</literal>、<literal>Slave</literal>、<literal>Started</literal> 或 <literal>Stopped</literal>）。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建约束</guimenu>以完成配置。屏幕顶端将显示一条消息，告知约束是否创建成功。
     </para>
@@ -576,29 +580,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    可使用资源集作为定义共置或顺序约束的备用格式。它们有与组相同的排序语义。
   </para>
-  <procedure id="pro-ha-config-hawk-constraints-sets">
+  <procedure xml:id="pro-ha-config-hawk-constraints-sets">
    <title>对共置或顺序约束使用资源集</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="pro-ha-config-hawk-constraints-collocation-order"/>中所述，定义共置或顺序约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      已将资源添加到依赖性链后，可通过单击右侧的链图标将这些资源放入资源集中。资源集通过属于集合的资源周围的框架显现。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      还可向资源集添加多个资源或创建多个资源集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要从资源集提取资源，请单击相应资源上方的剪刀图标。
     </para>
@@ -616,14 +620,14 @@ Please see LICENSE.txt for this document's license.
      该资源将从集合中删除，并回到依赖性链中的原始位置。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      确认更改以完成约束配置。
     </para>
    </step>
   </procedure>
   <para>
-   有关配置约束的更多信息以及顺序和共置基本概念的详细背景信息，请参见 <ulink url="http://www.clusterlabs.org/doc/"/> 上提供的文档：
+   有关配置约束的更多信息以及顺序和共置基本概念的详细背景信息，请参见 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上提供的文档：
   </para>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
@@ -642,27 +646,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
-  <procedure id="pro-ha-config-hawk-constraints-remove">
+  <procedure xml:id="pro-ha-config-hawk-constraints-remove">
    <title>删除约束</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>约束</guimenu>。<guimenu>约束</guimenu>屏幕显示所有类型的约束的类别并列出所有定义的约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击约束旁边的扳手图标，然后选择<guimenu>删除约束</guimenu>。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failover">
+ <section xml:id="sec-ha-config-hawk-failover">
   <title>指定资源故障转移节点</title>
   <para>
    资源在出现故障时会自动重启动。如果在当前节点上无法实现重启动，或如果在当前节点上发生 N 次故障，则资源会试图故障转移到其他节点。您可以多次定义资源的故障次数（<literal>migration-threshold</literal>），在该值之后资源会迁移到新节点。如果群集中存在两个以上的节点，则由 High Availability 软件选择特定资源故障转移的节点。
@@ -670,29 +674,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    可按照以下步骤指定资源将故障转移到的特定节点：
   </para>
-  <procedure id="pro-ha-config-hawk-failover">
-   <step performance="required">
+  <procedure xml:id="pro-ha-config-hawk-failover">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="pro-ha-config-hawk-constraints-location"/>中所述，为资源配置位置约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/><xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 中所述，为资源添加 <literal>migration-threshold</literal> 元属性，并输入 migration-threshold 的<guimenu>值</guimenu>。值应是小于 INFINITY 的正数。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果希望资源的失败计数自动失效，请按<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/><xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 中所述为该资源添加 <literal>failure-timeout</literal> 元属性，并输入 failure-timeout 的<guimenu>值</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果希望为资源指定更多的首选故障转移节点，请创建更多的位置约束。
     </para>
@@ -704,9 +708,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    您可以随时手动清理资源的失败计数，而不是让资源的失败计数自动失效。有关详细信息，请参见<xref linkend="sec-ha-config-hawk-cleanup"/>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failback">
+ <section xml:id="sec-ha-config-hawk-failback">
   <title>指定资源故障回复节点（资源黏性）</title>
   <para>
    当原始节点恢复联机并位于群集中时，资源可能会故障回复到该节点。要防止这种情况发生或指定其他节点供资源故障回复，请更改资源的粘性值。也可以在创建资源之际或之后指定资源粘性。
@@ -717,28 +721,28 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-stickiness">
+  <procedure xml:id="pro-ha-config-hawk-stickiness">
    <title>指定资源黏性</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/><xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 中所述，为资源添加 <literal>resource-stickiness</literal> 元属性。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      为 resource-stickiness 指定介于 <literal>-INFINITY</literal> 和 <literal>INFINITY</literal> 之间的值。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-utilization">
+ <section xml:id="sec-ha-config-hawk-utilization">
   <title>根据负载影响配置资源放置</title>
   <para>
    并非所有资源都相等。某些资源（如 Xen guest）需要托管它们的节点满足其容量要求。如果资源的放置导致其组合需求超过了提供的容量，则资源的性能会降低，或者失败。
@@ -784,74 +788,74 @@ Please see LICENSE.txt for this document's license.
   <para>
    配置了节点提供的容量和资源需要的容量后，需要设置全局群集选项中的放置策略，否则容量配置将不会生效。可使用多个策略来调度负载：例如，可以将负载集中到尽可能少的节点上，或使其均匀分布在所有可用节点上。有关更多信息，请参见<xref linkend="sec-ha-config-basics-utilization"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-placement">
+  <procedure xml:id="pro-ha-config-hawk-placement">
    <title>设置放置策略</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集属性</guimenu>可查看全局群集选项及其当前值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      从<guimenu>添加新属性</guimenu>下拉列表中，选择 <literal>placement-strategy</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根据要求，将<guimenu>放置策略</guimenu>设置为适当值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击加号图标添加新的群集属性（包括其值）。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      确认更改。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-monitor">
+ <section xml:id="sec-ha-config-hawk-monitor">
   <title>配置资源监视</title>
   <para>
    High Availability Extension 不仅能检测到节点故障，还能检测到节点上的单个资源失败。如果要确保资源正在运行，则为其配置资源监视。要进行资源监视，请指定超时和/或启动延迟值及间隔。间隔告诉 CRM 检查资源状态的频率。您还可以设置特定参数，如为 <literal>start</literal> 或 <literal>stop</literal> 操作设置 <literal>timeout</literal>。
   </para>
-  <procedure id="pro-ha-config-hawk-operations">
+  <procedure xml:id="pro-ha-config-hawk-operations">
    <title>添加或修改监视操作</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别并列出所有定义的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择要修改的资源，单击资源旁边的扳手图标，然后选择<guimenu>编辑资源</guimenu>。将显示资源定义。Hawk 会自动显示最重要的资源操作（<literal>monitor</literal>、<literal>start</literal>、<literal>stop</literal>）并建议默认值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      更改操作的值：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        单击操作旁边的钢笔图标。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在打开的对话框中，指定以下值：
       </para>
@@ -881,24 +885,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确认更改以关闭对话框并返回到<guimenu>编辑资源</guimenu>屏幕。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要完全删除操作，请单击操作旁边的减号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要添加另一个操作，请单击空下拉框，并选择操作。将显示操作的默认值。如果需要，可以通过单击笔形图标更改默认值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>应用更改</guimenu>以完成配置。屏幕顶端将显示一条消息，告知资源是否更新成功。
     </para>
@@ -910,9 +914,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    要查看资源失败，请切换到 Hawk 中的<guimenu>群集状态</guimenu>屏幕，然后选择您感兴趣的资源。单击资源旁边的扳手图标，然后选择<guimenu>显示细节</guimenu>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-group">
+ <section xml:id="sec-ha-config-hawk-group">
   <title>配置群集资源组</title>
   <para>
    某些群集资源依赖于其他组件或资源，并且要求每个组件或资源都按特定顺序启动并在同一服务器上运行。为了简化此配置，我们支持组的概念。
@@ -927,39 +931,39 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ha-config-hawk-group">
+  <procedure xml:id="pro-ha-config-hawk-group">
    <title>添加资源组</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别并列出所有定义的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<guimenu>组</guimenu>类别，然后单击加号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入唯一的<guimenu>组 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要定义组成员，请在<guimenu>可用原始资源</guimenu>列表中选择一个或多个条目，然后单击 &lt; 图标将其添加到<guimenu>组子项</guimenu>列表中。所有新的组成员都会添加到列表的底部。要定义组成员的顺序，当前需要按所需顺序添加和删除组成员。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，请按<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select: lable title nopage"/><xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>中所述修改或添加<guimenu>元属性</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建组</guimenu>以完成配置。屏幕顶端将显示一条消息，告知组是否创建成功。
     </para>
@@ -976,9 +980,9 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-confighawk-clone">
+ <section xml:id="sec-ha-confighawk-clone">
   <title>配置克隆资源</title>
   <para>
    如果希望特定资源同时在群集中的多个节点上运行，请将这些资源配置为克隆资源。例如，克隆适用于 STONITH 之类的资源和 OCFS2 之类的群集文件系统。可以克隆提供的任何资源。资源的资源代理支持克隆。根据运行克隆资源的节点，其配置可能也有所不同。
@@ -992,39 +996,39 @@ Please see LICENSE.txt for this document's license.
     克隆资源可以包含原始资源或组作为子资源。在 Hawk 中，在创建克隆时不能创建或修改子资源。添加克隆资源之前，创建子资源并根据需要配置它们。有关细节，请参见<xref linkend="pro-ha-config-hawk-primitives"/>或<xref linkend="pro-ha-config-hawk-group"/>。
    </para>
   </note>
-  <procedure id="pro-ha-config-hawk-clone">
+  <procedure xml:id="pro-ha-config-hawk-clone">
    <title>添加或修改克隆</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 <guimenu>资源</guimenu>屏幕显示所有类型的资源的类别并列出所有定义的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择<guimenu>克隆</guimenu>类别，然后单击加号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入唯一的<guimenu>克隆 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      从<guimenu>子资源</guimenu>列表中，选择原始资源或组作为克隆资源的子资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，请按<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/><xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/>中所述修改或添加<guimenu>元属性</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>创建克隆</guimenu>以完成配置。屏幕顶端将显示一条消息，告知克隆资源是否创建成功。
     </para>
@@ -1041,5 +1045,5 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_hawk_rsc_manage_i.xml
+++ b/zh_CN/xml/ha_hawk_rsc_manage_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_manage_i.xml" id="sec-ha-config-hawk-manage">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_manage_i.xml" xml:id="sec-ha-config-hawk-manage">
  <title>管理群集资源</title>
 
  <para>
@@ -46,7 +50,7 @@ Please see LICENSE.txt for this document's license.
   </mediaobject>
  </figure>
 
- <sect2 id="sec-ha-config-hawk-start">
+ <section xml:id="sec-ha-config-hawk-start">
   <title>启动资源</title>
   <para>
    启动群集资源之前，应确保资源设置正确。例如，如果要使用 Apache 服务器作为群集资源，请先设置 Apache 服务器。完成 Apache 配置，然后才能启动群集中的相应资源。
@@ -66,27 +70,27 @@ Please see LICENSE.txt for this document's license.
   <para>
    使用 Hawk 创建资源时，可通过 <literal>target-role</literal> 元属性设置其初始状态。如果将其值设置为 <literal>stopped</literal>，则该资源在创建后不会自动启动。
   </para>
-  <procedure id="pro-ha-config-hawk-start">
+  <procedure xml:id="pro-ha-config-hawk-start">
    <title>启动新资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个资源视图中，单击资源旁边的扳手图标，然后选择<guimenu>启动</guimenu>。要继续，请确认显示的消息。资源启动后，Hawk 会将资源的颜色更改为绿色并显示运行该资源的节点。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-cleanup">
+ <section xml:id="sec-ha-config-hawk-cleanup">
   <title>清理资源</title>
   <para>
    如果资源失败，它会自动重启动，但每次失败都会增加资源的失败计数。
@@ -97,95 +101,95 @@ Please see LICENSE.txt for this document's license.
   <para>
    可自动重设置资源的失败计数（通过设置资源的 <literal>failure-timeout</literal> 选项），也可如下所述手动重设置。
   </para>
-  <procedure id="pro-ha-config-hawk-clean">
+  <procedure xml:id="pro-ha-config-hawk-clean">
    <title>清理资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个资源视图中，单击失败的资源旁边的扳手图标，然后选择<guimenu>清理</guimenu>。要继续，请确认显示的消息。
     </para>
 
     <para>
-     这将对指定节点上的指定资源执行命令 <command>crm_resource <option>-C</option></command> 和 <command>crm_failcount <option>-D</option></command>。
+     这将对指定节点上的指定资源执行命令 <command>crm_resource </command> <option>-C</option> 和 <command>crm_failcount </command> <option>-D</option>。
     </para>
    </step>
   </procedure>
   <para>
    有关更多信息，请参见手册页 <command>crm_resource</command> 和 <command>crm_failcount</command>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-remove">
+ <section xml:id="sec-ha-config-hawk-remove">
   <title>删除群集资源</title>
   <para>
    如果需要从群集中删除资源，请遵循以下过程以免出现配置错误：
   </para>
 
 
-  <procedure id="pro-ha-config-hawk-rm">
+  <procedure xml:id="pro-ha-config-hawk-rm">
    <title>删除群集资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="pro-ha-config-hawk-clean"/>中所述清理所有节点上的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个资源视图中，单击资源旁边的扳手图标，然后选择<guimenu>停止</guimenu>。要继续，请确认显示的消息。
     </para>
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      如果资源已停止，则单击它旁边的扳手图标，然后选择<guimenu>删除资源</guimenu>。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-migrate">
+ <section xml:id="sec-ha-config-hawk-migrate">
   <title>迁移群集资源</title>
   <para>
    如<xref linkend="sec-ha-config-hawk-failover"/>中所述，如果软件或硬件发生故障，群集会根据可自定义的特定参数（例如，迁移阈值或资源粘性），自动进行资源故障转移（迁移）。除此之外，还可以手动将资源迁移到群集中的其他节点。或者，您可以将它移出当前节点，并让群集决定要将它放置到哪个位置。
   </para>
-  <procedure id="pro-ha-config-hawk-migrate">
+  <procedure xml:id="pro-ha-config-hawk-migrate">
    <title>手动迁移资源</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个资源视图中，单击资源旁边的扳手图标，然后选择<guimenu>移动</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在新窗口中，选择资源要移动到的节点。
     </para>
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
      此操作将创建目标节点分数为 <literal>INFINITY</literal> 的位置约束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      或者，选择移动资源<guimenu>离开当前节点</guimenu>。
     </para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
 
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      单击 <guimenu>OK</guimenu>（确定）确认迁移。
     </para>
@@ -222,33 +226,33 @@ Please see LICENSE.txt for this document's license.
   <para>
    要使资源重新移回，请按如下操作：
   </para>
-  <procedure id="pro-ha-config-hawk-migrate-back">
+  <procedure xml:id="pro-ha-config-hawk-migrate-back">
    <title>清除迁移约束</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个资源视图中，单击资源旁边的扳手图标，然后选择<guimenu>丢弃重定位规则</guimenu>。要继续，请确认显示的消息。
     </para>
     <para>
-     这将使用 <command>crm_resource <option>-U</option></command> 命令。资源<emphasis>可以</emphasis>移回到其原始位置，也可以留在当前位置（取决于资源黏性）。
+     这将使用 <command>crm_resource </command> <option>-U</option> 命令。资源<emphasis>可以</emphasis>移回到其原始位置，也可以留在当前位置（取决于资源黏性）。
     </para>
    </step>
   </procedure>
   <para>
-   有关更多信息，请参见 <command>crm_resource</command> 手册页，或<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明），可从 <ulink url="http://www.clusterlabs.org/doc/"/> 获取。请参见<citetitle>“Resource Migration”</citetitle>（资源迁移）一章。
+   有关更多信息，请参见 <command>crm_resource</command> 手册页，或<citetitle>“Pacemaker Explained”</citetitle>（Pacemaker 配置说明），可从 <link xlink:href="http://www.clusterlabs.org/doc/"/> 获取。请参见<citetitle>“Resource Migration”</citetitle>（资源迁移）一章。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-maint-mode">
+ <section xml:id="sec-ha-config-hawk-maint-mode">
   <title>使用维护模式</title>
     <para>您可能不时地需要对单个群集组件或整个群集执行测试或维护任务 - 更改群集配置、更新单个节点的软件包，或者将群集升级到更高的产品版本。 </para>
     <para>
@@ -291,39 +295,39 @@ Please see LICENSE.txt for this document's license.
    <para>
    有关处于维护模式的资源和群集的行为的细节，请参见<xref linkend="sec-ha-config-basics-maint-mode"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-maint-mode-rsc">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-rsc">
    <title>对资源应用维护模式</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>资源</guimenu>。 选择要置于维护模式或不受管理模式的资源，单击该资源旁边的扳手图标，然后选择<guimenu>编辑资源</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      打开<guimenu>元属性</guimenu>类别。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      从空下拉列表中，选择 <guimenu>maintenance</guimenu> 属性，然后单击加号图标添加该属性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选中 <literal>maintenance</literal> 旁边的复选框，以将 maintenance 属性设置为 <literal>yes</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      确认更改。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      完成该资源的维护任务之后，取消选中该资源的 <literal>maintenance</literal> 属性旁边的复选框。
     </para>
@@ -333,23 +337,23 @@ Please see LICENSE.txt for this document's license.
    </step>
   </procedure>
 
-  <procedure id="pro-ha-config-hawk-maint-mode-nodes">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-nodes">
    <title>对节点应用维护模式</title>
    <para>
     有时候需要将单个节点设置为维护模式。
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中某个节点视图中，单击节点旁边的扳手图标，然后选择<guimenu>维护</guimenu>。
     </para>
@@ -357,38 +361,38 @@ Please see LICENSE.txt for this document's license.
      这会将以下实例属性添加至节点：<literal>maintenance="true"</literal>。先前在维护模式节点上运行的资源将变为 <literal>unmanaged</literal>。在该节点脱离维护模式之前，系统不会向其分配新的资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要停用维护模式，请单击节点旁边的扳手图标，然后选择<guimenu>就绪</guimenu>。
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-maint-mode-cluster">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-cluster">
    <title>对群集应用维护模式</title>
    <para>
     要对整个群集设置或取消设置维护模式，请执行以下操作：
    </para>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集配置</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <guimenu>CRM 配置</guimenu>组中，从空下拉框中选择 <guimenu>maintenance-mode</guimenu> 属性，然后单击加号图标添加该属性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要设置 <literal>maintenance-mode</literal>，请选中 <literal>maintenance-mode</literal> 旁边的复选框，并确认您所做的更改。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      完成整个群集的维护任务之后，取消选中 <literal>maintenance-mode</literal> 属性旁边的复选框。
     </para>
@@ -397,27 +401,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-history">
+ <section xml:id="sec-ha-config-hawk-history">
   <title>查看群集历史记录</title>
 
   <para>
    Hawk 提供了以下可行的方法来查看群集上的过去的事件（按照不同级别和不同细节）。
   </para>
-  <procedure id="pro-ha-config-hawk-recent">
+  <procedure xml:id="pro-ha-config-hawk-recent">
    <title>查看节点或资源的最近事件</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>群集状态</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>树视图</guimenu>或<guimenu>表视图</guimenu>中，单击感兴趣的资源或节点旁边的扳手图标，然后选择<guimenu>查看最近的事件</guimenu>。
     </para>
@@ -426,28 +430,28 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-history-explorer">
+  <procedure xml:id="pro-ha-config-hawk-history-explorer">
    <title>使用历史记录浏览器查看转换</title>
    <para>
     <guimenu>历史记录浏览器</guimenu>提供可由您定义的时间范围内的转换信息。它还会列出其先前运行的记录，并允许您<guimenu>删除</guimenu>不再需要的报告。<guimenu>历史记录浏览器</guimenu>使用 <literal>hb_report</literal> 提供的信息。 
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左侧导航栏中，选择<guimenu>历史记录浏览器</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      默认情况下，浏览期限设置为过去 24 小时。要修改此期限，请设置其他<guimenu>开始时间</guimenu>和<guimenu>结束时间</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>显示</guimenu>开始收集转换数据。
     </para>
@@ -467,7 +471,7 @@ Please see LICENSE.txt for this document's license.
   <para>
    接着将显示下列信息：
   </para>
-  <variablelist id="vl-hawk-history-results">
+  <variablelist xml:id="vl-hawk-history-results">
    <title>历史记录浏览器结果</title>
    <varlistentry>
     <term><guimenu>时间</guimenu>
@@ -493,7 +497,7 @@ Please see LICENSE.txt for this document's license.
 
     <listitem>
      <para>
-      打开含有属于该特定转换的日志记录数据片段的弹出窗口。窗口显示的细节数量会有所不同：单击<guimenu>细节</guimenu>会显示 <command>crm history transition <replaceable>peinput</replaceable></command> 的输出（其中包括资源代理的日志讯息）。而<guimenu>完整日志</guimenu>还会包括来自 <systemitem>pengine</systemitem>、<systemitem>crmd</systemitem> 和 <systemitem>lrmd</systemitem> 的细节，其细节数量与 <command>crm history transition log <replaceable>peinput</replaceable></command> 相当。
+      打开含有属于该特定转换的日志记录数据片段的弹出窗口。窗口显示的细节数量会有所不同：单击<guimenu>细节</guimenu>会显示 <command>crm history transition</command> <replaceable>peinput</replaceable> 的输出（其中包括资源代理的日志讯息）。而<guimenu>完整日志</guimenu>还会包括来自 <systemitem>pengine</systemitem>、<systemitem>crmd</systemitem> 和 <systemitem>lrmd</systemitem> 的细节，其细节数量与 <command>crm history transition log</command> <replaceable>peinput</replaceable> 相当。
      </para>
     </listitem>
    </varlistentry>
@@ -529,22 +533,22 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-simulator">
+ <section xml:id="sec-ha-config-hawk-simulator">
   <title>浏览可能的失败方案</title>
 
   <para>
    Hawk 提供<guimenu>模拟器</guimenu>供您了解可能会发生的失败情况以防患于未然。切换到模拟器模式后，您可以更改节点的状态、添加或编辑资源和约束、更改群集配置或执行多个资源操作，以查看当这些事件发生时群集会如何操作。只要激活了模拟器模式，一个控制对话框就会显示在<guimenu>群集状态</guimenu>屏幕的右下角。模拟器会收集来自所有屏幕的更改，并将这些更改添加到它自己的内部事件队列中。除非在控制对话框中手动触发，否则不会用排入队列的事件执行模拟运行。进行模拟运行之后，您可以查看和分析已发生情况的细节（日志片段、转换图和 CIB 状态）。
   </para>
-  <procedure id="pro-ha-config-hawk-simulator">
+  <procedure xml:id="pro-ha-config-hawk-simulator">
    <title>切换到模拟器模式</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过单击顶行中（用户名旁边）的扳手图标并选择<guimenu>模拟器</guimenu>，激活模拟器模式。
     </para>
@@ -552,24 +556,24 @@ Please see LICENSE.txt for this document's license.
      Hawk 的背景颜色更改表示模拟器处于活动状态。<guimenu>群集状态</guimenu>屏幕右下角将显示一个模拟器控制对话框。它的标题<guimenu>模拟器（初始状态）</guimenu>指示目前尚未运行任何模拟器。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      填充模拟器的事件队列：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        要模拟节点的状态更改：单击模拟器控制对话框中的 <guimenu>+节点</guimenu>。选择要操作的<guimenu>节点</guimenu>，然后选择其目标<guimenu>状态</guimenu>。确认更改以将其添加到控制器对话框中列出的事件队列中。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要模拟资源操作：单击模拟器控制对话框中的 <guimenu>+操作</guimenu>。选择要操作的<guimenu>资源</guimenu>和要模拟的<guimenu>操作</guimenu>。如果必要，请定义<guimenu>间隔</guimenu>。选择要运行操作的<guimenu>节点</guimenu>及目标<guimenu>结果</guimenu>。确认更改以将其添加到控制器对话框中列出的事件队列中。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      对要模拟的任何其他节点状态更改或资源操作重复上述步骤。
     </para>
@@ -585,12 +589,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要注入想要模拟的其他更改，请执行以下操作：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        切换到下列一个或多个 Hawk 屏幕：<guimenu>群集状态</guimenu>、<guimenu>设置向导</guimenu>、<guimenu>群集配置</guimenu>、<guimenu>资源</guimenu>或<guimenu>约束</guimenu>。
       </para>
@@ -601,7 +605,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </note>
      </step>
-     <step performance="required">
+     <step>
       <para>
        根据需要在屏幕上添加或修改参数。
       </para>
@@ -610,19 +614,19 @@ Please see LICENSE.txt for this document's license.
        
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要返回到模拟器控制对话框，请切换到<guimenu>群集状态</guimenu>屏幕或单击顶行中的扳手图标，然后再次单击<guimenu>模拟器</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要删除<guimenu>注入的状态</guimenu>中列出的事件，请选择相应的条目，然后单击列表下的减号图标。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过在模拟器控制对话框中单击<guimenu>运行</guimenu>，开始模拟运行。<guimenu>群集状态</guimenu>屏幕显示模拟的事件。例如，如果将一个节点标记为未清理，则它现在将显示为脱机，其所有资源都将停止。模拟器控制对话框更改为<guimenu>模拟器（最终状态）</guimenu>。
     </para>
@@ -638,70 +642,70 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要查看关于模拟运行的更详细的信息：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        单击模拟器对话框中的<guimenu>细节</guimenu>链接可以查看已发生情况的日志片段。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        单击<guimenu>图形</guimenu>链接可以显示转换图。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        单击 <guimenu>CIB（初始）</guimenu>可以显示初始 CIB 状态。要查看转换后的 CIB，请单击 <guimenu>CIB（输出）</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要用新模拟从头开始，请使用<guimenu>重设置</guimenu>按钮。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要退出模拟模式，请关闭模拟器控制对话框。<guimenu>群集状态</guimenu>屏幕切换回其正常颜色并显示当前的群集状态。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-crm-report">
+ <section xml:id="sec-ha-config-hawk-crm-report">
   <title>生成群集报告</title>
 
   <para>
    为了对群集上发生的问题进行分析和诊断，Hawk 可以生成一个群集报告，用来收集群集中所有节点的信息。
   </para>
-  <procedure id="pro-ha-config-hawk-crm-report">
+  <procedure xml:id="pro-ha-config-hawk-crm-report">
    <title>生成 <literal>hb_report</literal></title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-config-hawk-intro-connect"/>中所述，启动 Web 浏览器并登录到群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击顶行中用户名旁边的扳手图标，然后选择<guimenu>生成 hb_report</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      默认情况下，检查期限为过去一小时。要修改此期限，请设置其他<guimenu>开始时间</guimenu>和<guimenu>结束时间</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>生成</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      创建报告后，通过单击相应链接下载 <filename>*.tar.bz2</filename> 文件。
     </para>
@@ -710,5 +714,5 @@ Please see LICENSE.txt for this document's license.
   <para>
    有关 <literal>hb_report</literal> 和 <literal>crm_report</literal> 等工具涵盖的日志文件的更多信息，请参见<xref linkend="vle-ha-crm-report"/>。
   </para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_installation.xml
+++ b/zh_CN/xml/ha_installation.xml
@@ -1,20 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_installation.xml" id="cha-ha-installation">
- <title>安装和基本设置</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_installation.xml" xml:id="cha-ha-installation"><?dbfo-need height="20em"?><title>安装和基本设置</title><info><abstract>
   <para> 本章说明如何从头开始安装并设置 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>。选择自动设置或手动设置。自动设置可让您在数分钟内启动并运行一个群集（可于稍后再调整任何选项），而手动设置则可让您一开始就设置好各个选项。 </para>
 
   <para>
    如果要迁移运行较早版本 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 的群集，或者更新属于运行中群集的节点上的软件包，请参见<xref linkend="app-ha-migration"/>一章。
   </para>
- </abstract>
- <sect1 id="sec-ha-installation-terms">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-installation-terms">
   <title>术语定义</title>
   <para>本章使用了若干术语，其定义如下。</para>
   <variablelist>
@@ -40,7 +44,7 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-mcastaddr">
+   <varlistentry xml:id="vle-ha-mcastaddr">
     <term>多路广播地址 (<systemitem>mcastaddr</systemitem>)
    </term>
     <listitem>
@@ -80,11 +84,11 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-rrp">
+   <varlistentry xml:id="vle-ha-rrp">
     <term>Redundant Ring Protocol (RRP)</term>
     <listitem>
      <para>
-       该协议支持使用多个冗余局域网来从部分或整体网络故障中恢复。这样，只要一个网络运行正常，群集通讯就仍可继续。Corosync 支持 Totem Redundant Ring Protocol。所有参与节点上都强制实施逻辑令牌传递环以确保可靠且有序地传递消息。只有拥有令牌的节点才允许广播消息。有关更多信息，请参见 <ulink url="http://www.rcsc.de/pdf/icdcs02.pdf"/>。
+       该协议支持使用多个冗余局域网来从部分或整体网络故障中恢复。这样，只要一个网络运行正常，群集通讯就仍可继续。Corosync 支持 Totem Redundant Ring Protocol。所有参与节点上都强制实施逻辑令牌传递环以确保可靠且有序地传递消息。只有拥有令牌的节点才允许广播消息。有关更多信息，请参见 <link xlink:href="http://www.rcsc.de/pdf/icdcs02.pdf"/>。
      </para>
      <para>
       在 Corosync 中定义了冗余通讯通道后，使用 RRP 告知群集如何使用这些接口。RRP 可具有三种模式 (<literal>rrp_mode</literal>)：
@@ -119,7 +123,7 @@ Please see LICENSE.txt for this document's license.
       对于身份验证，Csync2 使用 IP 地址和同步组中的预共享密钥。需要为每个同步组生成一个密钥文件，并将其复制到所有组成员。
      </para>
      <para>
-      有关 Csync2 的更多信息，请参见 <ulink url="http://oss.linbit.com/csync2/paper.pdf"/>。
+      有关 Csync2 的更多信息，请参见 <link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -127,7 +131,7 @@ Please see LICENSE.txt for this document's license.
     <term><systemitem class="resource">conntrack 工具</systemitem></term>
     <listitem>
      <para>
-      可与内核内连接跟踪系统交互，以便对 iptables 启用<emphasis>有状态</emphasis>包检测。High Availability Extension 使用此工具来同步群集节点之间的连接状态。有关详细信息，请参见 <ulink url="http://conntrack-tools.netfilter.org/"/>。
+      可与内核内连接跟踪系统交互，以便对 iptables 启用<emphasis>有状态</emphasis>包检测。High Availability Extension 使用此工具来同步群集节点之间的连接状态。有关详细信息，请参见 <link xlink:href="http://conntrack-tools.netfilter.org/"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -138,16 +142,16 @@ Please see LICENSE.txt for this document's license.
       AutoYaST 是能自动安装一个或多个 SUSE Linux Enterprise 系统而无需用户干预的系统。在 SUSE Linux Enterprise 上，可创建一个包含安装和配置数据的 AutoYaST 配置文件。此配置文件将告知 AutoYaST 要安装的内容以及如何配置已安装系统，以最终获得一个现成可用的系统。然后可使用此配置文件以各种方式（例如，克隆现有群集节点）进行大批量部署。
      </para>
      <para>
-      有关在各种情况下如何使用 AutoYaST 的详细说明，请参见 <ulink url="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。请参见<citetitle>自动安装</citetitle>一章。
+      有关在各种情况下如何使用 AutoYaST 的详细说明，请参见 <link xlink:href="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。请参见<citetitle>自动安装</citetitle>一章。
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-installation-overview">
+
+ <section xml:id="sec-ha-installation-overview">
   <title>概述</title>
 
   <para>
@@ -156,7 +160,7 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-installation-add-on" xrefstyle="select:title"/>：
     </para>
@@ -166,7 +170,7 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>zypper</command> in -t pattern ha_sles</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      初始群集设置：
     </para>
@@ -174,32 +178,32 @@ Please see LICENSE.txt for this document's license.
      在将属于群集的所有节点上安装软件后，需要执行以下步骤来初始配置群集。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-channels" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        可选： <xref linkend="sec-ha-installation-setup-security" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-csync2" xrefstyle="select:title"/>。虽然仅在一个节点上执行 Csync2 的配置，但需要在所有节点上启动服务 Csync2 和 <systemitem class="daemon">xinetd</systemitem>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        可选： <xref linkend="sec-ha-installation-setup-conntrackd" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-services" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-start" xrefstyle="select:title"/>。需要在所有节点上启动 OpenAIS/Corosync 服务。
       </para>
@@ -232,19 +236,19 @@ Please see LICENSE.txt for this document's license.
   <para>
    还可使用 AutoYaST 克隆现有节点以进行大批量部署。克隆节点会安装相同的包，并具有相同的系统配置。有关细节，请参见<xref linkend="sec-ha-installation-autoyast"/>。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-add-on">
+ <section xml:id="sec-ha-installation-add-on">
   <title>作为外接式附件安装</title>
 
   <para>
-   使用 High Availability Extension 配置和管理群集所需的包包含在 <literal>High Availability</literal> 安装模式中。只有作为 SUSE® Linux Enterprise Server 的外接式附件安装 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 后，此模式才可用。有关如何安装外接式附件产品的信息，请参见 <ulink url="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。请参见<citetitle>“安装外接式附件产品”</citetitle>一章。
+   使用 High Availability Extension 配置和管理群集所需的包包含在 <literal>High Availability</literal> 安装模式中。只有作为 SUSE® Linux Enterprise Server 的外接式附件安装 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 后，此模式才可用。有关如何安装外接式附件产品的信息，请参见 <link xlink:href="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。请参见<citetitle>“安装外接式附件产品”</citetitle>一章。
 
   </para>
 
-  <procedure id="pro-ha-install-pattern">
+  <procedure xml:id="pro-ha-install-pattern">
    <title>安装 High Availability 模式</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份启动 YaST 并选择<menuchoice><guimenu>软件</guimenu> <guimenu>软件管理</guimenu></menuchoice>。
     </para>
@@ -252,12 +256,12 @@ Please see LICENSE.txt for this document's license.
      或者，以 <systemitem class="username">root</systemitem> 用户身份使用 <command>yast2 sw_single</command> 从命令行启动 YaST 模块。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      从<guimenu>过滤器</guimenu>列表中选择<guimenu>模式</guimenu>，然后在模式列表中激活 <guimenu>High Availability</guimenu> 模式。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>接受</guimenu>开始安装包。
     </para>
@@ -267,7 +271,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </note>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在将包含在群集中的<emphasis>所有</emphasis>计算机上安装 High Availability 模式。
     </para>
@@ -276,9 +280,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-setup-auto">
+ <section xml:id="sec-ha-installation-setup-auto">
   <title>自动群集设置 (sleha-bootstrap)</title>
 
   <para> <systemitem class="resource">sleha-bootstrap</systemitem> 包提供了启动并运行单节点群集、加入其他节点并从现有群集中删除节点所需的所有功能： </para>
@@ -331,40 +335,40 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-installation-setup-sleha-init">
+  <procedure xml:id="pro-ha-installation-setup-sleha-init">
    <title>自动设置第一个节点</title>
    <para> <command>sleha-init</command> 命令检查 NTP 的配置并指引您完成群集通讯层 (Corosync) 的配置以及（可选）SBD 的配置来保护共享储存区。按照以下步骤执行操作。有关详细信息，请参见 <command>sleha-init</command> 手册页。 </para>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 用户身份登录到要用作群集节点的物理机或虚拟机。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 通过执行以下命令启动引导脚本 </para>
     <screen><prompt role="root">root # </prompt>sleha-init</screen>
     <para> 如果 NTP 未配置为在引导时启动，将显示一条消息。 </para>
     <para> 如果仍要继续，脚本将自动为 SSH 访问和 Csync2 同步工具生成密钥，并启动这两者所需的服务。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 配置群集通讯层 (Corosync)： </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para> 输入要绑定的网络地址。默认情况下，脚本将建议使用网络地址 <systemitem>eth0</systemitem>。也可以输入其他网络地址，例如地址 <literal>bond0</literal>。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> 输入多路广播地址。脚本将建议使用可用作默认值的随机地址。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> 输入多路广播端口。脚本建议使用 <literal>5405</literal> 作为默认值。 </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para> 要配置 SBD（可选），请输入要用于 SBD 的块设备分区的永久路径。该路径必须在群集中的所有节点中都一致。 </para>
     <para>
      
     </para>
     <para> 最后，脚本将启动 OpenAIS 服务以使单节点群集联机，并启用 Web 管理接口 Hawk。要用于 Hawk 的 URL 将显示在屏幕上。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 有关设置过程的任何细节，请查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -386,7 +390,7 @@ Please see LICENSE.txt for this document's license.
    <screen><prompt role="root">root # </prompt><command>passwd</command> hacluster</screen>
   </important>
 
-  <procedure id="pro-ha-installation-setup-sleha-join">
+  <procedure xml:id="pro-ha-installation-setup-sleha-join">
    <title>向现有群集添加节点</title>
    <para> 如果有一个群集启动并正在运行（包括一个或多个节点），则使用 <command>sleha-join</command> 引导脚本添加更多群集节点。该脚本只需访问一个现有群集节点即可在当前计算机上自动完成基本设置。按照以下步骤执行操作。有关详细信息，请参见 <command>sleha-join</command> 手册页。 </para>
    <para> 如果已使用 YaST 群集模块配置现有群集节点，请确保在运行 <command>sleha-join</command> 之前满足了以下先决条件： </para>
@@ -399,26 +403,26 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
    <para> 如果已通过 Hawk 登录到第一个节点，则可遵照群集状态中的更改并在 Web 界面中查看已激活的资源。 </para>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 用户身份登录到将要加入群集的物理机或虚拟机。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 通过执行以下命令启动引导脚本： </para>
     <screen><prompt role="root">root # </prompt>sleha-join</screen>
     <para> 如果 NTP 未配置为在引导时启动，将显示一条消息。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如果仍要继续，系统将提示您输入现有节点的 IP 地址。输入 IP 地址。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如果尚未配置两台计算机之间的无密码 SSH 访问，系统还将提示您输入现有节点的 <systemitem class="username">root</systemitem> 密码。 </para>
     <para> 登录到指定节点后，脚本将复制 Corosync 配置、配置 SSH 和 Csync2，并使当前计算机作为新群集节点联机。除此之外，还将启动 Hawk 所需的服务。如果已为 OCFS2 配置共享储存区，还将自动为 OCFS2 文件系统创建安装点目录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 对要添加到群集中的所有计算机重复上述步骤。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 有关过程细节，请查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -439,24 +443,24 @@ Please see LICENSE.txt for this document's license.
 
   
 
-  <procedure id="pro-ha-installation-setup-sleha-remove">
+  <procedure xml:id="pro-ha-installation-setup-sleha-remove">
    <title>从现有群集中删除节点</title>
    <para> 如果有一个启动并正在运行的群集（至少包括两个节点），则可以使用 <command>sleha-remove</command> 引导脚本从该群集中删除单个节点。您需要知道要从群集中去除的节点的 IP 地址或主机名。按照以下步骤执行操作。有关详细信息，请参见 <command>sleha-remove</command> 手册页。 </para>
    
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 用户身份登录其中一个群集节点。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 通过执行以下命令启动引导脚本： </para>
     <screen><prompt role="root">root # </prompt>sleha-remove -c <replaceable>IP_ADDR_OR_HOSTNAME</replaceable></screen>
     <para> 该脚本会启用 <systemitem class="daemon">sshd</systemitem>、停止所指定节点上的 OpenAIS 服务并传播要在其余节点之间使用 Csync2 同步的文件。 </para>
     
     <para> 如果您指定了主机名，但无法访问要去除的节点（或该主机名无法解析），脚本将通知您，并询问是否仍要去除该节点。如果您指定了 IP 地址，但无法访问该节点，该脚本将要求您输入主机名并确认是否仍要去除该节点。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 要删除更多节点，请重复上面的步骤。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 有关过程细节，请查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -466,25 +470,25 @@ Please see LICENSE.txt for this document's license.
   <procedure>
    <title>从计算机中去除 High Availability Extension 软件</title>
    <para>要从您不再需要用作群集节点的计算机中去除 High Availability Extension 软件，请执行以下操作。</para>
-   <step performance="required">
+   <step>
     <para>停止群集服务：</para>
     <screen><prompt role="root">root # </prompt>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>去除 High Availability Extension 外接式附件：</para>
     <screen><prompt role="root">root # </prompt><command>zypper</command> rm -t products sle-hae</screen>
    </step>
   </procedure>
 
- </sect1>
- <sect1 id="sec-ha-installation-setup-manual">
+ </section>
+ <section xml:id="sec-ha-installation-setup-manual">
   <title>手动群集设置 (YaST)</title>
 
   <para>
    有关初始设置所有步骤的概述，请参见<xref linkend="sec-ha-installation-overview"/>。
   </para>
 
-   <sect2 id="sec-ha-installation-setup-yast2cluster">
+   <section xml:id="sec-ha-installation-setup-yast2cluster">
    <title>YaST 群集模块</title>
    <para>
     以下各部分将指引您使用 YaST 群集模块完成每个设置步骤。要访问它，请以 <systemitem class="username">root</systemitem> 用户身份启动 YaST，并选择<menuchoice> <guimenu>高可用性</guimenu> <guimenu>群集</guimenu></menuchoice>。也可以使用 <command>yast2 cluster</command> 从命令行启动模块。
@@ -506,9 +510,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     请注意，YaST 群集模块中的一些选项仅应用于当前节点，而其他选项可自动传送到所有节点。可在以下各部分中找到有关此配置的详细信息。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-channels">
+  <section xml:id="sec-ha-installation-setup-channels">
    <title>定义通讯通道</title>
    <para>
     为实现群集节点间的成功通讯，请定义至少一个通讯通道。
@@ -534,37 +538,37 @@ Please see LICENSE.txt for this document's license.
      如果可能，请选择网络设备绑定。
     </para>
    </important>
-   <procedure id="pro-ha-installation-setup-channel1">
+   <procedure xml:id="pro-ha-installation-setup-channel1">
     <title>定义第一个通讯通道</title>
     <para>
      对于群集节点间的通讯，请使用多路广播 (UDP) 或单路广播 (UDPU)。
     </para>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到<guimenu>通讯通道</guimenu>类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用多路广播：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         将<guimenu>传输</guimenu>协议设为 <literal>UDP</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定义<guimenu>绑定网络地址</guimenu>。将此值设置为要用于群集多路广播的子网。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定义<guimenu>多路广播地址</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定义<guimenu>多路广播端口</guimenu>。
        </para>
@@ -586,27 +590,27 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用单路广播：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         将<guimenu>传输</guimenu>协议设为 <literal>UDPU</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定义<guimenu>绑定网络地址</guimenu>。将此值设置为要用于群集单路广播的子网。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定义<guimenu>多路广播端口</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para> 对于单路广播通讯，Corosync 需要知道群集中所有节点的 IP 地址。对于将要加入群集的每个节点，单击<guimenu>添加</guimenu>并输入以下细节：</para>
        <itemizedlist mark="bullet" spacing="normal">
         <listitem>
@@ -638,22 +642,22 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para> 默认情况下会启用<guimenu>自动生成节点 ID</guimenu> 选项。如果您使用的是 IPv4 地址，则节点 ID 是可选的；但如果使用 IPv6 地址，则必须指定节点 ID。要为每个群集节点自动生成唯一 ID（与手动为每个节点指定 ID 相比，这种做法较不容易出错），请让此选项保持启用。</para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集的任何选项，请确认更改并关闭群集模块。YaST 会将此配置写入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，可如下所述定义另一个通讯通道。或单击<guimenu>下一步</guimenu>并继续<xref linkend="pro-ha-installation-setup-security"/>。
      </para>
     </step>
    </procedure>
 
-   <procedure id="pro-ha-installation-setup-channel2">
+   <procedure xml:id="pro-ha-installation-setup-channel2">
     <title>定义冗余通讯通道</title>
     <para>
      如果由于任何原因不能使用网络设备绑定，第二个最佳选择就是在 Corosync 中定义冗余通讯通道（次环）。这样就可使用两个物理上分隔的网络进行通讯。如果一个网络发生故障，群集节点仍可通过另一个网络进行通讯。
@@ -664,17 +668,17 @@ Please see LICENSE.txt for this document's license.
       如果配置了多个环，则每个节点都可具有多个 IP 地址。这需要在所有节点的 <filename>/etc/hosts</filename> 文件中反映出来。
      </para>
     </important>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到<guimenu>通讯通道</guimenu>类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       请激活<guimenu>冗余通道</guimenu>。冗余通道必须使用与所定义的第一个通讯通道相同的协议。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用多路广播，则定义冗余通道的<guimenu>绑定网络地址</guimenu>、<guimenu>多路广播地址</guimenu>和<guimenu>多路广播端口</guimenu>。
      </para>
@@ -685,7 +689,7 @@ Please see LICENSE.txt for this document's license.
       现在，您已在 Corosync 中定义另一个通讯通道，它将形成次令牌传递环。在 <filename>/etc/corosync/corosync.conf</filename> 中，主环（配置的第一个通道）和次环（冗余通道）的环号分别为 <literal>0</literal> 和 <literal>1</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要告知 Corosync 如何以及何时使用其他通道，请选择要使用的 <guimenu>rrp_mode</guimenu>（<literal>active</literal> 或 <literal>passive</literal>）。有关模式的更多信息，请参见<xref linkend="vle-ha-rrp"/>或单击<guimenu>帮助</guimenu>。一旦使用 RRP，将使用流控制传送协议 (SCTP)（而非 TCP）进行节点间通讯。High Availability Extension 会监视当前环的状态，并在故障后自动重新启用冗余环。也可以使用 <command>corosync-cfgtool</command> 手动检查环状态。使用 <option>-h</option> 查看可用选项。
      </para>
@@ -693,12 +697,12 @@ Please see LICENSE.txt for this document's license.
       如果只定义了一个通讯通道，<guimenu>rrp_mode</guimenu> 将自动禁用（值 <literal>none</literal>）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集的任何选项，请确认更改并关闭群集模块。YaST 会将此配置写入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       有关进一步群集配置，请单击<guimenu>下一步</guimenu>并继续<xref linkend="sec-ha-installation-setup-security"/>。
      </para>
@@ -707,26 +711,26 @@ Please see LICENSE.txt for this document's license.
    <para>
     可在 <filename>/etc/corosync/corosync.conf.example</filename> 中找到 UDP 设置的示例文件。可在 <filename>/etc/corosync/corosync.conf.example.udpu</filename> 中找到 UDPU 设置的示例。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-security">
+  <section xml:id="sec-ha-installation-setup-security">
    <title>定义身份验证设置</title>
    <para>
     下一步是为群集定义身份验证设置。可使用需要共享机密来保护和验证消息的 HMAC/SHA1 身份验证。指定的身份验证密钥（密码）将用于群集中的所有节点。
    </para>
-   <procedure id="pro-ha-installation-setup-security">
+   <procedure xml:id="pro-ha-installation-setup-security">
     <title>启用安全性身份验证</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到<guimenu>安全性</guimenu>类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       激活<guimenu>启用安全身份验证</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       对于新创建的群集，请单击<guimenu>生成身份验证密钥文件</guimenu>。将创建身份验证密钥并将其写入 <filename>/etc/corosync/authkey</filename>。
      </para>
@@ -745,22 +749,22 @@ Please see LICENSE.txt for this document's license.
       如果希望当前计算机加入现有群集，则不用生成新的密钥文件。而是将 <filename>/etc/corosync/authkey</filename> 从一个节点复制到当前计算机（手动或使用 Csync2 皆可）。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集的任何选项，请确认更改并关闭群集模块。YaST 会将此配置写入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       有关进一步群集配置，请单击<guimenu>下一步</guimenu>并继续<xref linkend="sec-ha-installation-setup-csync2"/>。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-installation-setup-csync2">
+  <section xml:id="sec-ha-installation-setup-csync2">
    <title>将配置传送到所有节点</title>
    <para>
     如果不想将生成的配置文件手动复制到所有节点，可使用 <command>csync2</command> 工具在群集中的所有节点间进行复制。
@@ -769,12 +773,12 @@ Please see LICENSE.txt for this document's license.
     这需要以下基本步骤：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-yast" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-start" xrefstyle="select:title"/>。
      </para>
@@ -796,25 +800,25 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <para><ulink url="http://oss.linbit.com/csync2/"/> 和 <ulink url="http://oss.linbit.com/csync2/paper.pdf"/> 上提供了有关 Csync2 的详细信息。</para>
-   <procedure id="pro-ha-installation-setup-csync2-yast">
+   <para><link xlink:href="http://oss.linbit.com/csync2/"/> 和 <link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/> 上提供了有关 Csync2 的详细信息。</para>
+   <procedure xml:id="pro-ha-installation-setup-csync2-yast">
     <title>使用 YaST 配置 Csync2</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到 <guimenu>Csync2</guimenu> 类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要指定同步组，请在<guimenu>同步主机</guimenu>组中单击<guimenu>添加</guimenu>，然后输入群集中所有节点的本地主机名。对于每个节点，必须使用 <command>hostname</command> 命令返回的确切字符串。
      </para>
     </step>
-    <step id="step-csync2-generate-key" performance="required">
+    <step xml:id="step-csync2-generate-key">
      <para>
       单击<guimenu>生成预共享密钥</guimenu>以创建同步组的密钥文件。密钥文件将写入 <filename>/etc/csync2/key_hagroup</filename>。创建后，必须将其手动复制到群集的所有成员。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要使用通常需要在所有节点间同步的文件填充<guimenu>同步文件</guimenu>列表，请单击<guimenu>添加建议的文件</guimenu>。
      </para>
@@ -830,28 +834,28 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </figure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要从待同步的文件列表<guimenu>编辑</guimenu>、<guimenu>添加</guimenu>或<guimenu>删除</guimenu>文件，请使用相应按钮。必须为每个文件输入绝对路径名。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       通过单击<guimenu>打开 Csync2</guimenu> 激活 Csync2。这将执行 <command>chkconfig csync2</command>，以在引导时自动启动 Csync2。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集的任何选项，请确认更改并关闭群集模块。YaST 随即将 Csync2 配置写入 <filename>/etc/csync2/csync2.cfg</filename>。要立即启动同步过程，请继续<xref linkend="pro-ha-installation-setup-csync2-start"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       有关进一步群集配置，请单击<guimenu>下一步</guimenu>并继续<xref linkend="sec-ha-installation-setup-conntrackd"/>。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-installation-setup-csync2-start">
+   <procedure xml:id="pro-ha-installation-setup-csync2-start">
     <title>使用 Csync2 同步配置文件</title>
     <para>
      要使用 Csync2 成功同步文件，请确保满足以下先决条件：
@@ -882,7 +886,7 @@ rcxinetd start</screen>
       </note>
      </listitem>
     </itemizedlist>
-    <step performance="required">
+    <step>
      <para>
       在要<emphasis>从</emphasis>其复制配置的节点上，执行以下命令：
      </para>
@@ -897,7 +901,7 @@ rcxinetd start</screen>
 ERROR from peer hex-14: File is also marked dirty here!
 Finished with 1 errors.</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果确信当前节点上的文件版本是<quote>最佳</quote>版本，可以通过强制使用此文件并重新同步来解决冲突：
      </para>
@@ -906,7 +910,7 @@ csync2 -x</screen>
     </step>
    </procedure>
    <para>
-    有关 Csync2 选项的更多信息，请运行 <command>csync2 <option>-help</option></command>。
+    有关 Csync2 选项的更多信息，请运行 <command>csync2 </command> <option>-help</option>。
    </para>
    <note>
     <title>在任何更改后推送同步</title>
@@ -914,23 +918,23 @@ csync2 -x</screen>
      Csync2 仅推送更改。它<emphasis>不</emphasis>会在节点间连续同步文件。
     </para>
     <para>
-     每次更新需要同步的文件时，都必须将更改推送到其他节点：对已更改的节点运行 <command>csync2 <option>-xv</option></command>。如果对未更改文件的任何其他节点运行此命令，则不会执行任何操作。
+     每次更新需要同步的文件时，都必须将更改推送到其他节点：对已更改的节点运行 <command>csync2 </command> <option>-xv</option>。如果对未更改文件的任何其他节点运行此命令，则不会执行任何操作。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-conntrackd">
+  <section xml:id="sec-ha-installation-setup-conntrackd">
    <title>同步群集节点间的连接状态</title>
    <para>
     要对 iptables 启用<emphasis>有状态</emphasis>包检测，请配置并使用 conntrack 工具。 
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-conntrackd" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       为 <systemitem class="daemon">conntrackd</systemitem> 配置一个资源（类：<literal>ocf</literal>，提供程序：<literal>heartbeat</literal>）。如果使用 Hawk 添加资源，则使用 Hawk 推荐的默认值。
      </para>
@@ -940,44 +944,44 @@ csync2 -x</screen>
     配置 conntrack 工具后，可使用这些工具来<xref linkend="cha-ha-lvs" xrefstyle="select:title"/>。
    </para>
 
-   <procedure id="pro-ha-installation-setup-conntrackd">
+   <procedure xml:id="pro-ha-installation-setup-conntrackd">
     <title>使用 YaST 配置 <systemitem class="resource">conntrackd</systemitem></title>
     <para>
      使用 YaST 群集模块配置用户空间 <systemitem class="daemon">conntrackd</systemitem>。这需要未用于其他通讯通道的专用网络接口。守护程序可随后通过资源代理启动。
     </para>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到<guimenu>配置 conntrackd</guimenu> 类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       选择<guimenu>专用接口</guimenu>来同步连接状态。会自动检测所选接口的 IPv4 地址并显示在 YaST 中。该地址必须已经配置并且必须支持多路广播。
 
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定义要用于同步连接状态的<guimenu>多路广播地址</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>组号</guimenu>中，定义要将连接状态同步到其中的组的数字 ID。
       
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       单击<guimenu>生成 /etc/conntrackd/conntrackd.conf</guimenu> 来创建 <systemitem class="daemon">conntrackd</systemitem> 的配置文件。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集的任何选项，请确认更改并关闭群集模块。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       有关进一步群集配置，请单击<guimenu>下一步</guimenu>并继续<xref linkend="sec-ha-installation-setup-services"/>。
      </para>
@@ -994,21 +998,21 @@ csync2 -x</screen>
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-services">
+  <section xml:id="sec-ha-installation-setup-services">
    <title>配置服务</title>
    <para>
     在 YaST 群集模块中，定义是否在引导节点时启动其上的特定服务。也可使用模块手动启动和停止服务。为使群集节点联机并启动群集资源管理器，OpenAIS 必须作为服务运行。
    </para>
-   <procedure id="pro-ha-installation-setup-services">
+   <procedure xml:id="pro-ha-installation-setup-services">
     <title>启用群集服务</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 群集模块中，切换到<guimenu>服务</guimenu>类别。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要在每次引导此群集节点时启动 OpenAIS，请在<guimenu>引导</guimenu>组中选择相应选项。如果在<guimenu>引导</guimenu>组中选择<guimenu>关</guimenu>，则必须在每次引导此节点时手动启动 OpenAIS。要手动启动 OpenAIS，请使用 <command>rcopenais start</command> 命令。
      </para>
@@ -1022,21 +1026,21 @@ csync2 -x</screen>
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要使用 Pacemaker GUI 配置、管理和监视群集资源，请激活<guimenu>启用 mgmtd</guimenu>。GUI 需要此守护程序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要立即启动或停止 OpenAIS，请单击相应按钮。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>要在防火墙中打开所需的端口以在当前计算机上进行群集通讯，请激活<guimenu>打开防火墙中的端口</guimenu>。该配置将写入 <filename>/etc/sysconfig/SuSEfirewall2.d/services/cluster</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了现有群集节点的任何选项，请确认更改并关闭群集模块。请注意，该配置仅应用于当前计算机，而不是所有群集节点。
      </para>
@@ -1056,21 +1060,21 @@ csync2 -x</screen>
      </figure>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-start">
+  <section xml:id="sec-ha-installation-start">
    <title>使群集联机</title>
    <para>
     完成初始群集配置后，在<emphasis>每个</emphasis>群集节点上启动 OpenAIS/Corosync 服务，以使堆栈联机：
    </para>
    <procedure>
     <title>启动 OpenAIS/Corosync 并检查状态</title>
-    <step performance="required">
+    <step>
      <para>
       登录到现有节点。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       检查服务是否已在运行。
      </para>
@@ -1080,12 +1084,12 @@ csync2 -x</screen>
      </para>
 <screen><prompt role="root">root # </prompt>rcopenais start</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       对每个群集节点重复上述步骤。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在某个节点上，使用 <command>crm status</command> 命令检查群集状态。如果所有节点都联机，则输出应类似于如下内容：
      </para>
@@ -1105,9 +1109,9 @@ csync2 -x</screen>
    <para>
     完成基本配置且节点联机后，可以开始使用 crm 外壳、Pacemaker GUI 或 HA Web Konsole 等群集管理工具配置群集资源。有关更多信息，请参考以下章节。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-installation-autoyast">
+  </section>
+ </section>
+ <section xml:id="sec-ha-installation-autoyast">
   <title>使用 AutoYaST 进行大批量部署</title>
 
   <para>
@@ -1116,7 +1120,7 @@ csync2 -x</screen>
 
 
 
-  <procedure id="pro-ha-installation-clone-node">
+  <procedure xml:id="pro-ha-installation-clone-node">
    <title>使用 AutoYaST 克隆群集节点</title>
    <important>
     <title>相同硬件</title>
@@ -1124,43 +1128,43 @@ csync2 -x</screen>
      此方案假设您要将 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署到一组具有相同硬件配置的计算机上。
     </para>
    </important>
-   <para>如果需要在不同硬件上部署群集节点，请参见《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》的“<citetitle>自动安装</citetitle>”一章中的“<citetitle>基于规则的自动安装</citetitle>”一节，该文档的网址为 <ulink url="http://www.suse.com/doc"/>。 </para>
-   <step performance="required">
+   <para>如果需要在不同硬件上部署群集节点，请参见《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》的“<citetitle>自动安装</citetitle>”一章中的“<citetitle>基于规则的自动安装</citetitle>”一节，该文档的网址为 <link xlink:href="http://www.suse.com/doc"/>。 </para>
+   <step>
     <para>
      确保已正确安装和配置要克隆的节点。有关细节，请分别参见<xref linkend="sec-ha-installation-add-on"/>以及<xref linkend="sec-ha-installation-setup-auto"/>或<xref linkend="sec-ha-installation-setup-manual"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按照《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》中的概要说明进行简单的大批量安装。其中包括以下基本步骤：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        创建 AutoYaST 配置文件。使用 AutoYaST GUI 基于现有系统配置创建和修改配置文件。在 AutoYaST 中选择 <guimenu>High Availability</guimenu> 模块并单击<guimenu>克隆</guimenu>按钮。如果需要，调整其他模块中的配置，并将生成的控制文件另存为 XML 格式的文件。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确定 AutoYaST 配置文件的来源以及要传递到其他节点的安装例程的参数。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确定 SUSE Linux Enterprise Server 和 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 安装数据的来源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确定并设置自动安装的引导方案。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        通过手动添加参数或创建 <filename>info</filename> 文件，将命令行传递到安装例程。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        启动并监视自动安装进程。
       </para>
@@ -1173,14 +1177,14 @@ csync2 -x</screen>
    成功安装克隆节点后，执行以下步骤将克隆节点加入群集中：
   </para>
 
-  <procedure id="pro-ha-installation-clone-start">
+  <procedure xml:id="pro-ha-installation-clone-start">
    <title>使克隆节点处于联机状态</title>
-   <step performance="required">
+   <step>
     <para>
      按<xref linkend="sec-ha-installation-setup-csync2"/>中所述使用 Csync2 将密钥配置文件从已配置的节点传送到克隆节点。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要使节点联机，请如<xref linkend="sec-ha-installation-start"/>中所述在克隆的节点上启动 OpenAIS 服务。
     </para>
@@ -1190,5 +1194,5 @@ csync2 -x</screen>
   <para>
    现在克隆节点将加入群集，因为 <filename>/etc/corosync/corosync.conf</filename> 文件已通过 Csync2 应用到克隆节点。CIB 将在群集节点间自动同步。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_intro.xml
+++ b/zh_CN/xml/ha_intro.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE preface PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE preface>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<preface xml:base="ha_intro.xml" id="pre-ha">
- <title>关于本指南</title>
+<preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_intro.xml" xml:id="pre-ha"><title>关于本指南</title><info/>
+ 
  <para>
   <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability</phrase></phrase> 是一款采用开放源代码群集技术的的集成套件，能让您的企业实施高度可用的物理和虚拟 Linux 群集。为了快速有效地进行配置和管理，High Availability Extension 包含一个图形用户界面 (GUI) 和一个命令行界面 (CLI)，此外还随附 HA Web Konsole (Hawk)，便于您通过 Web 界面管理 Linux 群集。
  </para>
@@ -58,12 +62,12 @@ Please see LICENSE.txt for this document's license.
   本手册中的许多章节包含到附加文档资源的链接。 其中包括系统上提供的附加文档以及因特网上提供的文档。
  </para>
  <para>
-  有关该产品可用文档的概述和最新文档更新，请参见 <ulink url="http://www.suse.com/doc/"/>。
+  有关该产品可用文档的概述和最新文档更新，请参见 <link xlink:href="http://www.suse.com/doc/"/>。
  </para>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_feedback_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_typografie_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_making_i.xml" parse="xml"/>
+ <xi:include href="common_intro_feedback_i.xml" parse="xml"/>
+ <xi:include href="common_intro_typografie_i.xml" parse="xml"/>
+ <xi:include href="common_intro_making_i.xml" parse="xml"/>
  
  
 </preface>

--- a/zh_CN/xml/ha_lvs.xml
+++ b/zh_CN/xml/ha_lvs.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_lvs.xml" id="cha-ha-lvs">
- <title>Linux 虚拟服务器的负载平衡</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_lvs.xml" xml:id="cha-ha-lvs"><title>Linux 虚拟服务器的负载平衡</title><info/>
+ 
 
  <para>
   Linux 虚拟服务器 (LVS) 的目标是提供一个基本框架，将网络连接定向到共享其工作负载的多台服务器。Linux 虚拟服务器是服务器群集（一个或多个负载平衡器及多台用于运行服务的真实的服务器），对于外部客户端显示为一台大型的快速服务器。这种看上去像是单台服务器的服务器被称为<emphasis>虚拟服务器</emphasis>。Linux 虚拟服务器可用于构建可灵活缩放并具有高可用性的网络服务，如 Web、缓存、邮件、FTP、媒体和 VoIP 服务。
@@ -14,14 +18,14 @@ Please see LICENSE.txt for this document's license.
  <para>
   真实的服务器和负载平衡器可通过高速 LAN 或地理位置分散的 WAN 互相连接。负载平衡器可将请求发送到不同的服务器。它们使群集的并行服务看似单个 IP 地址（虚拟 IP 地址，即VIP）上的虚拟服务。发送请求时可使用 IP 负载平衡技术或应用程序级的负载平衡技术。系统的可伸缩性通过在群集中透明地添加或删除节点来实现。高可用性通过检测节点或守护程序故障并相应地重配置系统来提供。
  </para>
- <sect1 id="sec-ha-lvs-overview">
+ <section xml:id="sec-ha-lvs-overview">
   <title>概念概述</title>
 
   <para>
    以下部分概述了 LVS 主要组件和概念。
   </para>
 
-  <sect2 id="sec-ha-lvs-overview-director">
+  <section xml:id="sec-ha-lvs-overview-director">
    <title>定向器</title>
    <para>
     LVS 的主要组件是 ip_vs（也称 IPVS）内核代码。它在 Linux 内核（第 4 层交换）中实施传输层负载平衡。运行包含 IPVS 代码的 Linux 内核的节点称为<emphasis>定向器</emphasis>。控制器上运行的 IPVS 代码是 LVS 的基本功能。
@@ -32,9 +36,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     默认情况下，内核不需要安装 IPVS 模块。IPVS 内核模块包含在 <systemitem class="resource">cluster-network-kmp-default</systemitem> 包中。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-userspace">
+  <section xml:id="sec-ha-lvs-overview-userspace">
    <title>用户空间控制器和守护程序</title>
    <para>
     <systemitem class="daemon">ldirectord</systemitem> 守护程序是一个用户空间守护程序，用于管理 Linux 虚拟服务器并监视负载平衡虚拟服务器的 LVS 群集中的真实服务器。配置文件 <filename>/etc/ha.d/ldirectord.cf</filename> 指定虚拟服务及其关联的真实服务器，并告知 <systemitem class="daemon">ldirecord</systemitem> 如何将此服务器配置为 LVS 重定向器。守护程序初始化时，将为群集创建虚拟服务。
@@ -45,9 +49,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     <systemitem class="daemon">ldirectord</systemitem> 使用 <systemitem>ipvsadm</systemitem> 工具（包 <systemitem class="resource">ipvsadm</systemitem>）来操作 Linux 内核的虚拟服务器表。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-forwarding">
+  <section xml:id="sec-ha-lvs-overview-forwarding">
    <title>包的转发</title>
    <para>
     定向器可采用三种不同方法将包从客户端发送到真实服务器：
@@ -78,16 +82,16 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-schedulers">
+  <section xml:id="sec-ha-lvs-overview-schedulers">
    <title>调度算法</title>
    <para>
     确定将哪台真实服务器用于客户端请求的新连接，是使用不同算法来实现的。这些算法以模块的形式提供，可进行调整以适应特定需要。有关可用模块的概述，请参见 <command>ipvsadm(8)</command> 手册页。从客户端接收到连接请求时，控制器会根据<emphasis>日程表</emphasis>将一台真实的服务器指派给此客户端。调度程序是 IPVS 内核代码中的一部分，它决定哪台真实的服务器将获取下一个新连接。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-lvs-ldirectord">
+  </section>
+ </section>
+ <section xml:id="sec-ha-lvs-ldirectord">
   <title>使用 YaST 配置 IP 负载平衡</title>
 
   <para>
@@ -113,69 +117,69 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="sec-ha-lvs-ldirectord-global">
+  <procedure xml:id="sec-ha-lvs-ldirectord-global">
    <title>配置全局参数</title>
    <para>
     以下过程描述了如何配置最重要的全局参数。有关个别参数（以及此处未提及的参数）的更多细节，请单击<guimenu>帮助</guimenu>或参见 <systemitem class="daemon">ldirectord</systemitem> 手册页。
    </para>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>检查间隔</guimenu>定义 <systemitem class="daemon">ldirectord</systemitem> 连接到每台真实服务器以检查它们是否仍处于联机状态的间隔。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>检查超时</guimenu>设置真实服务器应该在多长时间内响应上次检查。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>失败计数</guimenu>定义在检查被视为失败前 <systemitem class="daemon">ldirectord</systemitem> 可尝试向真实服务器发送多少次请求。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>协商超时</guimenu>定义协商检查经过多少秒后应视为超时。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>回退</guimenu>中，输入当所有真实服务器都停机时，要将 Web 服务重定向到的 Web 服务器的主机名或 IP 地址。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果希望系统在任何真实服务器的连接状态发生改变时均发送警报，请在<guimenu>电子邮件警报</guimenu>中输入有效的电子邮件地址。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>电子邮件警报频率</guimenu>定义经过多少秒后，如果任何真实服务器仍无法访问，应重复发出电子邮件警报。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>电子邮件警报状态</guimenu>中指定应发送电子邮件警报的服务器状态。如果要定义多个状态，请使用逗号分隔的列表。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过<guimenu>自动重新装载</guimenu>定义 <systemitem class="daemon">ldirectord</systemitem> 是否应连续监视配置文件有无修改。如果设置为 <literal>yes</literal>，则将在发生更改时自动重新装载配置。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      通过 <guimenu>Quiescent</guimenu> 开关定义是否应从内核的 LVS 表中删除发生故障的真实服务器。如果设置为<guimenu>是</guimenu>，则不会删除发生故障的服务器。而是将其权重设置为 <literal>0</literal>，表示不接受新连接。已建立的连接将继续存在，直到超时为止。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要使用备用路径进行日志记录，请在<guimenu>日志文件</guimenu>中指定日志的路径。默认情况下，<systemitem class="daemon">ldirectord</systemitem> 会将其日志写入 <filename>/var/log/ldirectord.log</filename>。
     </para>
    </step>
   </procedure>
 
-  <figure id="fig-ha-lvs-yast-global">
+  <figure xml:id="fig-ha-lvs-yast-global">
    <title>YaST IP 负载平衡 - 全局参数</title>
    <mediaobject>
     <imageobject role="fo">
@@ -187,27 +191,27 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <procedure id="sec-ha-lvs-ldirectord-virtual">
+  <procedure xml:id="sec-ha-lvs-ldirectord-virtual">
    <title>配置虚拟服务</title>
    <para>
     可通过为每种虚拟服务定义若干参数来配置一个或多个虚拟服务。以下过程描述了如何配置虚拟服务最重要的参数。有关个别参数（以及此处未提及的参数）的更多细节，请单击<guimenu>帮助</guimenu>或参见 <systemitem class="daemon">ldirectord</systemitem> 手册页。
    </para>
-   <step performance="required">
+   <step>
     <para>
      在 YaST IP 负载平衡模块中，切换到<guimenu>虚拟服务器配置</guimenu>选项卡。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>添加</guimenu>新虚拟服务器或<guimenu>编辑</guimenu>现有虚拟服务器。一个新对话框将显示可用选项。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>虚拟服务器</guimenu>中，输入负载平衡器和真实服务器可作为 LVS 访问的共享虚拟 IP 地址（IPv4 或 IPv6）和端口。还可以指定主机名和服务来代替 IP 地址和端口号。或者，也可以使用防火墙标记。防火墙标记是一种将任意 <literal>VIP:port</literal> 服务的集合聚合到一个虚拟服务中的方法。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      要指定<guimenu>真实服务器</guimenu>，需要输入服务器的 IP 地址（IPv4、IPv6 或主机名）、端口（或服务名称）以及转发方法。转发方法必须是 <literal>gate</literal>、<literal>ipip</literal> 或 <literal>masq</literal> 中的一种，请参见<xref linkend="sec-ha-lvs-overview-forwarding"/>。
     </para>
@@ -215,47 +219,47 @@ Please see LICENSE.txt for this document's license.
      单击<guimenu>添加</guimenu>按钮，为每台真实服务器输入需要的自变量。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>检查类型</guimenu>中选择用于测试真实服务器是否仍然活动的检查类型。例如，要发送请求并检查响应是否包含预期的字符串，请选择 <literal>Negotiate</literal>。
     </para>
    </step>
-   <step id="step-ha-lvs-ldirectord-service" performance="required">
+   <step xml:id="step-ha-lvs-ldirectord-service">
     <para>
      如果已将<guimenu>检查类型</guimenu>设置为 <literal>Negotiate</literal>，则还需定义要监视的服务类型。从<guimenu>服务</guimenu>下拉列表中进行选择。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>请求</guimenu>中输入检查间隔期间每台真实服务器上所请求对象的 URI。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要检查来自真实服务器的响应是否包含特定字符串（如 <quote>I'm alive</quote> 消息），请定义需要匹配的正则表达式。将正则表达式输入到<guimenu>接收</guimenu>中。如果来自真实服务器的响应包含此表达式，则认为真实服务器处于活动状态。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根据您在<xref linkend="step-ha-lvs-ldirectord-service"/> 中选定的<guimenu>服务</guimenu>类型，您还必须为身份验证指定更多参数。切换到<guimenu>授权类型</guimenu>选项卡，输入<guimenu>登录</guimenu>、<guimenu>口令</guimenu>、<guimenu>数据库</guimenu>或<guimenu>机密</guimenu>等详细信息。有关更多信息，请参见 YaST 帮助文本或 <systemitem class="daemon">ldirectord</systemitem> 手册页。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      切换至<guimenu>其他</guimenu>选项卡。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择用于负载平衡的<guimenu>调度程序</guimenu>。有关可用调度程序的信息，请参见 <command>ipvsadm(8)</command> 手册页。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      选择要使用的<guimenu>协议</guimenu>。如果将虚拟服务指定为 IP 地址和端口，则它必须是 <literal>tcp</literal> 或 <literal>udp</literal>。如果将虚拟服务指定为防火墙标记，则协议必须是 <literal>fwm</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，可定义其他参数。单击<guimenu>确定</guimenu>确认配置。YaST 会将此配置写入 <filename>/etc/ha.d/ldirectord.cf</filename>。
     </para>
@@ -264,7 +268,7 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <figure id="fig-ha-lvs-yast-virtual">
+  <figure xml:id="fig-ha-lvs-yast-virtual">
    <title>YaST IP 负载平衡 - 虚拟服务</title>
    <mediaobject>
     <imageobject role="fo">
@@ -276,25 +280,25 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <example id="ex-ha-lvs-ldirectord">
+  <example xml:id="ex-ha-lvs-ldirectord">
    <title>简单的 ldirectord 配置</title>
    <para>
     <xref linkend="fig-ha-lvs-yast-global"/>和<xref linkend="fig-ha-lvs-yast-virtual"/>中所示的值将生成在 <filename>/etc/ha.d/ldirectord.cf</filename> 中定义的以下配置：
    </para>
-<screen>autoreload = yes <co id="co-ha-ldirectord-autoreload"/>
-checkinterval = 5 <co id="co-ha-ldirectord-checkintervall"/>
-checktimeout = 3 <co id="co-ha-ldirectord-checktimeout"/>
-quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
-    virtual = 192.168.0.200:80 <co id="co-ha-ldirectord-virtual"/>
-    checktype = negotiate <co id="co-ha-ldirectord-checktype"/>
-    fallback = 127.0.0.1:80 <co id="co-ha-ldirectord-fallback"/>
-    protocol = tcp <co id="co-ha-ldirectord-protocol"/>
-    real = 192.168.0.110:80 gate <co id="co-ha-ldirectord-real"/>
+<screen>autoreload = yes <co xml:id="co-ha-ldirectord-autoreload"/>
+checkinterval = 5 <co xml:id="co-ha-ldirectord-checkintervall"/>
+checktimeout = 3 <co xml:id="co-ha-ldirectord-checktimeout"/>
+quiescent = yes <co xml:id="co-ha-ldirectord-quiescent"/>
+    virtual = 192.168.0.200:80 <co xml:id="co-ha-ldirectord-virtual"/>
+    checktype = negotiate <co xml:id="co-ha-ldirectord-checktype"/>
+    fallback = 127.0.0.1:80 <co xml:id="co-ha-ldirectord-fallback"/>
+    protocol = tcp <co xml:id="co-ha-ldirectord-protocol"/>
+    real = 192.168.0.110:80 gate <co xml:id="co-ha-ldirectord-real"/>
     real = 192.168.0.120:80 gate <xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/>
-    receive = "still alive" <co id="co-ha-ldirectord-receive"/>
-    request = "test.html" <co id="co-ha-ldirectord-request"/>
-    scheduler = wlc <co id="co-ha-ldirectord-scheduler"/>
-    service = http <co id="co-ha-ldirectord-service"/></screen>
+    receive = "still alive" <co xml:id="co-ha-ldirectord-receive"/>
+    request = "test.html" <co xml:id="co-ha-ldirectord-request"/>
+    scheduler = wlc <co xml:id="co-ha-ldirectord-scheduler"/>
+    service = http <co xml:id="co-ha-ldirectord-service"/></screen>
    <calloutlist>
     <callout arearefs="co-ha-ldirectord-autoreload">
      <para>
@@ -367,8 +371,8 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     此配置将导致以下进程流：<systemitem class="daemon">ldirectord</systemitem> 每 5 秒连接一次每台真实服务器 (<xref linkend="co-ha-ldirectord-checkintervall" xrefstyle="select:label nopage"/>)，并按 <xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/> 和 <xref linkend="co-ha-ldirectord-request" xrefstyle="select:label nopage"/> 中指定的方式请求 <literal>192.168.0.110:80/test.html</literal> 或 <literal>192.168.0.120:80/test.html</literal>。如果上次检查后 3 秒内 (<xref linkend="co-ha-ldirectord-checktimeout" xrefstyle="select:label nopage"/>) 未收到来自真实服务器的预期的 <literal>still alive</literal> 字符串 (<xref linkend="co-ha-ldirectord-receive" xrefstyle="select:label nopage"/>)，它会将此真实服务器从可用池中删除。但是，由于 <literal>quiescent=yes</literal> 设置 (<xref linkend="co-ha-ldirectord-quiescent" xrefstyle="select:label nopage"/>)，真实服务器不会从 LVS 表中删除，但权重将设置为 <literal>0</literal>，这样就不会接受此真实服务器的新连接。已建立的连接将继续存在，直到超时为止。
    </para>
   </example>
- </sect1>
- <sect1 id="sec-ha-lvs-further">
+ </section>
+ <section xml:id="sec-ha-lvs-further">
   <title>其他设置</title>
 
   <para>
@@ -397,16 +401,16 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-lvs-more">
+ </section>
+ <section xml:id="sec-ha-lvs-more">
   <title>更多信息</title>
 
   <para>
-   要了解更多有关 Linux 虚拟服务器的信息，请参见 <ulink url="http://www.linuxvirtualserver.org/"/> 上的项目主页。
+   要了解更多有关 Linux 虚拟服务器的信息，请参见 <link xlink:href="http://www.linuxvirtualserver.org/"/> 上的项目主页。
   </para>
 
   <para>
    有关 <systemitem class="daemon">ldirectord</systemitem> 的更多信息，请参见其综合性手册页。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_management.xml
+++ b/zh_CN/xml/ha_management.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_management.xml" id="app-ha-management">
- <title>群集管理工具</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_management.xml" xml:id="app-ha-management"><title>群集管理工具</title><info/>
+ 
  <para>
   High Availability Extension 附带了一套全面的工具，帮助您从命令行管理群集。本章主要介绍管理 CIB 中的群集配置和群集资源所需的工具。用于管理资源代理的其他命令行工具或用于调试设置（和查错）的工具在<xref linkend="app-ha-troubleshooting"/>中有所介绍。
  </para>

--- a/zh_CN/xml/ha_migration.xml
+++ b/zh_CN/xml/ha_migration.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_migration.xml" id="app-ha-migration">
- <title>升级群集和更新软件包</title>
- <abstract>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_migration.xml" xml:id="app-ha-migration"><title>升级群集和更新软件包</title><info><abstract>
   <para>
    本章介绍两种不同方案：将群集升级为 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 的另一个版本（主要版本或服务包），以及更新各群集节点上的单个包。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-migration-terminology">
+ 
+ 
+ <section xml:id="sec-ha-migration-terminology">
   <title>术语</title>
   
   <para>
@@ -57,13 +61,13 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-upgrade">
+ <section xml:id="sec-ha-migration-upgrade">
   <title>将群集升级到最新产品版本</title>
   
   <para>
-   至于支持哪种升级路径以及如何执行升级，取决于运行群集的当前产品版本，以及您要迁移到的目标版本。有关一般信息，请参见《<citetitle>SUSE Linux Enterprise Server 11 部署指南</citetitle>》中的“<citetitle>更新 SUSE Linux Enterprise</citetitle>”一章。可通过 <ulink url="http://www.suse.com/documentation/"/> 获得。
+   至于支持哪种升级路径以及如何执行升级，取决于运行群集的当前产品版本，以及您要迁移到的目标版本。有关一般信息，请参见《<citetitle>SUSE Linux Enterprise Server 11 部署指南</citetitle>》中的“<citetitle>更新 SUSE Linux Enterprise</citetitle>”一章。可通过 <link xlink:href="http://www.suse.com/documentation/"/> 获得。
   </para>
   
   <important>
@@ -84,7 +88,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
   </important>
- <sect2 id="sec-ha-migration-sle11">
+ <section xml:id="sec-ha-migration-sle11">
   <title>从 SLES 10 升级到 SLE HA 11</title>
 
    <important>
@@ -134,34 +138,34 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect3 id="sec-ha-migration-sle11-prep">
+  <section xml:id="sec-ha-migration-sle11-prep">
    <title>准备和备份</title>
    <para>
     将群集升级为下一个产品版本并相应地转换数据之前，需要准备当前群集。
    </para>
-   <procedure id="pro-ha-migration-sle11-prep">
+   <procedure xml:id="pro-ha-migration-sle11-prep">
     <title>准备 SUSE Linux Enterprise Server 10 SP4 群集</title>
-    <step performance="required">
+    <step>
      <para>
       登录到群集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       查看检测信号配置文件 <filename>/etc/ha.d/ha.cf</filename> 并检查是否所有通讯媒体都支持多路广播。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       确保以下文件在所有节点上都是相同的：<filename>/etc/ha.d/ha.cf</filename> 和 <filename>/var/lib/heartbeat/crm/cib.xml</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       通过在每个节点上执行 <command>rcheartbeat stop</command> 使所有节点都处于脱机状态。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       除了在更新到最新版本之前执行所推荐的常规系统备份外，另请备份以下文件，以便在升级到 SUSE Linux Enterprise Server 11 之后用来运行转换脚本：
      </para>
@@ -188,36 +192,36 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </itemizedlist>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果有 EVMS2 资源，请将非 LVM EVMS2 卷转换为 SUSE Linux Enterprise Server 10 上的兼容卷。在转换过程中（请参见<xref linkend="sec-ha-migration-sle11-convert"/>），它们会随即转换为 LVM2 卷组。转换后，请务必使用 <command>vgchange -c y</command> 将每个卷组都标记为 High Availability 群集的成员。
 
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-install">
+  <section xml:id="sec-ha-migration-sle11-install">
    <title>升级/安装</title>
    <para>
     做好群集准备和文件备份后，在群集节点上全新安装 SUSE Linux Enterprise 11。
    </para>
-   <procedure id="pro-ha-migration-sle11-install">
+   <procedure xml:id="pro-ha-migration-sle11-install">
     <title>升级到 SUSE Linux Enterprise 11</title>
-    <step performance="required">
+    <step>
      <para>
       在所有群集节点上全新安装 SUSE Linux Enterprise Server 11。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在所有群集节点上，安装 SUSE Linux Enterprise Server 之后随即安装 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11，使之做为外接式附件。有关详细信息，请参见<xref linkend="sec-ha-installation-add-on"/>。
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-convert">
+  <section xml:id="sec-ha-migration-sle11-convert">
    <title>数据转换</title>
    <para>
     SUSE Linux Enterprise Server 11 和 High Availability Extension 均安装完成后，即可开始进行数据转换。High Availability Extension 附带的转换脚本已经过谨慎的设置，但是无法在全自动模式下处理所有设置。它会其所作更改显示警报，但是需要您进行干预和决策。您需要详细地了解群集 - 因为更改是否有意义取决于您的需求。转换脚本位于 <filename>/usr/lib/heartbeat</filename>（如果使用 64 位系统，则位于 <filename>/usr lib64/heartbeat</filename>）。
@@ -228,9 +232,9 @@ Please see LICENSE.txt for this document's license.
      要熟悉转换进程，我们强烈建议您首先测试一下转换（不作任何更改）。可以使用同一测试目录执行重复的测试运行，但是只需要复制一次文件。
     </para>
    </note>
-   <procedure id="pro-ha-migration-sle11-test">
+   <procedure xml:id="pro-ha-migration-sle11-test">
     <title>测试转换</title>
-    <step performance="required">
+    <step>
      <para>
       在某个节点上创建测试目录，并将备份文件复制到此测试目录：
      </para>
@@ -240,7 +244,7 @@ $ cp /var/lib/heartbeat/hostcache /tmp/hb2openais-testdir
 $ cp /etc/logd.cf /tmp/hb2openais-testdir
 $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用以下命令开始测试运行
      </para>
@@ -250,7 +254,7 @@ $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
      </para>
 <screen>$ /usr/lib64/heartbeat/hb2openais.sh -T /tmp/hb2openais-testdir -U</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       阅读并校验生成的 <filename>openais.conf</filename> 和 <filename>cib-out.xml</filename> 文件：
      </para>
@@ -262,27 +266,27 @@ $ crm_verify -V -x cib-out.xml</screen>
    <para>
     有关转换阶段的详细信息，请参见所安装的 High Availability Extension 中的 <filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>。
    </para>
-   <procedure id="pro-ha-migration-sle11-convert">
+   <procedure xml:id="pro-ha-migration-sle11-convert">
     <title>转换数据</title>
     <para>
      执行测试运行并检查输出后，可以立即开始数据转换。只需在<emphasis>一个</emphasis>节点上运行转换。主群集配置 (CIB) 会自动复制到其他节点。需要复制的所有其他文件会由转换脚本自动进行复制。
     </para>
-    <step performance="required">
+    <step>
      <para>
       确保 <systemitem class="daemon">sshd</systemitem> 运行于 <systemitem class="username">root</systemitem> 有权访问的所有节点上，以便转换脚本成功地将文件复制到其他群集节点。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       确保所有 ocfs2 文件系统都已卸载。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       High Availability Extension 随附一个默认的 OpenAIS 配置文件。如果要防止在后面的步骤中重写此默认配置，请制作 <filename>/etc/ais/openais.conf</filename> 配置文件的副本。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身份启动转换脚本。如果使用 sudo，请使用 <option>-u</option> 选项指定特权用户：
      </para>
@@ -291,7 +295,7 @@ $ crm_verify -V -x cib-out.xml</screen>
       基于 <filename>/etc/ha.d/ha.cf</filename> 中所存储的配置，脚本将为 OpenAIS 群集堆栈生成新的配置文件 <filename>/etc/ais/openais.conf</filename>。由于从 Heartbeat 更改到 OpenAIS，它还会分析 CIB 配置，并让您了解是否需要更改群集配置。在转换运行的节点上完成所有文件处理，并将文件处理复制到其他节点。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按照屏幕指导执行操作。
      </para>
@@ -304,16 +308,16 @@ $ crm_verify -V -x cib-out.xml</screen>
     升级之后，不支持还原到 SUSE Linux Enterprise Server 10。
    </para>
 
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-more">
+  <section xml:id="sec-ha-migration-sle11-more">
    <title>更多信息</title>
    <para>
     有关转换脚本和转换阶段的更多细节，请参见所安装的 High Availability Extension 中的 <filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>。
    </para>
-  </sect3>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp1">
   <title>从 SLE HA 11 升级到 SLE HA 11 SP1</title>
 
    <note>
@@ -325,7 +329,7 @@ $ crm_verify -V -x cib-out.xml</screen>
 
 
 
-  <procedure id="pro-ha-migration-rolling-upgrade">
+  <procedure xml:id="pro-ha-migration-rolling-upgrade">
    <title>执行滚动升级</title>
 
     <warning>
@@ -335,36 +339,36 @@ $ crm_verify -V -x cib-out.xml</screen>
       如果在软件更新期间，群集资源管理器所在节点处于活动状态，可能会导致不可预料的结果，例如活动的节点被屏蔽。
      </para>
     </warning>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份登录要更新的节点，然后停止 OpenAIS：
     </para>
 <screen>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      检查系统备份是否为最新并且可恢复。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-tolatest" performance="required">
+   <step xml:id="step-ha-migration-upgrade-tolatest">
     <para>
      从 SUSE Linux Enterprise Server 11 升级到 SUSE Linux Enterprise Server 11 SP1，然后从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 升级到 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP1。有关如何升级产品的信息，请参见《SUSE Linux Enterprise Server 11 SP1 部署指南》中的<citetitle>“更新 SUSE Linux Enterprise”</citetitle>一章。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-ais" performance="required">
+   <step xml:id="step-ha-migration-upgrade-ais">
     <para>
      在升级后的节点上重启动 OpenAIS/Corosync，使此节点重新加入群集：
     </para>
 <screen>rcopenais start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使下一个节点处于脱机状态，并对此节点重复上述过程。
     </para>
    </step>
   </procedure>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp2">
   <title>从 SLE HA 11 SP1 升级到 SLE HA 11 SP2</title>
 
   <para>
@@ -398,8 +402,8 @@ $ crm_verify -V -x cib-out.xml</screen>
     只有在<emphasis>所有</emphasis>群集节点升级到最新产品版本后，才可使用 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP2 所具有的新功能。对于 SP1/SP2 并存的群集，其在滚动升级期间受支持的时间非常短暂。请在一周内完成滚动升级。
    </para>
   </important>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp3">
   <title>从 SLE HA 11 SP2 升级到 SLE HA 11 SP3</title>
 
   <para>
@@ -416,9 +420,9 @@ $ crm_verify -V -x cib-out.xml</screen>
     只有在<emphasis>所有</emphasis>群集节点升级到最新产品版本后，才可使用 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 所具有的新功能。对于 SP2/SP3 并存的群集，其在滚动升级期间受支持的时间非常短暂。请在一周内完成滚动升级。
    </para>
   </important>
- </sect2>
+ </section>
   
-  <sect2 id="sec-ha-migration-sle11-sp4">
+  <section xml:id="sec-ha-migration-sle11-sp4">
    <title>从 SLE HA 11 SP3 升级到 SLE HA 11 SP4</title>
    
    <para>
@@ -429,7 +433,7 @@ $ crm_verify -V -x cib-out.xml</screen>
     使用以下偏差执行<xref linkend="pro-ha-migration-rolling-upgrade"/>中所述的步骤：在<xref linkend="step-ha-migration-upgrade-tolatest" xrefstyle="select:name"/>中，从 SUSE Linux Enterprise Server 11 SP3 升级到 SUSE Linux Enterprise Server 11 SP4，然后从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级到 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4。
    </para>
    
-   <note id="note-ha-cib-upgrade">
+   <note xml:id="note-ha-cib-upgrade">
     <title>升级 CIB 语法版本</title>
     <para>标记（用于对资源分组）和某些 ACL 功能仅适用于 <literal>pacemaker-2.0</literal> 或更高的 CIB 语法版本。（要检查版本，请运行 <command>cibadmin -Q |grep validate-with</command>）。如果您已从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级，则 CIB 版本默认<emphasis>不会</emphasis>升级。要手动升级到最新的 CIB 版本，请使用以下命令之一：</para>
     <screen><prompt role="root">root # </prompt>cibadmin --upgrade --force</screen>
@@ -443,10 +447,10 @@ $ crm_verify -V -x cib-out.xml</screen>
      只有在<emphasis>所有</emphasis>群集节点升级到最新产品版本后，才可使用 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 所具有的新功能。对于 SP3/SP4 并存的群集，其在滚动升级期间受支持的时间非常短暂。请在一周内完成滚动升级。
     </para>
    </important>
-  </sect2>
+  </section>
   
- </sect1>
- <sect1 id="sec-ha-update">
+ </section>
+ <section xml:id="sec-ha-update">
   <title>更新群集节点上的软件包</title>
   
   <warning>
@@ -461,7 +465,7 @@ $ crm_verify -V -x cib-out.xml</screen>
    在节点上安装任何包更新之前，请先确认以下问题：
   </para>
   
-  <itemizedlist id="il-ha-update-cond" mark="bullet" spacing="normal">
+  <itemizedlist xml:id="il-ha-update-cond" mark="bullet" spacing="normal">
    <title>停止群集堆栈的条件</title>
    <listitem>
     <para>
@@ -499,13 +503,13 @@ $ crm_verify -V -x cib-out.xml</screen>
   </para>
   
   <screen><prompt role="root">root # </prompt>rcopenais start</screen>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-more">
+ <section xml:id="sec-ha-migration-more">
   <title>更多信息</title>
 
   <para>
-   关您要升级到的产品的任何更改和新功能的详细信息，请参见其发行说明，所在网址为 <ulink url="https://www.suse.com/releasenotes/"/>。
+   关您要升级到的产品的任何更改和新功能的详细信息，请参见其发行说明，所在网址为 <link xlink:href="https://www.suse.com/releasenotes/"/>。
   </para>
- </sect1>
+ </section>
 </appendix>

--- a/zh_CN/xml/ha_naming.xml
+++ b/zh_CN/xml/ha_naming.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_naming.xml" id="app-naming">
-  <title>命名约定</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_naming.xml" xml:id="app-naming"><title>命名约定</title><info/>
+  
   <para>本指南针对群集节点和名称、群集资源与约束使用以下命名约定。
   </para>
   
-  <variablelist id="vl-naming-cluster-names-nodes">
+  <variablelist xml:id="vl-naming-cluster-names-nodes">
     
     <varlistentry>
       <term>群集节点</term>

--- a/zh_CN/xml/ha_netbonding.xml
+++ b/zh_CN/xml/ha_netbonding.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_netbonding.xml" id="cha-ha-netbonding">
- <title>网络设备绑定</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_netbonding.xml" xml:id="cha-ha-netbonding"><title>网络设备绑定</title><info/>
+ 
  <para>
   对于许多系统，需要实施高于典型以太网设备的标准数据安全性或可用性要求的网络连接。在这些情况下，可以将多个以太网设备聚合到单个绑定设备。
  </para>
@@ -17,7 +21,7 @@ Please see LICENSE.txt for this document's license.
   使用 OpenAIS 时，联接设备并不是通过群集软件管理的。因此，必须在每个可能需要访问联接设备的群集节点上配置联接设备。
  </para>
 
- <sect1 id="sec-ha-netbond-yast">
+ <section xml:id="sec-ha-netbond-yast">
   <title>使用 YaST 配置联接设备</title>
 
   <para>
@@ -25,27 +29,27 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份启动 YaST 并选择<menuchoice> <guimenu>网络设备</guimenu> <guimenu>网络设置</guimenu></menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>网络设置</guimenu>中，切换到<guimenu>概述</guimenu>选项卡以显示可用的设备。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      检查要聚合到联接设备的以太网设备是否有指定的 IP 地址。如果有，更改此地址：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        选择要更改的设备，然后单击<guimenu>编辑</guimenu>。
       </para>
      </step>
-     <step id="step-bond-slave" performance="required">
+     <step xml:id="step-bond-slave">
       <para>
        在打开的<guimenu>网卡设置</guimenu>对话框的<guimenu>地址</guimenu>选项卡中，选择<guimenu>无链接和 IP 设置（绑定从属）</guimenu>选项。
       </para>
@@ -60,24 +64,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        单击<guimenu>下一步</guimenu>，返回到<guimenu>网络设置</guimenu>对话框中的<guimenu>概述</guimenu>选项卡。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      添加新联接设备：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        单击<guimenu>添加</guimenu>并将<guimenu>设备类型</guimenu>更改为<guimenu>绑定</guimenu>。按<guimenu>下一步</guimenu>继续。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        选择如何为联接设备指派 IP 地址。有三种方法可供选择：
       </para>
@@ -102,12 +106,12 @@ Please see LICENSE.txt for this document's license.
        使用最适合您环境的方法。如果使用 OpenAIS 管理虚拟 IP 地址，请选择<guimenu>静态指派的 IP 地址</guimenu>，并为接口指派一个 IP 地址。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切换到<guimenu>绑定从属</guimenu>选项卡。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        它会显示在<xref linkend="step-bond-slave" xrefstyle="select:label       nopage"/> 中已配置为绑定从属的所有以太网设备。要选择需要加入绑定的以太网设备，请激活相关<guimenu>绑定从属</guimenu>前面的复选框。
       </para>
@@ -122,7 +126,7 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        编辑<guimenu>联接驱动程序选项</guimenu>。可以使用以下模式：
       </para>
@@ -192,22 +196,22 @@ Please see LICENSE.txt for this document's license.
        </varlistentry>
       </variablelist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        务必向<guimenu>联接驱动程序选项</guimenu>添加参数 <literal>miimon=100</literal>。如果不指定此参数，则不会定期检查链路，因此，绑定驱动程序可能会持续在有故障的链路上丢包。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>下一步</guimenu>，将 YaST 保留为<guimenu>确定</guimenu>，完成联接设备的配置。YaST 将配置写入 <filename>/etc/sysconfig/network/ifcfg-bond<replaceable>DEVICENUMBER</replaceable></filename>。
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-netbond-hotpug-yast">
+ <section xml:id="sec-ha-netbond-hotpug-yast">
   <title>联接从属的热插拔</title>
 
   <para>
@@ -220,12 +224,12 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果您想改用手动配置，请在《SUSE Linux Enterprise Server 11 管理指南》中参考“<citetitle>基础网络</citetitle>”一章内的“<citetitle>绑定从属的热插拔</citetitle>”部分。
    </para>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份启动 YaST 并选择<menuchoice> <guimenu>网络设备</guimenu> <guimenu>网络设置</guimenu></menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>网络设置</guimenu>中，切换到<guimenu>概述</guimenu>选项卡以显示已配置的设备。如果已配置绑定从属，则会显示在<guimenu>备注</guimenu>栏中。
     </para>
@@ -240,39 +244,39 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      对于已经聚合到联接设备的每个以太网设备，请执行以下步骤：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        选择要更改的设备，然后单击<guimenu>编辑</guimenu>。<guimenu>网卡设置</guimenu>对话框随即打开。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切换到<guimenu>常规</guimenu>选项卡，确保将<guimenu>激活设备</guimenu>设置为<literal>在热插拔时</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切换到<guimenu>硬件</guimenu>选项卡。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        针对 <guimenu>Udev 规则</guimenu>，单击<guimenu>更改</guimenu>并选择 <guimenu>BusID</guimenu> 选项。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        单击<guimenu>确定</guimenu>和<guimenu>下一步</guimenu>，返回到<guimenu>网络设置</guimenu>对话框中的<guimenu>概述</guimenu>选项卡。如果您现在单击以太网设备项，底部窗格会显示设备的详细信息，包括总线 ID。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      单击<guimenu>确定</guimenu>确认您的更改，并退出网络设置。
     </para>
@@ -282,8 +286,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    在引导时，<filename>/etc/init.d/network</filename> 不会等待热插拔从属接口，而是等待绑定准备就绪，而这需要至少有一个从属接口可用。当从系统中去除一个从属接口时（从 NIC 驱动程序拆开绑定、执行 NIC 驱动程序的 <command>rmmod</command> 命令或 PCI 热插拔去除为 true），内核会自动从绑定中将其去除。当向系统添加新网卡时（替换插槽中的硬件），<systemitem>udev</systemitem> 会应用基于总线的永久名称规则对新网卡进行重命名，并为其调用 <command>ifup</command>。<command>ifup</command> 命令会自动调用以将新网卡加入联接。
   </para>
- </sect1>
- <sect1 id="sec-ha-netbonding-more">
+ </section>
+ <section xml:id="sec-ha-netbonding-more">
   <title>更多信息</title>
 
   <para>
@@ -292,5 +296,5 @@ Please see LICENSE.txt for this document's license.
   <para>对于高可用性设置，本指南中所述的以下选项特别重要：<option>miimon</option> 和 <option>use_carrier</option>。</para>
 
 
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_news.xml
+++ b/zh_CN/xml/ha_news.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_news.xml" id="cha-ha-changes">
- <title>新增功能</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_news.xml" xml:id="cha-ha-changes"><title>新增功能</title><info/>
+ 
  <para>
   以下部分概述了版本之间的最重要软件修改。此摘要指出了基本设置是否已完全重配置、配置文件是否已移至其他位置或者发生的其他重要更改等信息。
  </para>
  <para>
-  有关更多细节和最新信息，请参考各自产品版本的发行说明。可以从已安装系统中获取：<filename>/usr/share/doc/release-notes</filename>，或在线获取：<ulink url="https://www.suse.com/releasenotes/"/>。
+  有关更多细节和最新信息，请参考各自产品版本的发行说明。可以从已安装系统中获取：<filename>/usr/share/doc/release-notes</filename>，或在线获取：<link xlink:href="https://www.suse.com/releasenotes/"/>。
  </para>
- <sect1 id="sec-ha-changes-sle11">
+ <section xml:id="sec-ha-changes-sle11">
   <title>版本 10 SP3 到版本 11</title>
 
   <para>
@@ -24,10 +28,10 @@ Please see LICENSE.txt for this document's license.
    有关从 SUSE® Linux Enterprise Server 10 SP3 到 SUSE Linux Enterprise Server 11 中 High Availability 组件的更改的更多详细信息，请参见以下部分。
   </para>
 
-  <sect2 id="sec-ha-changes-sle11-new">
+  <section xml:id="sec-ha-changes-sle11-new">
    <title>新增功能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-fail">
+    <varlistentry xml:id="vle-ha-news-fail">
      <term>迁移阈值和故障超时</term>
      <listitem>
       <para>
@@ -35,7 +39,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-news-defaults">
+    <varlistentry xml:id="vle-ha-news-defaults">
      <term>资源和操作默认值</term>
      <listitem>
       <para>
@@ -92,12 +96,12 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-changed">
+  <section xml:id="sec-ha-changes-sle11-changed">
    <title>变更功能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-options">
+    <varlistentry xml:id="vle-ha-news-options">
      <term>资源和群集选项的命名约定</term>
      <listitem>
       <para>
@@ -203,9 +207,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-removed">
+  <section xml:id="sec-ha-changes-sle11-removed">
    <title>删除功能</title>
    <variablelist>
     <varlistentry>
@@ -225,9 +229,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp1">
   <title>版本 11 到版本 11 SP1</title>
 
   <variablelist>
@@ -337,8 +341,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp2">
   <title>版本 11 SP1 到版本 11 SP2</title>
 
   <variablelist>
@@ -459,8 +463,8 @@ Please see LICENSE.txt for this document's license.
 
 
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp3">
   <title>版本 11 SP2 到版本 11 SP3</title>
 
   <variablelist>
@@ -579,8 +583,8 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
   
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp4">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp4">
   <title>版本 11 SP3 到版本 11 SP4</title>
   <variablelist>
    <varlistentry>
@@ -597,7 +601,7 @@ Please see LICENSE.txt for this document's license.
        <para>去除了包含代理列表的“<citetitle>HA OCF 代理</citetitle>”一章。因此，也去除了“<citetitle>查错和参考</citetitle>”部分，并将<xref linkend="app-ha-troubleshooting" xrefstyle="select:title"/>一章移到了附录中。</para>
       </listitem>
       <listitem>
-       <para>已将 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的文档转移到一份独立的文档 (Fate#316120)。有关如何使用和设置地理位置分散的群集的细节，请参见《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。可以从 <ulink url="http://www.suse.com/documentation/"/> 或者所安装系统的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到该文档。</para>
+       <para>已将 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的文档转移到一份独立的文档 (Fate#316120)。有关如何使用和设置地理位置分散的群集的细节，请参见《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。可以从 <link xlink:href="http://www.suse.com/documentation/"/> 或者所安装系统的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到该文档。</para>
       </listitem>
       <listitem>
        <para>更改了<literal>主-从</literal>资源的术语，在上游文档中，此类资源现在称为<literal>多状态</literal>资源。</para>
@@ -688,7 +692,7 @@ Please see LICENSE.txt for this document's license.
        <para>更新了该章，以反映<xref linkend="cha-ha-config-basics"/>中所述的新功能。</para>
       </listitem>
       <listitem>
-       <para>与地域群集相关的所有 Hawk 功能的介绍已移至单独的文档。请参见 <ulink url="http://www.suse.com/documentation/"/> 上的新文档《<citetitle>Geo Clustering for SUSE Linux Enterprise High Availability Extension Quick Start</citetitle>》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。</para>
+       <para>与地域群集相关的所有 Hawk 功能的介绍已移至单独的文档。请参见 <link xlink:href="http://www.suse.com/documentation/"/> 上的新文档《<citetitle>Geo Clustering for SUSE Linux Enterprise High Availability Extension Quick Start</citetitle>》（Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入门）。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -737,7 +741,7 @@ Please see LICENSE.txt for this document's license.
       </listitem>
       <listitem>
        <para>根据升级 CIB 验证版本后提供的新 ACL 功能更新了章节。有关细节，请参见<xref linkend="note-ha-cib-upgrade"/>。</para>
-       <para>如果您已从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级并保留了以前的 CIB 版本，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的“<citetitle>访问控制列表</citetitle>”一章。网址：<ulink url="http://www.suse.com/documentation/"/>。</para>
+       <para>如果您已从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升级并保留了以前的 CIB 版本，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的“<citetitle>访问控制列表</citetitle>”一章。网址：<link xlink:href="http://www.suse.com/documentation/"/>。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -748,16 +752,16 @@ Please see LICENSE.txt for this document's license.
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：添加了有关检查包以及访问检查包计时器的其他软件的说明 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：添加了有关检查包以及访问检查包计时器的其他软件的说明 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：添加了有关如何在引导时装载检查包驱动程序的信息 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：添加了有关如何在引导时装载检查包驱动程序的信息 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-fencing"/>：添加了与 <literal>msgwait</literal> 超时相关的 <literal>stonith-timeout</literal> 长度建议 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)。 </para>
+       <para><xref linkend="pro-ha-storage-protect-fencing"/>：添加了与 <literal>msgwait</literal> 超时相关的 <literal>stonith-timeout</literal> 长度建议 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)。 </para>
       </listitem>
       <listitem>
-       <para>调整了<xref linkend="pro-ha-storage-protect-sbd-daemon"/> (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
+       <para>调整了<xref linkend="pro-ha-storage-protect-sbd-daemon"/> (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
       </listitem>
       <listitem>
        <para>介绍如何通过使用 <literal>pcmk_delay_max</literal> 参数进行 STONITH 资源配置，来避免采用 <literal>no-quorum-policy=ignore</literal> 设置的群集发生双重屏蔽 (Fate#31713)。</para>
@@ -770,7 +774,7 @@ Please see LICENSE.txt for this document's license.
     <term><xref linkend="cha-ha-rear"/></term>
     <listitem>
      <para>本章内容进行了彻底修订，已更新为 Rear 版本 <literal>1.16</literal>。</para>
-     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 附带了两个 Rear 版本：版本 <literal>1.10.0</literal>（包含在 RPM 包 <systemitem class="resource">rear</systemitem> 中）和版本 <literal>1.16</literal>（包含在 RPM 包 <systemitem class="resource">rear116</systemitem> 中）。有关 Rear 版本 <literal>1.10.0</literal> 的文档，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。网址：<ulink url="http://www.suse.com/documentation/"/>。</para>
+     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 附带了两个 Rear 版本：版本 <literal>1.10.0</literal>（包含在 RPM 包 <systemitem class="resource">rear</systemitem> 中）和版本 <literal>1.16</literal>（包含在 RPM 包 <systemitem class="resource">rear116</systemitem> 中）。有关 Rear 版本 <literal>1.10.0</literal> 的文档，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。网址：<link xlink:href="http://www.suse.com/documentation/"/>。</para>
     </listitem>
    </varlistentry>
    
@@ -831,5 +835,5 @@ Please see LICENSE.txt for this document's license.
    
    
 
- </sect1>
+ </section>
 </appendix>

--- a/zh_CN/xml/ha_nfs_quick_config_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_config_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_config_i.xml" id="sec-ha-quick-nfs-initial">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_config_i.xml" xml:id="sec-ha-quick-nfs-initial">
  <title>Initial Configuration</title>
 
  <para>
@@ -18,7 +19,7 @@ Please see LICENSE.txt for this document's license.
   3 or 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-initial-drbd-resource">
+ <section xml:id="sec-ha-quick-nfs-initial-drbd-resource">
   <title>Configuring a DRBD Resource</title>
   <para>
    First, it is necessary to configure a DRBD resource to hold your data.
@@ -56,9 +57,9 @@ Please see LICENSE.txt for this document's license.
    Csync2, refer to <xref linkend="sec-ha-installation-setup-csync2"/>.
   </para>
   
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-initial-lvm-config">
+ <section xml:id="sec-ha-quick-nfs-initial-lvm-config">
   <title>Configuring LVM</title>
   <para>
    To use LVM with DRBD, it is necessary to change some options in the LVM
@@ -162,9 +163,9 @@ mkfs -t ext3 /dev/nfs/sales
 mkfs -t ext3 /dev/nfs/engineering</screen>
    </listitem>
   </orderedlist>
- </sect2>
+ </section>
 
- <sect2 os="sles" id="sec-ha-quick-nfs-initial-setup">
+ <section os="sles" xml:id="sec-ha-quick-nfs-initial-setup">
   <title>Initial Cluster Setup</title>
   <para>
    Use the YaST cluster module for the initial cluster setup. The process
@@ -192,11 +193,11 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
    Then start the OpenAIS/Corosync service as described in
    <xref linkend="sec-ha-installation-start"/>.
   </para>
- </sect2>
+ </section>
 
  
 
- <sect2 id="sec-ha-quick-nfs-initial-pacemaker">
+ <section xml:id="sec-ha-quick-nfs-initial-pacemaker">
   <title>Creating a Basic Pacemaker Configuration</title>
   <para>
    Configure a STONITH device as described in
@@ -236,5 +237,5 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
 crm(live)configure# property no-quorum-policy="ignore"
 crm(live)configure# rsc_defaults resource-stickiness="200"
 crm(live)configure# commit</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_nfs_quick_failover_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_failover_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_failover_i.xml" id="sec-ha-quick-nfs-failover">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_failover_i.xml" xml:id="sec-ha-quick-nfs-failover">
  <title>Ensuring Smooth Cluster Failover</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   failover.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time">
   <title>NFSv4 Lease Time</title>
   <para>
    For exports used by NFSv4 clients, the NFS server hands out
@@ -43,9 +44,9 @@ Please see LICENSE.txt for this document's license.
    may cause a prolonged period of NFS lock-up that clients experience
    during an NFS service transition on the cluster.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time-change">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time-change">
   <title>Modifying NFSv4 Lease Time</title>
   <para>
    To allow for faster failover, you may decrease the grace period.
@@ -65,5 +66,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>NFSD_V4_GRACE=10</screen>
   <para>Restart the NFS services.</para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_nfs_quick_install_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_install_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_install_i.xml" id="sec-ha-quick-nfs-prereq">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_install_i.xml" xml:id="sec-ha-quick-nfs-prereq">
  <title>Prerequisites and Installation</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   sure that the following prerequisites are fulfilled.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-prereq-pkg">
+ <section xml:id="sec-ha-quick-nfs-prereq-pkg">
   <title>Software Requirements</title>
   <itemizedlist os="sles" mark="bullet" spacing="normal">
    <listitem>
@@ -112,9 +113,9 @@ Please see LICENSE.txt for this document's license.
    </para>
    
   </note>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-prereq-services">
+ <section xml:id="sec-ha-quick-nfs-prereq-services">
   <title>Services at Boot Time</title>
   <para os="sles">
    After you have installed the required packages, take care of a few
@@ -142,5 +143,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_nfs_quick_intro_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_intro_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_intro_i.xml" id="sec-ha-quick-nfs-intro">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_intro_i.xml" xml:id="sec-ha-quick-nfs-intro">
  <title>Introduction</title>
 
  <para>
@@ -18,4 +19,4 @@ Please see LICENSE.txt for this document's license.
   enterprise: NFSv3 and NFSv4. The solution described in this document is
   applicable to NFS clients using either version.
  </para>
-</sect1>
+</section>

--- a/zh_CN/xml/ha_nfs_quick_rsc_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_rsc_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_rsc_i.xml" id="sec-ha-quick-nfs-resources">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_rsc_i.xml" xml:id="sec-ha-quick-nfs-resources">
  <title>Cluster Resources for a A Highly Available NFS Service</title>
 
  <para>
@@ -110,7 +111,7 @@ Please see LICENSE.txt for this document's license.
   </para>
  </example>
 
- <sect2 id="sec-ha-quick-nfs-resources-drbd">
+ <section xml:id="sec-ha-quick-nfs-resources-drbd">
   <title>DRBD Master/Slave Resource</title>
   <para>
    To configure this resource, issue the following commands from the
@@ -136,9 +137,9 @@ crm(live)configure# commit</screen>
    Check this with the <command>crm_mon</command> command, or by looking at
    the contents of <filename>/proc/drbd</filename>.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsserver">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsserver">
   <title>NFS Kernel Server Resource</title>
   <para>
    In the <literal>crm</literal> shell, the resource for the NFS server
@@ -166,9 +167,9 @@ crm(live)configure# commit</screen>
    After you have committed this configuration, Pacemaker should start the
    NFS Kernel server processes on both nodes.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-lvm">
+ <section xml:id="sec-ha-quick-nfs-resources-lvm">
   <title>LVM and File System Resources</title>
   <orderedlist spacing="normal">
    <listitem>
@@ -241,9 +242,9 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsexport">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsexport">
   <title>NFS Export Resources</title>
   <para>
    Once your DRBD, LVM, and file system resources are working properly,
@@ -251,7 +252,7 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
    available NFS export resources, use the <literal>exportfs</literal>
    resource type.
   </para>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
    <title>NFSv4 Virtual File System Root</title>
    <para>
     If clients exclusively use NFSv3 to connect to the server, you do not
@@ -305,8 +306,8 @@ crm(live)configure# commit</screen>
      </para>
     </listitem>
    </orderedlist>
-  </sect3>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
+  </section>
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
    <title>Non-root NFS Exports</title>
    <para>
     All NFS exports that do <emphasis>not</emphasis> represent an NFSv4
@@ -368,10 +369,10 @@ crm(live)configure# primitive p_exportfs_engineering \
      <screen>exportfs -v</screen>
     </listitem>
    </orderedlist>
-  </sect3>
- </sect2>
+  </section>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-ipaddr">
+ <section xml:id="sec-ha-quick-nfs-resources-ipaddr">
   <title>Resource for Floating IP Address</title>
   <para>
    To enable smooth and seamless failover, your NFS clients will be
@@ -435,5 +436,5 @@ crm(live)configure# primitive p_exportfs_engineering \
     will suffer service interruptions on cluster failover.
    </para>
   </note>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_nfs_quick_use_i.xml
+++ b/zh_CN/xml/ha_nfs_quick_use_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_use_i.xml" id="sec-ha-quick-nfs-use">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_use_i.xml" xml:id="sec-ha-quick-nfs-use">
  <title>Using the NFS Service</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   NFS client. It covers NFS clients using NFS versions 3 and 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv3">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv3">
   <title>Connecting with NFS Version 3</title>
   <para>
    To connect to the highly available NFS service with an NFS version 3
@@ -42,9 +43,9 @@ Please see LICENSE.txt for this document's license.
    For further NFSv3 mount options, consult the <command>nfs</command> man
    page.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv4">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv4">
   <title>Connecting with NFS Version 4</title>
   <important>
    <para>
@@ -72,5 +73,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>mount -t nfs4 -o rsize=32768,wsize=32768 \
   10.9.9.180:/engineering /home/engineering</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_CN/xml/ha_ocfs2.xml
+++ b/zh_CN/xml/ha_ocfs2.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_ocfs2.xml" id="cha-ha-ocfs2">
- <title>OCFS2</title><indexterm class="startofrange" id="idx-filesystems-ocfs2"> <primary>文件系统</primary> <secondary>OCFS2</secondary> </indexterm>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_ocfs2.xml" xml:id="cha-ha-ocfs2"><title>OCFS2</title><info><abstract>
   <para>
    Oracle Cluster File System 2 (OCFS2) 是一个自 Linux 2.6 内核以来完全集成的通用日记文件系统。OCFS2 可将应用程序二进制文件、数据文件和数据库储存到共享储存设备。群集中的所有节点对文件系统都有并行的读和写权限。用户空间控制守护程序（由克隆资源管理）提供与 HA 堆栈的集成，尤其是与 OpenAIS/Corosync 和分布式锁管理器 (DLM) 的集成。
   </para>
- </abstract>
- <sect1 id="sec-ha-ocfs2-features">
+ </abstract></info>
+ <indexterm class="startofrange" xml:id="idx-filesystems-ocfs2"> <primary>文件系统</primary> <secondary>OCFS2</secondary> </indexterm>
+ 
+ <section xml:id="sec-ha-ocfs2-features">
   <title>功能和优点</title>
 
   <para>
@@ -104,8 +108,8 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-ocfs2-utils">
+ </section>
+ <section xml:id="sec-ha-ocfs2-utils">
   <title>OCFS2 包和管理实用程序</title>
 
   <para>
@@ -197,8 +201,8 @@ Please see LICENSE.txt for this document's license.
     </tbody>
    </tgroup>
   </table>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create-service">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create-service">
   <title>配置 OCFS2 服务和 STONITH 资源</title>
 
 
@@ -218,7 +222,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ocfs2-resources">
+  <procedure xml:id="pro-ocfs2-resources">
    <title>配置 DLM 和 O2CB 资源</title>
    <para>
     这种配置由包含多个原始资源的基本组和一个基本克隆构成。基本组和基本克隆随后可以用于各种方案（例如，用于 OCFS2 和 cLVM）。您只需根据需要用相应的原始资源扩展基本组。由于基本组具有内部共置和排序功能，您不必指定许多单个组、克隆及其依赖性，方便了总体设置。
@@ -226,17 +230,17 @@ Please see LICENSE.txt for this document's license.
    <para>
     对群集中的一个节点执行以下步骤：
    </para>
-   <step performance="required">
+   <step>
     <para>
      启动壳层，并以 <systemitem class="username">root</systemitem> 用户身份或同等身份登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     运行 <command>crm <option>configure</option></command>。
+     运行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入以下命令创建 DLM 和 O2CB 的原始资源：
     </para>
@@ -250,7 +254,7 @@ Please see LICENSE.txt for this document's license.
      <literal>dlm</literal> 克隆资源会控制分布式锁管理器服务，并确保此服务在群集中的所有节点上都启动。由于基本组具有内部共置和排序功能，<literal>o2cb</literal> 服务仅在已有一个 <literal>dlm</literal> 服务副本在运行的节点上启动。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入以下命令以创建基本组和基本克隆：
 
@@ -259,19 +263,19 @@ Please see LICENSE.txt for this document's license.
 <command>clone</command> base-clone base-group \
       meta interleave="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 复查更改。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果全部都正确，请使用 <command>commit</command> 提交更改，并使用 <command>exit</command> 退出 crm 当前配置。
     </para>
    </step>
   </procedure>
 
-  <procedure id="pro-ocfs2-stonith">
+  <procedure xml:id="pro-ocfs2-stonith">
    <title>配置 STONITH 资源</title>
    <note>
     <title>所需的 STONITH 设备</title>
@@ -279,22 +283,22 @@ Please see LICENSE.txt for this document's license.
      您需要配置屏蔽设备。没有一个适当的 STONITH 机制（如 <literal>external/sbd</literal>），则配置会失败。
     </para>
    </note>
-   <step performance="required">
+   <step>
     <para>
      启动壳层，并以 <systemitem class="username">root</systemitem> 用户身份或同等身份登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如<xref linkend="pro-ha-storage-protect-sbd-create"/>中所述，创建 SBD 分区。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     运行 <command>crm <option>configure</option></command>。
+     运行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在将 <literal>/dev/sdb2</literal> 作为共享储存区上用于检测信号和屏蔽的专用分区的同时，将 <literal>external/sdb</literal> 配置为屏蔽设备：
     </para>
@@ -302,19 +306,19 @@ Please see LICENSE.txt for this document's license.
       params pcmk_delay_max="15" \
       op monitor interval="15" timeout="15"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 复查更改。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果全部内容都正确，请使用 <command>commit</command> 提交更改，并使用 <command>exit</command> 退出 crm 当前配置。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create">
   <title>创建 OCFS2 卷</title>
 
   <para>
@@ -336,7 +340,7 @@ Please see LICENSE.txt for this document's license.
    然后，按<xref linkend="pro-ocfs2-volume"/>中所述使用 <command>mkfs.ocfs2</command> 创建和格式化 OCFS2 卷。此命令最重要的参数列于<xref linkend="tab-ha-ofcs2-mkfs-ocfs2-params"/>中。有关此命令的更多信息和命令语法，请参见 <command>mkfs.ocfs2</command> 手册页。
   </para>
 
-  <table id="tab-ha-ofcs2-mkfs-ocfs2-params">
+  <table xml:id="tab-ha-ofcs2-mkfs-ocfs2-params">
    <title>重要的 OCFS2 参数</title>
    <tgroup cols="2">
     <thead>
@@ -449,22 +453,22 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <procedure id="pro-ocfs2-volume">
+  <procedure xml:id="pro-ocfs2-volume">
    <title>创建并格式化 OCFS2 卷</title>
    <para>
     只在群集节点之<emphasis>一</emphasis>上执行以下步骤。
    </para>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份打开终端窗口并登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用命令 <command>crm status</command> 检查群集是否联机。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>mkfs.ocfs2</command> 实用程序创建并格式化卷。有关此命令语法的信息，请参见 <command>mkfs.ocfs2</command> 手册页。
     </para>
@@ -475,27 +479,27 @@ Please see LICENSE.txt for this document's license.
 
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-mount">
+ </section>
+ <section xml:id="sec-ha-ocfs2-mount">
   <title>装入 OCFS2 卷</title>
 
   <para>
    可以手动装入 OCFS2 卷，也可以按<xref linkend="pro-ocfs2-mount-cluster"/>中所述使用群集管理器将其装入。
   </para>
 
-  <procedure id="pro-ocfs2-mount-manual">
+  <procedure xml:id="pro-ocfs2-mount-manual">
    <title>手动装入 OCFS2 卷</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 用户身份打开终端窗口并登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用命令 <command>crm status</command> 检查群集是否联机。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>mount</command> 命令从命令行装入卷。
     </para>
@@ -509,22 +513,22 @@ Please see LICENSE.txt for this document's license.
    </para>
   </warning>
 
-  <procedure id="pro-ocfs2-mount-cluster">
+  <procedure xml:id="pro-ocfs2-mount-cluster">
    <title>使用群集管理器装入 OCFS2 卷</title>
    <para>
     要为 High Availability 软件安装 OCFS2 卷，请在群集中配置 ocf 文件系统资源。以下过程使用 <command>crm</command> 外壳配置群集资源。或者，您还可以使用 Pacemaker GUI 配置该资源。
    </para>
-   <step performance="required">
+   <step>
     <para>
      启动壳层，并以 <systemitem class="username">root</systemitem> 用户身份或同等身份登录。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     运行 <command>crm <option>configure</option></command>。
+     运行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      配置 Pacemaker 以在群集中的每个节点上装入 OCFS2 文件系统：
     </para>
@@ -532,19 +536,19 @@ Please see LICENSE.txt for this document's license.
       params device="/dev/sdb1" directory="/mnt/shared" fstype="ocfs2" options="acl" \
       op monitor interval="20" timeout="40"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      将文件系统原始资源添加到您在<xref linkend="pro-ocfs2-resources"/>中配置的基本组：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        输入
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt>edit base-group</screen>
      </step>
 
-     <step performance="required">
+     <step>
       <para>
        在打开的 vi 编辑器中，如下所示修改组并保存更改：
       </para>
@@ -556,19 +560,19 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 复查更改。要检查是否配置了所有需要的资源，另请参考<xref linkend="cha-ha-config-example"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果全部都正确，则使用 <command>commit</command> 提交更改，并使用 <command>exit</command> 退出 crm 当前配置。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-quota">
+ </section>
+ <section xml:id="sec-ha-ocfs2-quota">
   <title>在 OCFS2 文件系统上使用定额</title>
 
 
@@ -592,8 +596,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    由于性能原因，每个群集节点都会在本地执行定额会计，并每 10 秒将此信息与通用中央储存同步一次。此间隔可使用 <command>tunefs.ocfs2</command> 及 <option>usrquota-sync-interval</option> 和 <option>grpquota-sync-interval</option> 选项调整。因此，定额信息可能不会始终都准确，因而在几个群集节点上并行操作时，用户或组可以稍微超出其定额限制。
   </para>
- </sect1>
- <sect1 id="sec-ha-ocfs2-more">
+ </section>
+ <section xml:id="sec-ha-ocfs2-more">
   <title>更多信息</title>
 
   <para>
@@ -602,7 +606,7 @@ Please see LICENSE.txt for this document's license.
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </term>
     <listitem>
      <para>
@@ -611,7 +615,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/documentation"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/documentation"/>
     </term>
     <listitem>
      <para>
@@ -620,5 +624,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist><indexterm class="endofrange" startref="idx-filesystems-ocfs2"/>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_rear.xml
+++ b/zh_CN/xml/ha_rear.xml
@@ -1,26 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_rear.xml" id="cha-ha-rear">
- <title>使用 Rear 实现灾难恢复</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_rear.xml" xml:id="cha-ha-rear"><title>使用 Rear 实现灾难恢复</title><info><abstract>
   <para> Relax-and-Recover（以前称为 <quote>ReaR</quote>，本章中缩写为 Rear）是由系统管理员使用的灾难恢复框架。它是一个 Bash 脚本集合，您需要根据要在发生灾难时加以保护的特定生产环境调整这些脚本。</para>
   <para>不存在能够现成地解决问题的灾难恢复解决方案。因此，在发生任何灾难<emphasis>之前</emphasis>做好预防措施至关重要。 </para>
   
- </abstract>
+ </abstract></info>
  
-  <sect1 id="sec-ha-rear-concept">
+ 
+ 
+  <section xml:id="sec-ha-rear-concept">
   <title>概念概述</title>
   
  
   <para>以下几节介绍了一般性的灾难恢复概念，以及使用 Rear 成功实现恢复所需执行的基本步骤。另外，还提供了一些有关 Rear 要求、当前产品附带的 Rear 版本、要注意的一些限制、各种方案和备份工具的指导。</para>
    
    
-   <sect2 id="sec-ha-rear-concept-drp">
+   <section xml:id="sec-ha-rear-concept-drp">
     <title>创建灾难恢复计划</title>
     
     <para>
@@ -59,21 +63,21 @@ Please see LICENSE.txt for this document's license.
       </formalpara>
      </listitem>
     </itemizedlist>
-   </sect2>
+   </section>
   
-  <sect2 id="sec-ha-rear-concept-recovery">
+  <section xml:id="sec-ha-rear-concept-recovery">
    <title>灾难恢复意味着什么？</title>
    <para>如果生产环境中的某个系统已毁坏（可能出于任何原因 - 例如，硬件损坏、配置不当或软件问题），您需要重创建该系统。可以在相同的硬件或者兼容的替代硬件上重创建。重创建系统并不只是意味着从备份中恢复文件，还包括准备系统的储存（与文件系统、分区或安装点相关），以及重新安装引导加载程序。</para>
-  </sect2>
+  </section>
    
-  <sect2 id="sec-ha-rear-concept-basics">
+  <section xml:id="sec-ha-rear-concept-basics">
    <title>灾难恢复如何与 Rear 配合工作？</title>
    <para>在系统正常运行期间，创建文件的备份并在恢复媒体上创建恢复系统。该恢复系统包含一个恢复安装程序。</para>
    <para>如果系统已损坏，您可以更换受损的硬件（如果需要），从恢复媒体引导恢复系统，然后起动恢复安装程序。恢复安装程序会重创建系统：首先，它会准备储存（分区、文件系统、安装点），然后从备份中恢复文件。最后，它会重新安装引导加载程序。 </para>
-  </sect2>
+  </section>
    
    
-  <sect2 id="sec-ha-rear-concept-requirements">
+  <section xml:id="sec-ha-rear-concept-requirements">
    <title>Rear 要求</title>
    <para>
     要使用 Rear，至少需要两个相同的系统：运行生产环境的计算机，以及相同的测试计算机。举例来说，这里所说的<quote>相同</quote>是指您可以将一块网卡替换为使用相同内核驱动程序的另一块网卡。 </para>
@@ -81,14 +85,14 @@ Please see LICENSE.txt for this document's license.
     <title>需要相同的驱动程序</title>
     <para>如果某个硬件组件使用的驱动程序不同于生产环境中所用的驱动程序，则 Rear 不会将该组件视为相同。</para>
    </warning>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-versions">
+  <section xml:id="sec-ha-rear-concept-versions">
    <title>Rear 版本</title>
    <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 附带了两个 Rear 版本：</para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
-     <para>Rear 版本 <literal>1.10.0</literal>（包含在 RPM 包 <systemitem class="resource">rear</systemitem> 中）。有关此 Rear 版本的文档，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。网址：<ulink url="http://www.suse.com/documentation/"/>。</para>
+     <para>Rear 版本 <literal>1.10.0</literal>（包含在 RPM 包 <systemitem class="resource">rear</systemitem> 中）。有关此 Rear 版本的文档，请参见《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。网址：<link xlink:href="http://www.suse.com/documentation/"/>。</para>
     </listitem>
     <listitem>
      <para>Rear 版本 <literal>1.16</literal>（包含在 RPM 包 <systemitem class="resource">rear116</systemitem> 中）。本章将会介绍此版本。 </para>
@@ -99,9 +103,9 @@ Please see LICENSE.txt for this document's license.
     <para>但是，如果 Rear 版本 1.10.0 不能满足您的特定需求（另请参见<xref linkend="sec-ha-rear-concept-limit" xrefstyle="select:label"/>），您可以手动升级到 Rear 版本 1.16。<systemitem class="resource">rear</systemitem> 和 <systemitem class="resource">rear116</systemitem> 包有意被设置为相互冲突，以防安装的版本意外被另一个版本替换。</para>
     <para>每次升级 Rear 版本时，都必须仔细重新验证您的特定灾难恢复过程是否仍可发挥作用。</para>
    </important>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-limit">
+  <section xml:id="sec-ha-rear-concept-limit">
    <title>针对 Btrfs 的限制</title>
     <para>如果您使用 Btrfs，请注意以下限制。</para>
    
@@ -124,17 +128,17 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-scenarios">
+  <section xml:id="sec-ha-rear-concept-scenarios">
    <title>方案和备份工具</title>
    <para>Rear 能够创建可从本地媒体（例如硬盘、闪存盘、DVD/CD-R）或通过 PXE 引导的灾难恢复系统（包括一个特定的恢复安装程序）。可以根据<xref linkend="ex-ha-rear-nfs-server-backup" xrefstyle="select:label"/>所述，将备份数据储存在网络文件系统中，如 NFS。
     </para>
    <para>Rear 不会替换文件备份，而是对它进行补充。默认情况下，Rear 支持常规 <command>tar</command> 命令和若干第三方备份工具（例如 Tivoli Storage Manager、QNetix Galaxy、Symantec NetBackup、EMC NetWorker 或 HP DataProtector）。有关将 Rear 与用作备份工具的 EMC NetWorker 配合使用的示例配置，请参见<xref linkend="ex-ha-rear-config-EMC" xrefstyle="select:label"/>。</para>
-  </sect2>
+  </section>
   
   
-  <sect2 id="sec-ha-rear-concept-overview">
+  <section xml:id="sec-ha-rear-concept-overview">
    <title>基本步骤</title>
    <para>要在发生灾难时使用 Rear 成功进行恢复，需要执行以下基本步骤： </para>
 
@@ -166,10 +170,10 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
+  </section>
+ </section>
   
- <sect1 id="sec-ha-rear-config">
+ <section xml:id="sec-ha-rear-config">
   <title>设置 Rear 和您的备份解决方案</title>
   <para>要设置 Rear，您至少需要编辑 Rear 配置文件 <filename>/etc/rear/local.conf</filename>，此外可以根据需要编辑属于 Rear 框架一部分的 Bash 脚本。 </para>
   <para>具体而言，您需要定义 Rear 应该执行的以下任务：</para>
@@ -200,27 +204,27 @@ Please see LICENSE.txt for this document's license.
   <para>更改 Rear 配置文件后，运行以下命令并检查该命令的输出：</para>
    <screen>rear dump</screen>
   
-  <example id="ex-ha-rear-nfs-server-backup">
+  <example xml:id="ex-ha-rear-nfs-server-backup">
    <title>使用 NFS 服务器储存文件备份</title>
    <para>Rear 可在多种情境下使用。以下示例使用 NFS 服务器作为文件备份的储存。
    </para>
   </example>
   
   <procedure>
-     <step performance="required">
-    <para>按照《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 管理指南》中的“<citetitle>通过 NFS 共享文件系统</citetitle>”一章所述，使用 YaST 设置 NFS 服务器。网址：<ulink url="http://www.suse.com/documentation/"/>。 </para>
+     <step>
+    <para>按照《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 管理指南》中的“<citetitle>通过 NFS 共享文件系统</citetitle>”一章所述，使用 YaST 设置 NFS 服务器。网址：<link xlink:href="http://www.suse.com/documentation/"/>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>在 <filename>/etc/exports</filename> 文件中定义 NFS 服务器的配置。确保 NFS 服务器上的目录（要储存备份数据的位置）具有适当的装入选项。例如：</para>
      <screen><replaceable>/srv/nfs</replaceable> *(fsid=0,crossmnt,rw,no_root_squash,sync,no_subtree_check)</screen>
     <para>如果需要，请将 <filename>/srv/nfs</filename> 替换为 NFS 服务器上备份数据的路径，并调整装入选项。您可能需要使用 <literal>no_root_squash</literal> 来访问备份数据，因为 <command>rear mkbackup</command> 命令是以 <systemitem class="username">root</systemitem> 身份运行的。</para>
    </step>
-   <step performance="required">
+   <step>
     <para> 调整各个 <varname>BACKUP</varname> 参数（在配置文件 <filename>/etc/rear/local.conf</filename> 中），以便 Rear 将文件备份储存在相应的 NFS 服务器上。已安装系统中的 <filename>/usr/share/rear/conf/SLE11-ext3-example.conf</filename> 下提供了示例。 </para>
     </step>
   </procedure>
   
-  <example id="ex-ha-rear-config-EMC">
+  <example xml:id="ex-ha-rear-config-EMC">
    <title>使用 EMC NetWorker 等第三方备份工具</title>
    <para> 要使用第三方备份工具代替 <command>tar</command>，您需要在 Rear 配置文件中进行相应的设置。</para>
    <para>以下是 EMC NetWorker 的示例配置。将此配置片段添加到 <filename>/etc/rear/local.conf</filename> 中，并根据您的设置进行调整：</para>
@@ -232,9 +236,9 @@ Please see LICENSE.txt for this document's license.
     RETENTION_TIME="Month"</screen>
   </example>
   
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-rear-mkbackup">
+ <section xml:id="sec-ha-rear-mkbackup">
  <title>创建恢复安装系统</title>
   <para>根据<xref linkend="sec-ha-rear-config" xrefstyle="select:label"/>所述配置 Rear 后，使用以下命令创建恢复安装系统（包括 Rear 恢复安装程序）和文件备份：</para>
   <screen>rear -d  -D mkbackup</screen> 
@@ -256,9 +260,9 @@ Please see LICENSE.txt for this document's license.
   </listitem>
   
  </orderedlist>
-</sect1>
+</section>
  
- <sect1 id="sec-ha-rear-testing">
+ <section xml:id="sec-ha-rear-testing">
   <title>测试恢复过程</title>
 
   <para> 创建恢复系统之后，在具有相同硬件的测试计算机上测试恢复过程。另请参见<xref linkend="sec-ha-rear-concept-requirements"/>。确保测试计算机已正确设置，并可替代主计算机。
@@ -269,37 +273,37 @@ Please see LICENSE.txt for this document's license.
    <para>必须在计算机上全面测试灾难恢复过程。请定期测试恢复过程，确保一切按预期运行。 </para>
   </warning>
 
-  <procedure id="pro-ha-rear-testing">
+  <procedure xml:id="pro-ha-rear-testing">
    <title>在测试计算机上执行灾难恢复</title>
-   <step performance="required">
+   <step>
     <para>将您在<xref linkend="sec-ha-rear-mkbackup" xrefstyle="select:label"/>中创建的恢复系统刻录到 DVD 或 CD 中，以创建恢复媒体。或者，您可以通过 PXE 使用网络引导。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>从恢复媒体引导测试计算机。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 从菜单中选择<guimenu>恢复</guimenu>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 用户身份登录（无需密码）。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 输入以下命令启动恢复安装程序：</para>
     <screen>rear -d -D recover</screen>
     <para>有关在此过程中 Rear 所执行的步骤的细节，请参见<xref linkend="ol-ha-rear-recovers-steps"/>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>恢复过程完成后，检查是否已成功地重创建系统，并且该系统可在生产环境中替代原始系统运作。</para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-rear-recover">
+ </section>
+ <section xml:id="sec-ha-rear-recover">
   <title>从灾难中恢复</title>
   <para>如果灾难已发生，请根据需要更换任何受损的硬件。然后按照<xref linkend="pro-ha-rear-testing" xrefstyle="select:label"/>所述，使用已修复的计算机（或使用已经过测试可替代原始系统运作的相同计算机）继续操作。</para>
   
 <para><command>rear recover</command> 命令将执行以下步骤：</para>  
   
-  <orderedlist id="ol-ha-rear-recovers-steps" spacing="normal">
+  <orderedlist xml:id="ol-ha-rear-recovers-steps" spacing="normal">
    <title>恢复过程</title>
    <listitem>
    <para>
@@ -317,10 +321,10 @@ Please see LICENSE.txt for this document's license.
    </para>
    </listitem>
    </orderedlist>
-  </sect1>
+  </section>
  
   
- <sect1 id="sec-ha-rear-more">
+ <section xml:id="sec-ha-rear-more">
   <title>更多信息</title>
 
 
@@ -328,7 +332,7 @@ Please see LICENSE.txt for this document's license.
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://en.opensuse.org/SDB:Disaster_Recovery"/>
+     <link xlink:href="http://en.opensuse.org/SDB:Disaster_Recovery"/>
     </para>
    </listitem>
    <listitem>
@@ -342,5 +346,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_requirements.xml
+++ b/zh_CN/xml/ha_requirements.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_requirements.xml" id="cha-ha-requirements">
- <title>系统要求和建议</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_requirements.xml" xml:id="cha-ha-requirements"><?dbfo-need height="10em"?><title>系统要求和建议</title><info><abstract>
   <para>
    下面的小节说明了系统要求以及 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 的一些先决条件。此外，还提供了有关群集设置的建议。
   </para>
- </abstract>
- <sect1 id="sec-ha-requirements-hw">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-requirements-hw">
   <title>硬件要求</title>
 
   <para>
@@ -40,11 +44,11 @@ Please see LICENSE.txt for this document's license.
     
    </listitem>
   </itemizedlist>
- </sect1>
-<?dbfo-need height="10em"?>
+ </section>
 
 
- <sect1 id="sec-ha-requirements-sw">
+
+ <section xml:id="sec-ha-requirements-sw">
   <title>软件要求</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     <para>如果您要使用地域群集，请确保所有将要加入群集的节点上都安装了 Geo Clustering for SUSE Linux Enterprise High Availability Extension <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>（包含所有可用的联机更新）。 </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-disk">
+ </section>
+ <section xml:id="sec-ha-requirements-disk">
   <title>储存要求</title>
 
   <para> 为确保数据的高可用性，我们建议您为群集设置共享磁盘系统（储存区域网络，简称 SAN）。如果使用共享磁盘子系统，请确保符合以下要求： </para>
@@ -97,12 +101,12 @@ Please see LICENSE.txt for this document's license.
    </listitem>
    
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-other">
+ </section>
+ <section xml:id="sec-ha-requirements-other">
   <title>其他要求和建议</title>
   <para>为了实现受支持且有用的高可用性设置，请考虑以下建议：</para>
   <variablelist>
-   <varlistentry id="vle-ha-req-nodes">
+   <varlistentry xml:id="vle-ha-req-nodes">
     <term>群集节点数</term>
     <listitem>
      <para>
@@ -115,7 +119,7 @@ Please see LICENSE.txt for this document's license.
      </important>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-stonith">
+   <varlistentry xml:id="vle-ha-req-stonith">
     <term>STONITH</term>
     <listitem>
      <important>
@@ -133,7 +137,7 @@ Please see LICENSE.txt for this document's license.
      </itemizedlist>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-communication">
+   <varlistentry xml:id="vle-ha-req-communication">
     <term>冗余通讯路径</term>
     <listitem>
      <para>要实现受支持的高可用性设置，您需要通过两个或更多冗余路径建立群集通讯。这可通过以下方式实现： </para>
@@ -152,7 +156,7 @@ Please see LICENSE.txt for this document's license.
    <varlistentry>
     <term>时间同步</term>
     <listitem>
-     <para> 群集节点应同步到群集外的 NTP 服务器。 有关详细信息，请参见 <ulink url="http://www.suse.com/doc/"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。请参见<citetitle>“使用 NTP 同步时间”</citetitle>一章。 </para>
+     <para> 群集节点应同步到群集外的 NTP 服务器。 有关详细信息，请参见 <link xlink:href="http://www.suse.com/doc/"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。请参见<citetitle>“使用 NTP 同步时间”</citetitle>一章。 </para>
      <para> 如果节点未同步，将难以分析日志文件和群集报告。 </para>
     </listitem>
    </varlistentry>
@@ -174,18 +178,18 @@ Please see LICENSE.txt for this document's license.
        <para> 在此文件中以完全限定的主机名和简短主机名列出所有群集节点。群集成员必须能够按名称找到彼此。如果名称不可用，则将无法进行群集内部通讯。 </para>
       </listitem>
      </itemizedlist>
-     <para> 有关详细信息，请参见 <ulink url="http://www.suse.com/doc"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。请参见“<citetitle>基本联网知识</citetitle>”一章中的“<citetitle>使用 YaST 配置网络连接</citetitle>”&gt;“<citetitle>配置主机名和 DNS</citetitle>”小节。 </para>
+     <para> 有关详细信息，请参见 <link xlink:href="http://www.suse.com/doc"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。请参见“<citetitle>基本联网知识</citetitle>”一章中的“<citetitle>使用 YaST 配置网络连接</citetitle>”&gt;“<citetitle>配置主机名和 DNS</citetitle>”小节。 </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-storage">
+   <varlistentry xml:id="vle-ha-req-storage">
     <term>储存要求</term>
     <listitem>
      
      <para>有些服务可能需要使用共享储存。有关要求，请参见<xref linkend="sec-ha-requirements-disk"/>。您也可以使用外部 NFS 共享或 DRBD。如果使用外部 NFS 共享，必须能够从所有群集节点通过冗余通讯路径可靠地访问该共享。请参见<xref linkend="vle-ha-req-communication"/>。 </para>
-     <para>如果使用 SBD 作为 STONITH 设备，则共享储存还需要满足其他要求。有关细节，请参见 <ulink url="http://linux-ha.org/wiki/SBD_Fencing"/> 上的“<citetitle>Requirements</citetitle>”（要求）部分。</para>
+     <para>如果使用 SBD 作为 STONITH 设备，则共享储存还需要满足其他要求。有关细节，请参见 <link xlink:href="http://linux-ha.org/wiki/SBD_Fencing"/> 上的“<citetitle>Requirements</citetitle>”（要求）部分。</para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-ssh">
+   <varlistentry xml:id="vle-ha-req-ssh">
     <term>SSH</term>
     <listitem>
      <para> 所有群集节点都必须能通过 SSH 相互访问。<command>hb_report</command> 或 <command>crm_report</command>（用于查错）和 Hawk 的<guimenu>历史记录浏览器</guimenu>等工具要求节点之间采用无口令 SSH 访问方式，否则它们只能从当前节点收集数据。如果使用非标准 SSH 端口，请使用 <option>-X</option> 选项（参见手册页）。例如，如果 SSH 端口为 <literal>3479</literal>，请使用以下命令调用 <literal>hb_report</literal>：</para>
@@ -207,5 +211,5 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
 
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_samba.xml
+++ b/zh_CN/xml/ha_samba.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_samba.xml" id="cha-ha-samba">
- <title>Samba 群集</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_samba.xml" xml:id="cha-ha-samba"><title>Samba 群集</title><info><abstract>
   <para>
    群集 Samba 服务器提供异构网络的高可用性解决方案。本章说明了一些背景信息以及如何设置群集 Samba 服务器。
   </para>
- </abstract>
- <sect1 id="sec-ha-samba-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-samba-overview">
   <title>概念概述</title>
 
   <para>
@@ -37,7 +41,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <figure id="fig-ha-samba-overview">
+  <figure xml:id="fig-ha-samba-overview">
    <title>CTDB 群集的结构</title>
    <mediaobject>
     <imageobject role="fo">
@@ -79,8 +83,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    目标是：具有 N+1 个节点的群集 Samba 服务器比只有 N 个节点的快。一个节点不会比非群集 Samba 服务器慢。
   </para>
- </sect1>
- <sect1 id="sec-ha-samba-basicconf">
+ </section>
+ <section xml:id="sec-ha-samba-basicconf">
   <title>基本配置</title>
   
   <note>
@@ -94,24 +98,24 @@ Please see LICENSE.txt for this document's license.
    要设置群集 Samba 服务器，请按如下操作：
   </para>
 
-  <procedure id="pro-ha-samba-basicconf">
+  <procedure xml:id="pro-ha-samba-basicconf">
    <title>设置基本的群集 Samba 服务器</title>
-   <step performance="required">
+   <step>
     <para>
      准备群集：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        按照本指南的<xref linkend="part-config"/>中所述配置群集（OpenAIS、Pacemaker、OCFS2）。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        配置共享文件系统（如 OCFS2），并将其装入例如 <filename>/shared</filename> 的位置。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        要打开 POSIX ACL，请启用它：
       </para>
@@ -134,7 +138,7 @@ Please see LICENSE.txt for this document's license.
        </listitem>
       </itemizedlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        确保服务 <systemitem class="service">ctdb</systemitem>、<systemitem class="service">smb</systemitem>、<systemitem class="service">nmb</systemitem> 和 <systemitem class="service">winbind</systemitem> 已禁用：
       </para>
@@ -145,20 +149,20 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在共享文件系统上为 CTDB 锁定创建一个目录：
     </para>
     <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /shared/samba/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <filename>/etc/ctdb/nodes</filename> 中插入包含群集中每个节点的所有私用 IP 地址的所有节点：
     </para>
 <screen>192.168.1.10
 192.168.1.11</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>csync2</command> 将配置文件复制到您的所有节点：
     </para>
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      将 CTDB 资源添加到群集：
     </para>
@@ -188,7 +192,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ctdb-after-fs inf: fs-clone ctdb-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      添加群集 IP 地址：
     </para>
@@ -199,7 +203,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ip-after-ctdb inf: ctdb-clone ip-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      检查结果：
     </para>
@@ -216,19 +220,19 @@ Clone Set: dlm-clone
      ip:0       (ocf::heartbeat:IPaddr2):       Started hex-13
      ip:1       (ocf::heartbeat:IPaddr2):       Started hex-14</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>从客户端计算机进行测试。在 Linux 客户端上，添加一个用于访问 Samba 的用户：
     </para>
     <screen><prompt role="root">root # </prompt><command>smbpasswd</command> <option>-a</option> <replaceable>USERNAME</replaceable></screen>
    </step>
-   <step performance="required"><para>测试您是否可以连接到该新用户的主目录：</para>
+   <step><para>测试您是否可以连接到该新用户的主目录：</para>
     <screen><prompt role="root">root # </prompt>smbclient -u <replaceable>USERNAME</replaceable>//192.168.2.222/<replaceable>USERNAME</replaceable></screen>
    </step>
 
 
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-ad">
+ </section>
+ <section xml:id="sec-ha-samba-ad">
   <title>加入 Active Directory 域</title>
 
   
@@ -242,7 +246,7 @@ Clone Set: dlm-clone
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      有关如何设置 Active Directory 域的说明，请参考 Windows Server 文档。在此示例中，使用以下参数：
     </para>
@@ -284,12 +288,12 @@ Clone Set: dlm-clone
     </informaltable>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-ctdb"/>
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-join-ad"/>
     </para>
@@ -300,20 +304,20 @@ Clone Set: dlm-clone
    下一步是配置 CTDB：
   </para>
 
-  <procedure id="pro-ha-samba-config-ctdb">
+  <procedure xml:id="pro-ha-samba-config-ctdb">
    <title>配置 CTDB</title>
-   <step performance="required">
+   <step>
     <para>
      确保您已按<xref linkend="sec-ha-samba-basicconf"/>中所示配置群集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      停止一个节点上的 CTDB 资源：
     </para>
 <screen><prompt role="root">root # </prompt> crm resource stop ctdb-clone</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      打开 <filename>/etc/samba/smb.conf</filename> 配置文件、添加 NetBIOS 名称，然后关闭该文件：
     </para>
@@ -323,13 +327,13 @@ Clone Set: dlm-clone
      安全性、工作组等其他设置通过 YaST 向导添加。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      更新所有节点上的 <filename>/etc/samba.conf</filename> 文件：
     </para>
 <screen><prompt role="root">root # </prompt>csync2 -xv</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      重启动 CTDB 资源：
     </para>
@@ -341,9 +345,9 @@ Clone Set: dlm-clone
    最后，将群集加入 Active Directory 服务器：
   </para>
 
-  <procedure id="pro-ha-samba-config-join-ad">
+  <procedure xml:id="pro-ha-samba-config-join-ad">
    <title>加入 Active Directory</title>
-   <step performance="required">
+   <step>
     <para>
      请确保 Csync2 的配置中包含下列文件，才可在所有群集主机上进行安装：
     </para>
@@ -357,24 +361,24 @@ Clone Set: dlm-clone
      您也可以为此任务使用 YaST 的<guimenu>配置 Csync2</guimenu> 模块，请参见<xref linkend="sec-ha-installation-setup-csync2"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按照<xref linkend="pro-ha-samba-basicconf"/>中所述创建 CTDB 资源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      运行 YaST 并从<guimenu>网络服务</guimenu>项中打开 <guimenu>Windows 域成员资格</guimenu>模块。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      输入域或工作组设置然后单击<guimenu>确定</guimenu>完成设置。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-testing">
+ </section>
+ <section xml:id="sec-ha-samba-testing">
   <title>调试和测试群集 Samba</title>
 
   <para>
@@ -416,7 +420,7 @@ Clone Set: dlm-clone
     </term>
     <listitem>
      <para>
-      检查文件系统是否支持 CTDB 使用 <command>ping_pong</command>。它会对群集文件系统执行一致性和性能之类的特定测试（请参见 <ulink url="http://wiki.samba.org/index.php/Ping_pong"/>），从而给出群集在高负载下将会表现如何的一些指示。
+      检查文件系统是否支持 CTDB 使用 <command>ping_pong</command>。它会对群集文件系统执行一致性和性能之类的特定测试（请参见 <link xlink:href="http://wiki.samba.org/index.php/Ping_pong"/>），从而给出群集在高负载下将会表现如何的一些指示。
      </para>
     </listitem>
    </varlistentry>
@@ -428,7 +432,7 @@ Clone Set: dlm-clone
       <systemitem class="resource">SendArp</systemitem> 资源代理位于 <filename>/usr/lib/heartbeat/send_arp</filename>（或 <filename>/usr/lib64/heartbeat/send_arp</filename>）。<command>send_arp</command> 工具发出免费的 ARP（Address Resolution Protocol，地址解析协议）包，可用于更新其他计算机的 ARP 表。它可以帮助确定故障转移过程之后的通讯问题。 如果节点显示 Samba 的群集 IP 地址，但您却无法连接到该节点或 ping 它，请使用 <command>send_arp</command> 命令测试节点是否只需要更新 ARP 表。
      </para>
      <para>
-      有关更多信息，请参见 <ulink url="http://wiki.wireshark.org/Gratuitous_ARP"/>。
+      有关更多信息，请参见 <link xlink:href="http://wiki.wireshark.org/Gratuitous_ARP"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -440,7 +444,7 @@ Clone Set: dlm-clone
 
   <procedure>
    <title>测试群集文件系统的一致性和性能</title>
-   <step performance="required">
+   <step>
     <para>
      在一个节点上启动命令 <command>ping_pong</command>，将占位符 <replaceable>N</replaceable> 替换为节点数 + 1。文件 <filename><replaceable>ABSPATH</replaceable>/data.txt</filename> 在共享存储区中提供，因此在所有节点（<replaceable>ABSPATH</replaceable> 表示绝对路径）上都可以访问到：
     </para>
@@ -449,7 +453,7 @@ Clone Set: dlm-clone
      应该会得到很高的锁定率，因为只运行一个节点。如果程序不打印锁定率，请替换群集文件系统。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用相同的参数在另一个节点上启动 <command>ping_pong</command> 的第二个副本。
     </para>
@@ -474,42 +478,42 @@ Clone Set: dlm-clone
      </listitem>
     </itemizedlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      启动 <command>ping_pong</command> 的第三个副本。添加另一个节点，注意锁定率的变化。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      逐个终止 <command>ping_pong</command> 命令。 应该观察到锁定率上升，直到回到单一节点的情况。如果没有看到预期行为，请参见<xref linkend="cha-ha-ocfs2"/> 中的详细信息。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-moreinfo">
+ </section>
+ <section xml:id="sec-ha-samba-moreinfo">
   <title>更多信息</title>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
+     <link xlink:href="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/CTDB_Setup"/>
+     <link xlink:href="http://wiki.samba.org/index.php/CTDB_Setup"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://ctdb.samba.org"/>
+     <link xlink:href="http://ctdb.samba.org"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
+     <link xlink:href="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_storage_protection.xml
+++ b/zh_CN/xml/ha_storage_protection.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_storage_protection.xml" id="cha-ha-storage-protect">
- <title>储存保护</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_storage_protection.xml" xml:id="cha-ha-storage-protect"><title>储存保护</title><info><abstract>
 
   <para>
    高可用性群集堆栈的首要任务是保护数据的完整性。这是通过避免未经协调而并发访问数据储存来实现的：例如，Ext3 文件系统只在群集中装入一次；只有在与其他群集节点协调后才会装入 OCFS2 卷。在功能良好的群集中，Pacemaker 会检测资源活动是否超出其并发限制，并启动恢复。此外，其策略引擎绝不会超出这些限制。
@@ -24,15 +26,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章介绍利用储存区本身的 IO 屏蔽机制，后面是对附加保护层（用于确保对储存区的排它访问）的描述。这两套机制可以结合起来使用，以提供更高的保护级别。
   </para>
- </abstract>
- <sect1 id="sec-ha-storage-protect-fencing">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-storage-protect-fencing">
   <title>基于储存区的屏蔽</title>
 
   <para>
    您可以使用一个或多个 STONITH 块设备 (SBD)、<literal>watchdog</literal> 支持和 <literal>external/sbd</literal> STONITH 代理来可靠地避免节点分裂状况。
   </para>
 
-  <sect2 id="sec-ha-storage-protect-fencing-oview">
+  <section xml:id="sec-ha-storage-protect-fencing-oview">
    <title>概述</title>
    <para>
     在所有节点都可访问共享储存的环境中，设备的某个小分区会格式化，以用于 SBD。该分区的大小取决于所用磁盘的块大小（对于块大小为 512 字节的标准 SCSI 磁盘，该分区大小为 1 MB；块大小为 4 KB 的 DASD 磁盘需要 4 MB）。配置完相应的守护程序后，它在其余群集堆栈启动之前将在每个节点上都处于联机状态。它在所有其他群集组件都关闭之后才终止，从而确保了群集资源绝不会在没有 SBD 监督的情况下被激活。
@@ -49,11 +53,11 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果 Pacemaker 集成已激活，则当设备大多数节点丢失时，SBD 将不会进行自我屏蔽。例如，您的群集包含 3 个节点：A、B 和 C。由于网络分隔，A 只能看到它自己，而 B 和 C 仍可相互通讯。在此案例中，有两个群集分区，一个因节点占多数（B 和 C）而具有法定票数，而另一个则不具有 (A)。如果发生此情况，当无法访问屏蔽设备的大多数节点时，则节点 A 会立即自我关闭，而节点 B 和 C 将会继续运行。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-storage-protect-fencing-number">
+  <section xml:id="sec-ha-storage-protect-fencing-number">
    <title>SBD 设备的数量</title>
    <para>
     SBD 支持使用 1 到 3 个设备：
@@ -87,35 +91,35 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-fencing-setup">
+  <section xml:id="sec-ha-storageprotection-fencing-setup">
    <title>设置基于储存区的保护</title>
    <para>
     以下步骤是设置基于储存区的保护所必需的：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-create" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-watchdog" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-daemon" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-test" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-fencing" xrefstyle="select:title"/>
      </para>
@@ -145,7 +149,7 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </important>
-   <sect3 id="pro-ha-storage-protect-sbd-create">
+   <section xml:id="pro-ha-storage-protect-sbd-create">
     <title>创建 SBD 分区</title>
     <para>
      建议在设备启动时创建一个 1MB 的分区。如果 SBD 设备驻留在多路径组上，则需要调整 SBD 所用的超时，因为 MPIO 的沿路径检测可能导致一些等待时间。<literal>msgwait</literal> 超时后，将假定此消息已传递到节点。对于多路径，这应是 MPIO 检测路径故障并切换到下一个路径所需的时间。您可能需要在自己的环境中对此进行测试。如果节点上运行的 SBD 守护程序未足够快速地更新检查包计时器，则节点会自行终止。在特定的环境中测试选择的超时。如果只对一个 SBD 设备使用多路径储存，请密切关注发生的故障转移延迟。
@@ -163,7 +167,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        使用以下命令初始化 SBD 设备：
       </para>
@@ -176,12 +180,12 @@ Please see LICENSE.txt for this document's license.
       </para>
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD1</replaceable> -d /dev/<replaceable>SBD2</replaceable> -d /dev/<replaceable>SBD3</replaceable> create</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果 SBD 设备驻留在多路径组中，请调整 SBD 所用的超时。这可以在初始化 SBD 设备时指定（所有超时的单位都是秒）：
       </para>
 
-<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co id="co-msgwait"/> -1 90<co id="co-watchdog"/> create</screen>
+<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co xml:id="co-msgwait"/> -1 90<co xml:id="co-watchdog"/> create</screen>
       <calloutlist>
        <callout arearefs="co-msgwait">
         <para>
@@ -195,7 +199,7 @@ Please see LICENSE.txt for this document's license.
        </callout>
       </calloutlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        使用以下命令检查已写入设备的内容：
       </para>
@@ -212,8 +216,8 @@ Timeout (msgwait)  : 10</screen>
     <para>
      正如您看到的，超时数也储存在报头中，以确保所有参与的节点在这方面都一致。
     </para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-watchdog">
+   </section>
+   <section xml:id="pro-ha-storage-protect-watchdog">
     <title>设置软件检查包</title>
     <para>在未被其他软件使用的情况下，检查包可以在出现 SBD 故障时保护系统。</para>
      
@@ -222,7 +226,7 @@ Timeout (msgwait)  : 10</screen>
      </important>
      
      <para>
-     在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 中，默认会启用内核中的检查包支持：本产品随附了多个不同的内核模块，可提供特定于硬件的检查包驱动程序。High Availability Extension 使用 SBD 守护程序作为<quote>供给</quote>检查包的软件组件。如果按<xref linkend="pro-ha-storage-protect-sbd-daemon"/>中进行了配置，使用 <command>rcopenais <option>start</option></command> 将相应节点联机时会自动启动 SBD 守护程序。
+     在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 中，默认会启用内核中的检查包支持：本产品随附了多个不同的内核模块，可提供特定于硬件的检查包驱动程序。High Availability Extension 使用 SBD 守护程序作为<quote>供给</quote>检查包的软件组件。如果按<xref linkend="pro-ha-storage-protect-sbd-daemon"/>中进行了配置，使用 <command>rcopenais </command> <option>start</option> 将相应节点联机时会自动启动 SBD 守护程序。
     </para>
     <para>
      在系统引导过程中，一般会自动装载适用于您硬件的检查包驱动程序。<literal>softdog</literal> 是最通用的驱动程序，但建议使用带有实际硬件集成的驱动程序。例如：
@@ -252,7 +256,7 @@ Timeout (msgwait)  : 10</screen>
      <para>以下<quote>公式</quote>大致表达了这三个值之间的关系：
     </para>
      
-     <example id="ex-ha-storage-protect-sbd-timings">
+     <example xml:id="ex-ha-storage-protect-sbd-timings">
        <title>使用 SBD 作为 STONITH 设备的群集计时</title>
        <screen>Timeout (msgwait) = (Timeout (watchdog) * 2)
 stonith-timeout = Timeout (msgwait) + 20%</screen>
@@ -273,15 +277,15 @@ Timeout (loop)     : 1
 Timeout (msgwait)  : 40
 ==Header on disk /dev/sdb is dumped</screen>
      <para>如果您要设置新群集，<command>sleha-init</command> 命令会考虑上述因素。</para>
-    <para>如需 SBD 相关计时变量的更多细节，请参见 <ulink url="https://www.suse.com/support/kb/doc.php?id=7011346"/> 上的《<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>》（HAE 群集的 SBD 操作指南）。</para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-daemon">
+    <para>如需 SBD 相关计时变量的更多细节，请参见 <link xlink:href="https://www.suse.com/support/kb/doc.php?id=7011346"/> 上的《<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>》（HAE 群集的 SBD 操作指南）。</para>
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-daemon">
     <title>启动 SBD 守护程序</title>
     <para>
      SBD 守护程序是群集堆栈的关键部分。只要群集堆栈正在运行，此守护程序就必须运行，即使群集堆栈的一部分已崩溃时也是如此，这样才能屏蔽节点。
     </para>
     <procedure>
-        <step performance="required">
+        <step>
        <para>运行 <command>sleha-init</command>。此脚本可确保正确配置 SBD，并将配置文件 <filename>/etc/sysconfig/sbd</filename> 添加到需要与 Csync2 同步的文件列表。 </para>
        <para>如果要手动配置 SBD，请执行以下步骤：</para>
             <para> 要启动 OpenAIS init 脚本和停止 SBD，请编辑 <filename>/etc/sysconfig/sbd</filename> 文件，搜索下面的行，搜索时将 <replaceable>SBD</replaceable> 替换为您的 SBD 设备： </para>
@@ -299,17 +303,17 @@ Timeout (msgwait)  : 40
        </para>
       </note>
      </step>     
-     <step performance="required">
+     <step>
       <para>
-       在继续下一步之前，请通过执行 <command>rcopenais<option> restart</option></command> 确保所有节点上都启动了 SBD。
+       在继续下一步之前，请通过执行 <command>rcopenais</command> <option> restart</option> 确保所有节点上都启动了 SBD。
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-test">
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-test">
     <title>测试 SBD</title>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        以下命令会将节点槽及其当前消息从 SBD 设备进行转储：
       </para>
@@ -318,14 +322,14 @@ Timeout (msgwait)  : 40
        现在，您应该看到此处列出了使用 SBD 启动过的所有群集节点，并且消息槽应显示 <literal>clear</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        尝试将测试消息发送到节点之一：
       </para>
       
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD</replaceable> message alice test</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        此节点将在系统日志文件中确认收到了该讯息：
       </para>
@@ -335,8 +339,8 @@ Timeout (msgwait)  : 40
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-fencing">
+   </section>
+   <section xml:id="pro-ha-storage-protect-fencing">
     <title>配置屏蔽资源</title>
     <para>
      要完成 SBD 设置，请将 SBD 配置为 CIB 中的 STONITH/屏蔽机制。
@@ -347,16 +351,16 @@ Timeout (msgwait)  : 40
      <para>在双节点群集（以及 <literal>no-quorum-policy</literal> 设置为 <literal>ignore</literal> 的其他群集）中，经常会发生不合时宜的屏蔽，因为这两个节点会在发生节点分裂时相互屏蔽。要避免这种双重屏蔽，请将 <literal>pcmk_delay_max</literal> 参数添加到 STONITH 资源的配置中。这样，网卡正常运行的服务器就更有机会得以幸存。</para>
     </tip>
     <procedure>
-     <step performance="required">
+     <step>
       <para>登录到其中一个节点，然后使用 <command>crm configure</command> 启动交互式 crmsh。</para>
      </step>
-     <step performance="required">
+     <step>
       <para>输入以下内容：</para>
       
       <screen><prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-enabled="true"
-<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co id="co-ha-sbd-stonith-timeout"/>
+<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co xml:id="co-ha-sbd-stonith-timeout"/>
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> stonith_sbd stonith:external/sbd \
-   pcmk_delay_max="30" <co id="co-ha-sbd-pcmk-delay-max"/></screen>
+   pcmk_delay_max="30" <co xml:id="co-ha-sbd-pcmk-delay-max"/></screen>
       <para> 不需要克隆资源。由于节点槽是自动分配的，因此无需定义手动主机列表。 </para>
       <calloutlist>
        <callout arearefs="co-ha-sbd-stonith-timeout">
@@ -369,11 +373,11 @@ Timeout (msgwait)  : 40
        </callout>
       </calloutlist>
       </step>
-     <step performance="required">
+     <step>
       <para> 提交更改： </para>
       <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        禁用以前可能配置过的任何其他屏蔽设备，因为现在用于此功能的是 SBD 机制。
       </para>
@@ -382,16 +386,16 @@ Timeout (msgwait)  : 40
     <para>
      资源启动后，群集的共享储存屏蔽配置即告成功，群集将在需要屏蔽节点时使用此方法。
     </para>
-   </sect3>
-   <sect3>
+   </section>
+   <section>
     <title>更多信息</title>
     <para>
-     <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>
+     <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>
     </para>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storageprotection-exstoract">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-storageprotection-exstoract">
   <title>确保储存区的排它激活</title>
 
   <para>
@@ -402,7 +406,7 @@ Timeout (msgwait)  : 40
    根据设计意图，sfex 不能用于需要执行并发操作的工作负载（如 OCFS2），而是用作传统故障转移式工作负载的保护层。这实际上与 SCSI-2 保留相类似，但更具一般性。
   </para>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-description">
+  <section xml:id="sec-ha-storageprotection-exstoract-description">
    <title>概述</title>
    <para>
     在共享储存环境中，储存区的一个小分区专门设置为储存一个或多个锁。
@@ -413,9 +417,9 @@ Timeout (msgwait)  : 40
    <para>
     这些锁必须定期刷新，这样某个节点的终止才不会永久性地阻止此锁，其他节点仍可继续操作。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-requirements">
+  <section xml:id="sec-ha-storageprotection-exstoract-requirements">
    <title>设置</title>
    <para>
     以下内容可帮助您了解如何创建用于 sfex 的共享分区以及如何为 CIB 中的 sfex 锁配置资源。单个 sfex 分区可保存任意数量的锁，默认值为 1，需要为每个锁分配 1 KB 的储存空间。
@@ -442,18 +446,18 @@ Timeout (msgwait)  : 40
    </important>
    <procedure>
     <title>创建 sfex 分区</title>
-    <step performance="required">
+    <step>
      <para>
       创建用于 sfex 的共享分区。注意此分区的名称，并用它替代下面的 <filename>/dev/sfex</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用以下命令创建 sfex 元数据：
      </para>
 <screen><prompt role="root">root # </prompt><command>sfex_init</command> -n 1 /dev/sfex</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       校验元数据已正确创建：
      </para>
@@ -465,7 +469,7 @@ Timeout (msgwait)  : 40
    </procedure>
    <procedure>
     <title>为 sfex 锁配置资源</title>
-    <step performance="required">
+    <step>
      <para>
       sfex 锁通过 CIB 中的资源表示，其配置如下：
      </para>
@@ -474,27 +478,27 @@ Timeout (msgwait)  : 40
       lock_timeout="70" monitor_interval="10" \
 #	op monitor interval="10s" timeout="30s" on_fail="fence"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       要通过 sfex 锁保护资源，请在保护对象和 sfex 资源之间创建强制顺序和放置约束。如果受保护资源的 ID 是 <literal>filesystem1</literal>：
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> order-sfex-1 inf: sfex_1 filesystem1
 <prompt role="custom">crm(live)configure# </prompt><command>colocation</command> colo-sfex-1 inf: filesystem1 sfex_1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用组语法，请将 sfex 资源添加为组内的第一个资源：
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>group</command> LAMP sfex_1 filesystem1 apache ipaddr</screen>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storage-moreinfo">
+  </section>
+ </section>
+ <section xml:id="sec-ha-storage-moreinfo">
   <title>更多信息</title>
 
   <para>
-   请参见 <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/> 和 <command>man sbd</command>。
+   请参见 <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/> 和 <command>man sbd</command>。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_CN/xml/ha_troubleshooting.xml
+++ b/zh_CN/xml/ha_troubleshooting.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_troubleshooting.xml" id="app-ha-troubleshooting">
- <title>查错</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_troubleshooting.xml" xml:id="app-ha-troubleshooting"><title>查错</title><info><abstract>
   <para>
    用户可能会遇到奇怪而不易理解的问题，特别是刚开始尝试使用 High Availability 时。不过，有一些实用程序可用来仔细地观察 High Availability 的内部进程。本章将推荐各种解决方案。
   </para>
- </abstract>
- <sect1 id="sec-ha-troubleshooting-install">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-troubleshooting-install">
   <title>安装及初始步骤</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-log">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-log">
   <title>日志记录</title>
 
   <variablelist>
@@ -125,11 +129,11 @@ Operations:
       * Node alice:</screen>
      </example>
      <para>
-      <ulink url="http://www.clusterlabs.org/doc/"/> 上《<citetitle>Pacemaker Explained</citetitle>》（Pacemaker 说明）PDF 文件中的“<citetitle>How are OCF Return Codes Interpreted?</citetitle>”（如何解释 OCF 返回代码？）部分中介绍了三种不同的恢复类型。
+      <link xlink:href="http://www.clusterlabs.org/doc/"/> 上《<citetitle>Pacemaker Explained</citetitle>》（Pacemaker 说明）PDF 文件中的“<citetitle>How are OCF Return Codes Interpreted?</citetitle>”（如何解释 OCF 返回代码？）部分中介绍了三种不同的恢复类型。
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-crm-report">
+   <varlistentry xml:id="vle-ha-crm-report">
     
     <term>如何创建包含所有群集节点分析的报告？</term>
     <listitem>
@@ -235,8 +239,8 @@ Operations:
    </varlistentry>
    
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-resource">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-resource">
   <title>资源</title>
 
   <variablelist>
@@ -303,8 +307,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-stonith">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-stonith">
   <title>STONITH 和屏蔽</title>
 
   <variablelist>
@@ -345,8 +349,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-misc">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-misc">
   <title>杂项</title>
 
   <variablelist>
@@ -423,12 +427,12 @@ Jan 12 16:04:22 alice modprobe: FATAL: Module ocfs2_stackglue not found.</screen
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-moreinfo">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-moreinfo">
   <title>更多信息</title>
 
   <para>
-   有关 Linux 上的高可用性的更多信息（包括配置群集资源以及管理和自定义高可用性群集），请参见 <ulink url="http://clusterlabs.org/wiki/Documentation"/>。
+   有关 Linux 上的高可用性的更多信息（包括配置群集资源以及管理和自定义高可用性群集），请参见 <link xlink:href="http://clusterlabs.org/wiki/Documentation"/>。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/DC-SLE-ha-all
+++ b/zh_TW/DC-SLE-ha-all
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/zh_TW/DC-SLE-ha-guide
+++ b/zh_TW/DC-SLE-ha-guide
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86;amd64;em64t"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/zh_TW/xml/MAIN.SLEHA.xml
+++ b/zh_TW/xml/MAIN.SLEHA.xml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<!DOCTYPE set PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE set>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<set lang="zh-tw">
- <title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 文件</title>
- <setinfo>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
- </setinfo>
+<set xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:lang="zh-tw"><title><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 文件</title><info><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber></info>
+ 
+ 
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_haguide.xml" parse="xml"/>
+ <xi:include href="book_sle_haguide.xml" parse="xml"/>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="book_sle_ha_techguides.xml" parse="xml"/>
+ <xi:include href="book_sle_ha_techguides.xml" parse="xml"/>
 </set>

--- a/zh_TW/xml/art_sle_ha_nfs_quick.xml
+++ b/zh_TW/xml/art_sle_ha_nfs_quick.xml
@@ -1,33 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE article PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE article>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<?provo dirname="nfs_quick/"?>
-<article xml:base="art_sle_ha_nfs_quick.xml" lang="zh-tw" id="art-ha-quick-nfs">
-<?suse-quickstart columns="no" version="2"?>
-
-
- <title>Highly Available NFS Storage with DRBD and Pacemaker</title>
- <subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle>
- <articleinfo>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productname role="abbrev">SLE HA</productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <authorgroup>
-   <author><firstname>Florian</firstname><surname>Haas</surname>
-   </author>
-   <author><firstname>Tanja</firstname><surname>Roth</surname>
-   </author>
-  </authorgroup>
- </articleinfo>
-
- <abstract>
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="art_sle_ha_nfs_quick.xml" xml:lang="zh-tw" xml:id="art-ha-quick-nfs"><?suse-quickstart columns="no" version="2"?><title>Highly Available NFS Storage with DRBD and Pacemaker</title><subtitle><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></subtitle><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productname role="abbrev">SLE HA</productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><authorgroup>
+   <author><personname><firstname>Florian</firstname><surname>Haas</surname></personname></author>
+   <author><personname><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+  </authorgroup><abstract>
   <para os="sles">
    This document describes how to set up highly available NFS storage in a
    2-node cluster, using the following components that are shipped with
@@ -35,12 +20,20 @@ Please see LICENSE.txt for this document's license.
    (Logical Volume Manager version 2), and Pacemaker, the cluster resource
    management framework.
   </para>
- </abstract>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_intro_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_install_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_use_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_nfs_quick_failover_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides_quick.xml" parse="xml"/>
+ </abstract></info>
+
+
+
+ 
+ 
+ 
+
+ 
+ <xi:include href="ha_nfs_quick_intro_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_install_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_config_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_rsc_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_use_i.xml" parse="xml"/>
+ <xi:include href="ha_nfs_quick_failover_i.xml" parse="xml"/>
+ <xi:include href="copyright_techguides_quick.xml" parse="xml"/>
 </article>

--- a/zh_TW/xml/book_sle_ha_techguides.xml
+++ b/zh_TW/xml/book_sle_ha_techguides.xml
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml"
-                 title="Profiling step"?>
-<book xml:base="book_sle_ha_techguides.xml" lang="zh-tw" id="book-sleha-techguides">
- <bookinfo>
-  <title>Technical Guides</title><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
-<?dbtimestamp format="B d, Y"?></date>
-
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright_techguides.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="art_sle_ha_nfs_quick.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_ha_techguides.xml" xml:lang="zh-tw" xml:id="book-sleha-techguides"><title>Technical Guides</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date>
+<?dbtimestamp format="B d, Y"?></date><xi:include href="copyright_techguides.xml" parse="xml"/></info>
+ 
+ <xi:include href="art_sle_ha_nfs_quick.xml" parse="xml"/>
  
 
 </book>

--- a/zh_TW/xml/book_sle_haguide.xml
+++ b/zh_TW/xml/book_sle_haguide.xml
@@ -1,61 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE book>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
- type="text/xml" 
- title="Profiling step"?>
-<?provo dirname="ha/"?>
-<book xml:base="book_sle_haguide.xml" lang="zh-tw" id="book-sleha">
- <bookinfo>
-  <title>高可用性指南</title>
-  <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname>
-
-  <productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber>
-  <date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_copyright_gfdl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_authors.xml" parse="xml"/>
- </bookinfo>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_intro.xml" parse="xml"/>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="book_sle_haguide.xml" xml:lang="zh-tw" xml:id="book-sleha"><title>高可用性指南</title><info><productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></productname><productnumber><phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase></productnumber><date><?dbtimestamp format="Y"?> 年 <?dbtimestamp format="B"?> 月 <?dbtimestamp format="d"?> 日</date><xi:include href="common_copyright_gfdl.xml" parse="xml"/><xi:include href="ha_authors.xml" parse="xml"/></info>
+ 
+ <xi:include href="ha_intro.xml" parse="xml"/>
 
 
 
- <part id="part-install">
-  <title>安裝與設定</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_concepts.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_requirements.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_installation.xml" parse="xml"/>
+ <part xml:id="part-install"><title>安裝與設定</title><info/>
+  
+  <xi:include href="ha_concepts.xml" parse="xml"/>
+  <xi:include href="ha_requirements.xml" parse="xml"/>
+  <xi:include href="ha_installation.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-config">
-  <title>組態與管理</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_basics.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_hawk.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_gui.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_cli.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_agents.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_fencing.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_acl.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_netbonding.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_lvs.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_geocluster.xml" parse="xml"/>
+ <part xml:id="part-config"><title>組態與管理</title><info/>
+  
+  <xi:include href="ha_config_basics.xml" parse="xml"/>
+  <xi:include href="ha_config_hawk.xml" parse="xml"/>
+  <xi:include href="ha_config_gui.xml" parse="xml"/>
+  <xi:include href="ha_config_cli.xml" parse="xml"/>
+  <xi:include href="ha_agents.xml" parse="xml"/>
+  <xi:include href="ha_fencing.xml" parse="xml"/>
+  <xi:include href="ha_acl.xml" parse="xml"/>
+  <xi:include href="ha_netbonding.xml" parse="xml"/>
+  <xi:include href="ha_lvs.xml" parse="xml"/>
+  <xi:include href="ha_geocluster.xml" parse="xml"/>
  </part>
 
 
 
- <part id="part-storage">
-  <title>儲存與資料複製</title>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_ocfs2.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_drbd.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_clvm.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_storage_protection.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_samba.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_rear.xml" parse="xml"/>
+ <part xml:id="part-storage"><title>儲存與資料複製</title><info/>
+  
+  <xi:include href="ha_ocfs2.xml" parse="xml"/>
+  <xi:include href="ha_drbd.xml" parse="xml"/>
+  <xi:include href="ha_clvm.xml" parse="xml"/>
+  <xi:include href="ha_storage_protection.xml" parse="xml"/>
+  <xi:include href="ha_samba.xml" parse="xml"/>
+  <xi:include href="ha_rear.xml" parse="xml"/>
  </part>
   
   
@@ -63,17 +55,17 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <part id="part-appendix">
-  <title>附錄</title>
+ <part xml:id="part-appendix"><title>附錄</title><info/>
   
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_troubleshooting.xml" parse="xml"/>
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_naming.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_config_example.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_management.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_migration.xml" parse="xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_news.xml" parse="xml"/>
+  
+  <xi:include href="ha_troubleshooting.xml" parse="xml"/>
+   <xi:include href="ha_naming.xml" parse="xml"/>
+  <xi:include href="ha_example.xml" parse="xml"/>
+  <xi:include href="ha_config_example.xml" parse="xml"/>
+  <xi:include href="ha_management.xml" parse="xml"/>
+  <xi:include href="ha_migration.xml" parse="xml"/>
+  <xi:include href="ha_news.xml" parse="xml"/>
  </part>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_glossary.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_legal.xml" parse="xml"/>
+ <xi:include href="ha_glossary.xml" parse="xml"/>
+ <xi:include href="common_legal.xml" parse="xml"/>
 </book>

--- a/zh_TW/xml/common_copyright_gfdl.xml
+++ b/zh_TW/xml/common_copyright_gfdl.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="common_copyright_gfdl.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="common_copyright_gfdl.xml">
  <para>
   版權所有 © 2006–<?dbtimestamp format="Y"?>
 
@@ -16,7 +20,7 @@ Please see LICENSE.txt for this document's license.
   根據 GNU 自由文件授權 (GNU Free Documentation License) 1.2 版或 1.3 版 (自由選擇)，使用者可以複製、散佈與/或修改本文件；「恆常章節」為此著作權聲明與授權。<quote>GNU 自由文件授權</quote>一節中包含 1.2 版授權的一份副本。
  </para>
  <para>
-  如需 SUSE 或 Novell 商標之相關資訊，請參閱 Novell 商標和服務標誌清單 <ulink url="http://www.novell.com/company/legal/trademarks/tmlist.html"/>。所有其他協力廠商商標，為各所有人所有之財產。商標符號 (®、™ 等) 代表 SUSE 或 Novell 的商標；星號 (*) 代表協力廠商的商標。
+  如需 SUSE 或 Novell 商標之相關資訊，請參閱 Novell 商標和服務標誌清單 <link version="5.1" xlink:href="http://www.novell.com/company/legal/trademarks/tmlist.html"/>。所有其他協力廠商商標，為各所有人所有之財產。商標符號 (®、™ 等) 代表 SUSE 或 Novell 的商標；星號 (*) 代表協力廠商的商標。
  </para>
  <para>
   本手冊中所有資訊在編輯時，都已全力注意各項細節。但這不保證百分之百的正確性。因此，SUSE LLC 及其附屬公司、作者或譯者都不需對任何錯誤或造成的結果負責。

--- a/zh_TW/xml/common_gfdl1.2_i.xml
+++ b/zh_TW/xml/common_gfdl1.2_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-                 type="text/xml" 
-                 title="Profiling step"?>
-<sect1 xml:base="common_gfdl1.2_i.xml" role="legal">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_gfdl1.2_i.xml" role="legal">
  <title>GNU Free Documentation License</title>
 
  <para>
@@ -498,7 +499,7 @@ Please see LICENSE.txt for this document's license.
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to
   address new problems or concerns. See
-  <ulink url="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</ulink>.
+  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>
@@ -548,4 +549,4 @@ Please see LICENSE.txt for this document's license.
   software license, such as the GNU General Public License, to permit their
   use in free software.
  </para>
-</sect1>
+</section>

--- a/zh_TW/xml/common_intro_feedback_i.xml
+++ b/zh_TW/xml/common_intro_feedback_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_feedback_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_feedback_i.xml">
  <title>意見反應</title>
 
  <para>
@@ -18,10 +22,10 @@ Please see LICENSE.txt for this document's license.
    <term>錯誤與增強功能要求</term>
    <listitem>
     <para>
-     有關適用於產品的服務與支援選項，請參閱 <ulink url="http://www.suse.com/support/"/>。
+     有關適用於產品的服務與支援選項，請參閱 <link xlink:href="http://www.suse.com/support/"/>。
     </para>
     <para>
-     若要報告產品元件的錯誤，請登入 Novell Customer Center (<ulink url="http://www.suse.com/support/"/>)，然後選取<menuchoice><guimenu>我的支援</guimenu> <guimenu>服務要求</guimenu></menuchoice>。
+     若要報告產品元件的錯誤，請登入 Novell Customer Center (<link xlink:href="http://www.suse.com/support/"/>)，然後選取<menuchoice><guimenu>我的支援</guimenu> <guimenu>服務要求</guimenu></menuchoice>。
     </para>
    </listitem>
   </varlistentry>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    <term>使用者意見</term>
    <listitem>
     <para>
-     我們希望得到您對本手冊以及本產品隨附之其他文件的意見和建議。請使用線上文件每頁底部的「使用者備註」功能，或造訪 <ulink url="http://www.suse.com/doc/feedback.html"/> 在其中輸入您的意見。
+     我們希望得到您對本手冊以及本產品隨附之其他文件的意見和建議。請使用線上文件每頁底部的「使用者備註」功能，或造訪 <link xlink:href="http://www.suse.com/doc/feedback.html"/> 在其中輸入您的意見。
 
     </para>
    </listitem>
@@ -43,4 +47,4 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </varlistentry>
  </variablelist>
-</sect1>
+</section>

--- a/zh_TW/xml/common_intro_making_i.xml
+++ b/zh_TW/xml/common_intro_making_i.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_making_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_making_i.xml">
  <title>關於本手冊編寫</title>
 
  <para>
-  本手冊是採用 Novdoc 所編寫，這是 DocBook 的子集合 (請參閱 <ulink url="http://www.docbook.org"/>)。其中 XML 來源檔案已由 <command>xmllint</command> 驗證，經由 <command>xsltproc</command> 處理，而且採用 Norman Walsh 樣式表的自定版本轉換成 XSL-FO。完稿的 PDF 是使用 RenderX 的 XEP 進行格式化所產生。 
+  本手冊是採用 Novdoc 所編寫，這是 DocBook 的子集合 (請參閱 <link xlink:href="http://www.docbook.org"/>)。其中 XML 來源檔案已由 <command>xmllint</command> 驗證，經由 <command>xsltproc</command> 處理，而且採用 Norman Walsh 樣式表的自定版本轉換成 XSL-FO。完稿的 PDF 是使用 RenderX 的 XEP 進行格式化所產生。 
  </para>
-</sect1>
+</section>

--- a/zh_TW/xml/common_intro_typografie_i.xml
+++ b/zh_TW/xml/common_intro_typografie_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="common_intro_typografie_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_intro_typografie_i.xml">
 
 
  <title>文件慣例</title>
@@ -64,4 +68,4 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
-</sect1>
+</section>

--- a/zh_TW/xml/common_legal.xml
+++ b/zh_TW/xml/common_legal.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="common_legal.xml" role="legal">
- <title>GNU 授權</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="common_legal.xml" role="legal"><title>GNU 授權</title><info/>
+ 
  <para>
   本附錄包含 GNU Free Documentation License (GNU 自由文件授權) 1.2 版。
  </para>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_gfdl1.2_i.xml" parse="xml"/>
+ <xi:include href="common_gfdl1.2_i.xml" parse="xml"/>
 </appendix>

--- a/zh_TW/xml/copyright_techguides.xml
+++ b/zh_TW/xml/copyright_techguides.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE legalnotice PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE legalnotice>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<legalnotice xml:base="copyright_techguides.xml">
+<legalnotice xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="copyright_techguides.xml">
  <para>
   Copyright © 2011 Novell Inc., doc-team@suse.de. Used with
   permission.
@@ -31,12 +35,12 @@ Please see LICENSE.txt for this document's license.
   </para>
  </formalpara>
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link version="5.1" xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link version="5.1" xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
 </legalnotice>

--- a/zh_TW/xml/copyright_techguides_quick.xml
+++ b/zh_TW/xml/copyright_techguides_quick.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="copyright_techguides_quick.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="copyright_techguides_quick.xml">
  <title>Legal Notice</title>
 
  <para>
@@ -37,13 +41,13 @@ Please see LICENSE.txt for this document's license.
  </formalpara>
 
  <simplelist>
-  <member>A summary of CC BY-NC-ND-3.0 is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
-  <member>The full license text is available at <ulink url="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
+  <member>A summary of CC BY-NC-ND-3.0 is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/"/>.</member>
+  <member>The full license text is available at <link xlink:href="http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"/>.</member>
  </simplelist>
 
  <para>
   In accordance with CC BY-NC-ND-3.0, if you distribute this document, you
   must provide the URL for the original version:
-  <ulink url="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
+  <link xlink:href="http://www.linbit.com/en/education/tech-guides/highly-available-nfs-with-drbd-and-pacemaker/"/>.
  </para>
-</sect1>
+</section>

--- a/zh_TW/xml/ha_acl.xml
+++ b/zh_TW/xml/ha_acl.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_acl.xml" id="cha-ha-acl">
- <title>存取控制清單</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_acl.xml" xml:id="cha-ha-acl"><title>存取控制清單</title><info><abstract>
   <para>
    crm 外圍程序 (crmsh)、Hawk 或 Pacemaker GUI 等叢集管理工具可由 <systemitem class="username">root</systemitem> 或 <systemitem class="groupname">haclient</systemitem> 群組中的任何使用者使用。依預設，這些使用者擁有完整的讀取/寫入存取權。若要限制存取權或指定更精細的存取權限，可以使用<emphasis>存取控制清單</emphasis> (ACL)。
   </para>
@@ -15,14 +17,16 @@ Please see LICENSE.txt for this document's license.
   <para>
    存取控制清單由一組排序的存取規則構成。每個規則允許對一部分叢集組態進行讀取或寫入存取，或者拒絕對該部分進行存取。多個規則通常會組合起來構成特定的角色，這樣便可以將使用者指定到與其任務相符的角色。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  
  <note>
   <title>CIB 驗證版本與 ACL 的差異</title>
   <para>僅當您的 CIB 是由 <literal>pacemaker-2.0</literal> 或更高 CIB 語法版本驗證時，此 ACL 文件才適用。如需關於如何檢查這一點以及升級 CIB 版本的詳細資料，請參閱<xref linkend="note-ha-cib-upgrade"/>。 </para>
-  <para>如果您已從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級並保留了以前的 CIB 版本，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的「<citetitle>存取控制清單</citetitle>」一章。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。</para>
+  <para>如果您已從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級並保留了以前的 CIB 版本，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的「<citetitle>存取控制清單</citetitle>」一章。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。</para>
  </note>
- <sect1 id="sec-ha-acl-require">
+ <section xml:id="sec-ha-acl-require">
   <title>要求和必要條件</title>
 
   <para>
@@ -74,10 +78,10 @@ Please see LICENSE.txt for this document's license.
   </important>
 
   <para>
-   若要使用 ACL，您需要瞭解一些 XPath 方面的知識。XPath 是一種用於在 XML 文件中選取節點的語言。請參閱 <ulink url="http://en.wikipedia.org/wiki/XPath"/> 或在 <ulink url="http://www.w3.org/TR/xpath/"/> 上查詢規格。
+   若要使用 ACL，您需要瞭解一些 XPath 方面的知識。XPath 是一種用於在 XML 文件中選取節點的語言。請參閱 <link xlink:href="http://en.wikipedia.org/wiki/XPath"/> 或在 <link xlink:href="http://www.w3.org/TR/xpath/"/> 上查詢規格。
   </para>
- </sect1>
- <sect1 id="sec-ha-acl-enable">
+ </section>
+ <section xml:id="sec-ha-acl-enable">
   <title>在叢集中啟用 ACL</title>
 
   <para>
@@ -90,31 +94,31 @@ Please see LICENSE.txt for this document's license.
    也可以依照<xref linkend="pro-ha-acl-enable-hawk"/>所述使用 Hawk。
   </para>
 
-  <procedure id="pro-ha-acl-enable-hawk">
+  <procedure xml:id="pro-ha-acl-enable-hawk">
    <title>使用 Hawk 啟用 ACL</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集內容</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <guimenu>CRM 組態</guimenu>群組中，從空白下拉式方塊中選取 <guimenu>enable-acl</guimenu> 屬性，然後按一下加號圖示新增該屬性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要設定 <literal>enable-acl=true</literal>，請啟用 <literal>enable-acl</literal> 旁邊的核取方塊，並確認您所做的變更。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-basics">
+ </section>
+ <section xml:id="sec-ha-acl-basics">
   <title>ACL 的基本知識</title>
 
   <para>
@@ -151,14 +155,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <sect2 id="sec-ha-acl-config-xpath">
+  <section xml:id="sec-ha-acl-config-xpath">
    <title>透過 XPath 運算式設定 ACL 規則</title>
    <para>
     若要透過 XPath 管理 ACL 規則，您需要瞭解基礎 XML 的結構。使用以下指令擷取結構，該指令將以 XML 格式顯示您的叢集組態 (請參閱<xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>)：
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure show xml</screen>
    
-   <example id="ex-ha-acl-excerpt">
+   <example xml:id="ex-ha-acl-excerpt">
     <title>XML 中的叢集組態摘錄</title>
 <screen>&lt;num_updates="59" 
       dc-uuid="175704363"
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     例如，<xref linkend="tab-ha-acl-operator"/>顯示了用於建立<quote>operator</quote>角色的參數 (存取類型和 XPath 運算式)。具有此角色的使用者僅可執行第二欄中所述的任務 — 他們既不能重新設定任何資源 (例如，變更參數或操作)，也不能變更並存或順序條件約束的組態。
    </para>
-   <table id="tab-ha-acl-operator">
+   <table xml:id="tab-ha-acl-operator">
     <title>Operator 角色 — 存取類型和 XPath 運算式</title>
     <tgroup cols="2">
      <thead>
@@ -305,10 +309,10 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
   
-   <sect2 id="sec-ha-acl-config-tag">
+   <section xml:id="sec-ha-acl-config-tag">
    <title>透過縮寫設定 ACL 規則</title>
    <para>
     不想處理 XML 結構的使用者可以使用更簡單的方法， 
@@ -331,51 +335,51 @@ Please see LICENSE.txt for this document's license.
     簡寫語法可以用在 crmsh 和 Hawk 中。CIB 精靈知道如何將 ACL 規則套用至相符物件。
    </para>
    
-   </sect2>
-  </sect1>
- <sect1 id="sec-ha-acl-config-hbgui">
+   </section>
+  </section>
+ <section xml:id="sec-ha-acl-config-hbgui">
   <title>使用 Pacemaker GUI 設定 ACL</title>
 
   <para> 下面的程序說明如何透過定義 <literal>monitor</literal> 角色並將其指定給使用者，來設定對叢集組態的唯讀存取權。您也可以依照<xref linkend="sec-ha-acl-config-hawk"/>和<xref linkend="pro-ha-acl-crm"/>所述，使用 Hawk 或 crmsh 來實現此目的。 </para>
 
-  <procedure id="pro-ha-acl-hbgui">
+  <procedure xml:id="pro-ha-acl-hbgui">
    <title>使用 Pacemaker GUI 新增 monitor 角色並指定使用者</title>
-   <step performance="required">
+   <step>
     <para>
      啟動 Pacemaker GUI，並依<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>組態</guimenu>樹狀結構中的<guimenu>ACL</guimenu>項目。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>新增</guimenu>。一個對話方塊即會顯示。請選擇 <guimenu>ACL 目標</guimenu>或 <guimenu>ACL 角色</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要定義 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選擇<guimenu>ACL 角色</guimenu>。一個視窗即會開啟，您可在其中新增組態選項。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-id" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-id">
       <para>
        在<guimenu>ID</guimenu>文字欄位中新增一個唯一識別碼，例如 <literal>monitor</literal>。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-add" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-add">
       <para>
        按一下<guimenu>新增</guimenu>並選擇權限 (<guimenu>讀取</guimenu>、<guimenu>寫入</guimenu>、或<guimenu>拒絕</guimenu>)。本範例中選取<guimenu>讀取</guimenu>。
       </para>
      </step>
-     <step id="st-ha-acl-config-hbgui-xpath" performance="required">
+     <step xml:id="st-ha-acl-config-hbgui-xpath">
       <para>
        在<guimenu>Xpath</guimenu>文字欄位中輸入 XPath 運算式 <literal>/cib</literal>。按一下<guimenu>確定</guimenu>繼續。
       </para>
@@ -383,34 +387,34 @@ Please see LICENSE.txt for this document's license.
        附註：如果您有資源或條件約束，也可以使用<xref linkend="sec-ha-acl-config-tag"/> 中所述的簡寫語法。 
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果您有其他條件，請重複這些步驟 (<xref linkend="st-ha-acl-config-hbgui-add"/>與<xref linkend="st-ha-acl-config-hbgui-xpath"/>)。在本例中，情況並非如此，因此您的角色已完成，此時您可以按一下<guimenu>確定</guimenu>關閉視窗。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將角色指定給使用者：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        按一下<guimenu>新增</guimenu>按鈕。一個對話方塊即會顯示，讓您選擇 <guimenu>ACL 目標</guimenu>或 <guimenu>ACL 角色</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選擇 <guimenu>ACL 目標</guimenu>。一個視窗即會開啟，您可在其中新增組態選項。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在<guimenu>ID</guimenu>文字欄位中輸入使用者名稱。請確定此使用者屬於 <systemitem class="groupname">haclient</systemitem> 群組。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        按一下並使用<xref linkend="st-ha-acl-config-hbgui-id"/>中指定的角色名稱。
       </para>
@@ -418,47 +422,47 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-acl-config-hawk">
+ </section>
+ <section xml:id="sec-ha-acl-config-hawk">
   <title>使用 Hawk 設定 ACL</title>
   
   <para>
    下面的程序說明如何透過定義 <literal>monitor</literal> 角色並將其指定給使用者，來設定對叢集組態的唯讀存取權。您也可以依照<xref linkend="pro-ha-acl-crm"/>所述使用 crmsh 來實現此目的。
   </para>
   
-  <procedure id="pro-ha-acl-hawk">
+  <procedure xml:id="pro-ha-acl-hawk">
    <title>使用 Hawk 新增 Monitor 角色並指定使用者</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>存取控制清單</guimenu>。檢視窗會顯示已定義的<guimenu>角色</guimenu>與<guimenu>使用者</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要定義 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選取<guimenu>角色</guimenu>類別並按一下加號圖示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        輸入唯一的<guimenu>角色 ID</guimenu>，例如 <literal>monitor</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        本範例是要定義一個 <literal>monitor</literal> 角色，因此請從<guimenu>權限</guimenu>下拉式方塊中選取<literal>讀取</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 <guimenu>Xpath</guimenu> 文字方塊中，輸入 Xpath 運算式 <literal>/cib</literal> 並按一下<guimenu>建立角色</guimenu>。
       </para>
@@ -466,19 +470,19 @@ Please see LICENSE.txt for this document's license.
        這會建立一個名為 <literal>monitor</literal> 的新角色，為其設定<literal>讀取</literal>權限，並使用 XPath 運算式 <literal>/cib</literal> 將其套用至 CIB 中的所有元素。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果需要，您可以透過按一下加號圖示並指定相應的參數，來新增更多的存取權限和 XPath 引數。確認您的變更。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將角色指定給使用者：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選取<guimenu>使用者</guimenu>類別並按一下加號圖示。
       </para>
@@ -486,12 +490,12 @@ Please see LICENSE.txt for this document's license.
        <guimenu>建立使用者</guimenu>檢視窗會顯示可用的角色。此外，它還包含額外的一行，用於設定該使用者的個別 ACL 規則。在該檢視窗中，您可以向使用者指定一或多個角色，<emphasis>或者</emphasis>為該使用者定義一或多個不同的規則。選取某個角色時，各個規則的行將會消失；取消選取某個角色時，該行將會顯示。您無法既指定角色又定義個別規則。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        輸入唯一的<guimenu>使用者 ID</guimenu>，例如 <literal>tux</literal>。請確定此使用者屬於 <systemitem class="groupname">haclient</systemitem> 群組。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要將角色指定給使用者，請從<guimenu>角色</guimenu>中選取相應的項目。對於本範例，請選取您所建立的 <literal>monitor</literal> 角色。
       </para>
@@ -510,12 +514,12 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </figure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果您要定義個別規則，請選取一個<guimenu>權限</guimenu>，並為要定義的規則輸入相應的 Xpath 參數。按一下加號圖示可定義更多規則。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        確認您的選擇，然後按一下<guimenu>建立使用者</guimenu>將角色或規則指定給使用者。
       </para>
@@ -527,35 +531,35 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要設定對資源或條件約束的存取權限，也可以依照<xref linkend="sec-ha-acl-config-tag"/>所述使用簡寫語法。 
   </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-acl-config-crm">
+ <section xml:id="sec-ha-acl-config-crm">
   <title>使用 crmsh 設定 ACL</title>
 
   <para>
    下面的程序說明如何透過定義 <literal>monitor</literal> 角色並將其指定給使用者，來設定對叢集組態的唯讀存取權。
   </para>
 
-  <procedure id="pro-ha-acl-crm">
+  <procedure xml:id="pro-ha-acl-crm">
    <title>使用 crmsh 新增 Monitor 角色並指定使用者</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      啟動 crmsh 的互動模式：
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure
 <prompt role="custom">crm(live)configure# </prompt></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定義 ACL 角色：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        使用 <command>role</command> 指令定義新角色：
       </para>
@@ -564,26 +568,26 @@ Please see LICENSE.txt for this document's license.
        上面的指令會建立一個名為 <literal>monitor</literal> 的新角色，為其設定<literal>讀取</literal>權限，並使用 XPath 運算式 <literal>/cib</literal> 將其套用至 CIB 中的所有元素。如果需要，您可以新增更多存取權限及 XPath 引數。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        根據需要新增其他角色。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將角色指定給一或多個 ACL 目標，即相應的系統使用者。請確定他們屬於 <systemitem class="groupname">haclient</systemitem> 群組。
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>acl_target</command> tux monitor</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查您的變更：
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      提交您的變更：
     </para>
@@ -594,6 +598,6 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要設定對資源或條件約束的存取權限，也可以依照<xref linkend="sec-ha-acl-config-tag"/>所述使用簡寫語法。 
   </para>
- </sect1>
+ </section>
  
 </chapter>

--- a/zh_TW/xml/ha_agents.xml
+++ b/zh_TW/xml/ha_agents.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_agents.xml" id="cha-ha-agents">
- <title>新增或修改資源代辦</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_agents.xml" xml:id="cha-ha-agents"><title>新增或修改資源代辦</title><info><abstract>
   <para>
    需由叢集管理的所有任務都必須當成資源使用。其中，有兩個主要群組需要注意，即資源代辦和 STONITH 代辦。對於這兩種類別，您都可以新增自己的代辦，以延伸叢集的功能來滿足自己的需要。
   </para>
- </abstract>
- <sect1 id="sec-ha-stonithagents">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-stonithagents">
   <title>STONITH 代辦</title>
 
   <para>
@@ -33,8 +37,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    到目前為止，尚沒有關於如何撰寫 STONITH 代辦的文件。若要撰寫新的 STONITH 代辦，請參閱 <systemitem class="resource">cluster-glue</systemitem> 套件原始碼中提供的範例。
   </para>
- </sect1>
- <sect1 id="sec-ha-writingresourceagents">
+ </section>
+ <section xml:id="sec-ha-writingresourceagents">
   <title>撰寫 OCF 資源代辦</title>
 
   <para>
@@ -103,18 +107,18 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      將 <filename>/usr/lib/ocf/resource.d/pacemaker/Dummy</filename> 檔案做為樣板載入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      為每個新的資源代辦新建子目錄，以避免命名衝突。例如，若您擁有資源群組 <literal>kitchen</literal> (內含資源 <literal>coffee_machine</literal>)，請將此資源新增至 <filename>/usr/lib/ocf/resource.d/kitchen/</filename> 目錄。若要存取此資源代辦，請執行 <command>crm</command> 指令：
     </para>
 <screen><command>configure</command><command>primitive</command> coffee_1 <emphasis>ocf:coffee_machine:kitchen</emphasis> ...</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      執行不同的外圍程序函數，並以不同的名稱儲存檔案。
     </para>
@@ -122,8 +126,8 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
   <para>
-   如需關於撰寫 OCF 資源代辦的更多詳細資料，請造訪 <ulink url="http://linux-ha.org/wiki/Resource_Agents"/>。有關幾個概念的特殊資訊，請參閱<xref linkend="cha-ha-concepts"/>。
+   如需關於撰寫 OCF 資源代辦的更多詳細資料，請造訪 <link xlink:href="http://linux-ha.org/wiki/Resource_Agents"/>。有關幾個概念的特殊資訊，請參閱<xref linkend="cha-ha-concepts"/>。
   </para>
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_error_codes.xml" parse="xml"/>
+ </section>
+ <xi:include href="ha_error_codes.xml" parse="xml"/>
 </chapter>

--- a/zh_TW/xml/ha_authors.xml
+++ b/zh_TW/xml/ha_authors.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE authorgroup PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE authorgroup>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<authorgroup xml:base="ha_authors.xml">
- <author><firstname>Tanja</firstname><surname>Roth</surname>
- </author>
- <author><firstname>Thomas</firstname><surname>Schraitle</surname>
- </author>
+<authorgroup xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="ha_authors.xml">
+ <author><personname version="5.1"><firstname>Tanja</firstname><surname>Roth</surname></personname></author>
+ <author><personname version="5.1"><firstname>Thomas</firstname><surname>Schraitle</surname></personname></author>
 </authorgroup>

--- a/zh_TW/xml/ha_clvm.xml
+++ b/zh_TW/xml/ha_clvm.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_clvm.xml" id="cha-ha-clvm">
- <title>叢集邏輯磁碟區管理員 (cLVM)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_clvm.xml" xml:id="cha-ha-clvm"><title>叢集邏輯磁碟區管理員 (cLVM)</title><info><abstract>
   <para>
    管理叢集上的共享儲存時，儲存子系統發生的變更必須通知到每個節點。廣泛用於管理本地儲存的 Linux Volume Manager 2 (LVM2) 已經過延伸，現可支援對整個叢集中磁碟區群組的透明管理。可使用與本地儲存相同的指令來管理叢集化磁碟區群組。
   </para>
- </abstract>
- <sect1 id="sec-ha-clvm-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-clvm-overview">
   <title>概念綜覽</title>
 
 
@@ -47,8 +51,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-clvm-config">
+ </section>
+ <section xml:id="sec-ha-clvm-config">
   <title>cLVM 的組態</title>
 
   <para>
@@ -117,7 +121,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect2 id="sec-ha-clvm-config-cmirrord">
+  <section xml:id="sec-ha-clvm-config-cmirrord">
    <title>設定 Cmirrord</title>
 
    <para>
@@ -127,12 +131,12 @@ Please see LICENSE.txt for this document's license.
     假設 <filename>/dev/sda</filename> 與 <filename>/dev/sdb</filename> 是共享儲存裝置。如有必要，請使用您自己的裝置名稱取代它們。請執行下列步驟：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       建立一個至少包含兩個節點的叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對叢集進行設定，以執行 <command>dlm</command>、<command>clvmd</command> 與 STONITH：
      </para>
@@ -150,12 +154,12 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>clone</command> base-clone base-group \
         meta interleave="true"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>exit</command> 離開 crmsh 並確定您的變更。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       建立叢集化磁碟區群組 (VG)：
 
@@ -163,45 +167,45 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> -cy vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在您的叢集中建立鏡像複製記錄邏輯磁碟區 (LV)：
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> -nlv -m1 -l10%VG vg --mirrorlog mirrored</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>lvs</command> 顯示進度。如果百分比數字已達到 100%，則表示已成功同步化鏡像複製磁碟。
      </para>
     </step>
-    <step id="st-ha-clvm-config-cmirrord-test" performance="required">
+    <step xml:id="st-ha-clvm-config-cmirrord-test">
      <para>
       若要測試叢集化磁碟區 <filename>/dev/vg/lv</filename>，可執行下列步驟：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         針對 <filename>/dev/vg/lv</filename> 執行讀取或寫入操作。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvchange</command> <option>-an</option> 停用 LV。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvchange</command> <option>-ay</option> 啟動 LV。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         使用 <command>lvconvert</command> 將鏡像複製記錄轉換成磁碟記錄。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在另一個叢集 VG 中建立鏡像複製記錄 LV。這個磁碟區群組與前面使用的磁碟區群組不同。
      </para>
@@ -216,20 +220,20 @@ Please see LICENSE.txt for this document's license.
    </para>
    <procedure>
 
-    <step performance="required">
+    <step>
      <para>
       建立磁碟區群組 (VG)：
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sda /dev/sdb
 <prompt role="root">root # </prompt><command>vgcreate</command> vg /dev/sda /dev/sdb</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       開啟檔案 <filename>/etc/lvm/lvm.conf</filename>，並轉至 <literal>allocation</literal> 區段。設定下行並儲存該檔案：
      </para>
 <screen>mirror_legs_require_separate_pvs = 1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       將您的標記新增至 PV：
      </para>
@@ -239,7 +243,7 @@ Please see LICENSE.txt for this document's license.
       標記是指定給儲存物件中繼資料的無序關鍵字或詞彙。透過使用標記，您可以為 LVM 儲存物件的中繼資料附加無序的標記清單，用實用的方式對物件集合進行分類。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       列出您的標記：
      </para>
@@ -253,11 +257,11 @@ Please see LICENSE.txt for this document's license.
     </step>
    </procedure>
    <para>
-    如需關於 LVM 的更多資訊，請參閱《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>儲存管理指南</citetitle>》中的「<citetitle>LVM 組態</citetitle>」一章，此文件位於 <ulink url="http://www.suse.com/documentation/"/>。
+    如需關於 LVM 的更多資訊，請參閱《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>儲存管理指南</citetitle>》中的「<citetitle>LVM 組態</citetitle>」一章，此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-config-resources">
+  <section xml:id="sec-ha-clvm-config-resources">
    <title>建立叢集資源</title>
    <para>
     準備要使用 cLVM 的叢集的工作包括下列基本步驟：
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-clvm-dlmresource">
+   <procedure xml:id="pro-ha-clvm-dlmresource">
     <title>建立 DLM 資源</title>
 
     <note>
@@ -283,22 +287,22 @@ Please see LICENSE.txt for this document's license.
       cLVM 與 OCFS2 都需要在叢集的所有節點上執行的 DLM 資源，因此該資源通常會設定為複製品。如果您的環境中包含 OCFS2 與 cLVM，只需為 OCFS2 與 cLVM 設定<emphasis>一個</emphasis> DLM 資源就足夠了。
      </para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       啟動外圍程序並以 <systemitem class="username">root</systemitem> 身分登入。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      執行 <command>crm <option>configure</option></command>。
+      執行 <command>crm</command> <option>configure</option>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>show</command> 檢查叢集資源的目前組態。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您已設定 DLM 資源 (以及對應的基礎群組和基礎複製品)，請繼續<xref linkend="pro-ha-clvm-lvmresources"/>。
      </para>
@@ -306,25 +310,25 @@ Please see LICENSE.txt for this document's license.
       若非如此，請依照<xref linkend="pro-ocfs2-resources"/> 所述設定 DLM 資源以及對應的基礎群組和基礎複製品。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>exit</command> 離開 crm 即時組態。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-clvm-lvmresources">
+   <procedure xml:id="pro-ha-clvm-lvmresources">
     <title>建立 LVM 及 cLVM 資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動外圍程序並以 <systemitem class="username">root</systemitem> 身分登入。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
-      執行 <command>crm <option>configure</option></command>。
+      執行 <command>crm</command> <option>configure</option>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按如下方式設定 cLVM 資源：
      </para>
@@ -333,7 +337,7 @@ Please see LICENSE.txt for this document's license.
 
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       按如下方式為磁碟區群組設定 LVM 資源：
      </para>
@@ -341,7 +345,7 @@ Please see LICENSE.txt for this document's license.
       params volgrpname="cluster-vg" \
       op monitor interval="60" timeout="60"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您希望磁碟區群組在<emphasis>一個</emphasis>節點上以獨佔模式啟用，請依照如下方式設定 LVM 資源並省略<xref linkend="step-ha-clvm-lvmresources-group"/>：
      </para>
@@ -352,18 +356,18 @@ Please see LICENSE.txt for this document's license.
       如此，cLVM 將保護 VG 內的所有邏輯磁碟區，避免它們在多個節點上啟用，這是保護非叢集化應用程式的另一種方法。
      </para>
     </step>
-    <step id="step-ha-clvm-lvmresources-group" performance="required">
+    <step xml:id="step-ha-clvm-lvmresources-group">
      <para>
       為了確保在整個叢集內啟用 cLVM 與 LVM 資源，請將這兩種基本資源新增至您在<xref linkend="pro-ocfs2-resources"/> 中建立的基礎群組︰
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         輸入
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>edit</command> base-group</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在開啟的 vi 編輯器中，對群組做如下修改並儲存所做的變更：
        </para>
@@ -377,25 +381,25 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>show</command> 檢閱所做的變更。若要檢查您是否已設定所有的必要資源，另請參閱<xref linkend="cha-ha-config-example"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果所有設定都正確，請使用 <command>commit</command> 提交變更，然後使用 <command>exit</command> 離開 crm 即時組態。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-clvm-scenario-iscsi">
+  <section xml:id="sec-ha-clvm-scenario-iscsi">
    <title>案例︰SAN 上 cLVM 與 iSCSI 搭配使用</title>
    <para>
     以下案例將使用兩個 SAN Box，它們會將 iSCSI 目標輸出至多個用戶端。<xref linkend="fig-ha-clvm-scenario-iscsi"/> 中說明了一般的情況。
    </para>
-   <figure id="fig-ha-clvm-scenario-iscsi">
+   <figure xml:id="fig-ha-clvm-scenario-iscsi">
     <title>cLVM 搭配 iSCSI 的設定</title>
     <mediaobject>
      <imageobject role="fo">
@@ -416,80 +420,80 @@ Please see LICENSE.txt for this document's license.
     開始請只設定一個 SAN Box。每個 SAN Box 需要輸出自己的 iSCSI 目標。請執行下列步驟：
    </para>
 
-   <procedure id="pro-ha-clvm-scenario-iscsi-targets">
+   <procedure xml:id="pro-ha-clvm-scenario-iscsi-targets">
     <title>設定 iSCSI 目標 (SAN)</title>
-    <step performance="required">
+    <step>
      <para>
       執行 YaST，然後按一下<menuchoice><guimenu>網路服務</guimenu> <guimenu>iSCSI 目標</guimenu></menuchoice>，啟動 iSCSI 伺服器模組。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您希望電腦每次開機時啟動 iSCSI 目標，請選擇<guimenu>開機時</guimenu>，否則請選擇<guimenu>手動</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果有防火牆在執行，則啟用<guimenu>在防火牆中開啟埠</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切換至<guimenu>全域</guimenu>索引標籤。如果需要驗證，請啟用內送驗證、外送驗證或兩者均啟用。在本例中，我們選取的是<guimenu>無驗證</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新增新的 iSCSI 目標︰
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         切換至<guimenu>目標</guimenu>索引標籤。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         按一下<guimenu>新增</guimenu>。
        </para>
       </step>
-      <step id="st-ha-clvm-iscsi-iqn" performance="required">
+      <step xml:id="st-ha-clvm-iscsi-iqn">
        <para>
         輸入目標名稱。名稱需要採用以下格式︰
        </para>
 <screen>iqn.<replaceable>DATE</replaceable>.<replaceable>DOMAIN</replaceable></screen>
        <para>
-        如需該格式的詳細資訊，請參閱<citetitle>第 3.2.6.3.1 節「Type "iqn." (iSCSI Qualified Name)」</citetitle>(「iqn.」(iSCSI 合格名稱) 類型)，網址為︰<ulink url="http://www.ietf.org/rfc/rfc3720.txt"/>。
+        如需該格式的詳細資訊，請參閱<citetitle>第 3.2.6.3.1 節「Type "iqn." (iSCSI Qualified Name)」</citetitle>(「iqn.」(iSCSI 合格名稱) 類型)，網址為︰<link xlink:href="http://www.ietf.org/rfc/rfc3720.txt"/>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果您想使用更具描述性的名稱，可以變更名稱，只要確保每個目標的識別碼都是唯一的即可。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         按一下<guimenu>新增</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>路徑</guimenu>中輸入裝置名稱，並使用<guimenu>Scsiid</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         按兩次<guimenu>下一步</guimenu>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       出現警告對話方塊時，按一下<guimenu>是</guimenu>加以確認。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       開啟組態檔案 <filename>/etc/iscsi/iscsi.conf</filename>，並將參數 <literal>node.startup</literal> 變更為 <literal>automatic</literal>。
      </para>
@@ -498,71 +502,71 @@ Please see LICENSE.txt for this document's license.
    <para>
     接著，按如下所示設定 iSCSI 啟動器︰
    </para>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-initiator">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-initiator">
     <title>設定 iSCSI 啟動器</title>
-    <step performance="required">
+    <step>
      <para>
       執行 YaST，然後按一下<menuchoice><guimenu>網路服務</guimenu> <guimenu>iSCSI 啟動器</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您要在電腦開機時啟動 iSCSI 啟動器，請選擇<guimenu>開機時</guimenu>，否則請設定<guimenu>手動</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切換至<guimenu>探查</guimenu>索引標籤，然後按一下<guimenu>探查</guimenu>按鈕。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       新增 iSCSI 目標的 IP 位址和連接埠 (請參閱<xref linkend="pro-ha-clvm-scenario-iscsi-targets"/>)。一般不用變更連接埠，使用其預設值即可。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用驗證，請插入內送及外送的使用者名稱和密碼，否則請啟用<guimenu>無驗證</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<guimenu>下一步</guimenu>。清單中會顯示找到的連接。
      </para>
     </step>
     
-    <step performance="required">
+    <step>
      <para>若要測試 iSCSI 啟動器是否已成功啟動，請選取顯示的目標之一，然後按一下<guimenu>登入</guimenu>。</para>
     </step>
 
    </procedure>
-   <procedure id="pro-ha-clvm-scenarios-iscsi-lvm">
+   <procedure xml:id="pro-ha-clvm-scenarios-iscsi-lvm">
     <title>建立 LVM 磁碟區群組</title>
-    <step performance="required">
+    <step>
      <para>
       在其中一個您於 <xref linkend="pro-ha-clvm-scenarios-iscsi-initiator"/> 中執行了 iSCSI 啟動器的節點上開啟 <systemitem class="username">root</systemitem> 外圍程序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對磁碟 <filename>/dev/sdd</filename> 和 <filename>/dev/sde</filename> 使用指令 <command>pvcreate</command>，為 LVM 準備好實體磁碟區︰
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/sdd
 <prompt role="root">root # </prompt><command>pvcreate</command> /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在兩個磁碟上建立叢集感知磁碟區群組︰
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y clustervg /dev/sdd /dev/sde</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根據需要建立邏輯磁碟區︰
      </para>
 <screen><prompt role="root">root # </prompt><command>lvcreate</command> --name clusterlv --size 500M clustervg</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>pvdisplay</command> 檢查實體磁碟區：
      </para>
@@ -588,7 +592,7 @@ Please see LICENSE.txt for this document's license.
       Allocated PE          0
       PV UUID               Ouj3Xm-AI58-lxB1-mWm2-xn51-agM2-0UuHFC</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>vgdisplay</command> 檢查磁碟區群組：
      </para>
@@ -621,28 +625,28 @@ Please see LICENSE.txt for this document's license.
    </para>
 
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-clvm-scenario-drbd">
+  <section xml:id="sec-ha-clvm-scenario-drbd">
    <title>案例︰cLVM 與 DRBD 搭配</title>
    <para>
     如果您的資料中心分佈在城市、國家甚至大陸的不同位置，可以參照以下案例。
    </para>
-   <procedure id="pro-ha-clvm-withdrbd">
+   <procedure xml:id="pro-ha-clvm-withdrbd">
     <title>使用 DRBD 建立叢集感知磁碟區群組</title>
-    <step performance="required">
+    <step>
      <para>
       建立主要/次要 DRBD 資源︰
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         首先，如<xref linkend="step-drbd-configure"/> 中所述將一部 DRBD 裝置設定成主要或次要裝置。確定兩個節點上的磁碟狀態均為<literal>最新</literal>。可以使用 <command>cat</command> <option>/proc/drbd</option> 或 <command>rcdrbd</command> <option>status</option> 指令來檢查。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在組態檔案 (通常類似於 <filename>/etc/drbd.d/r0.res</filename>) 中新增以下選項︰
        </para>
@@ -657,13 +661,13 @@ Please see LICENSE.txt for this document's license.
   ...
 }</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         將變更後的組態檔案複製到另一個節點，例如︰
        </para>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.d/r0.res venus:/etc/drbd.d/</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<emphasis>兩個</emphasis>節點上執行以下指令︰
        </para>
@@ -671,7 +675,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="root">root # </prompt><command>drbdadm</command> connect r0
 <prompt role="root">root # </prompt><command>drbdadm</command> primary r0</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         檢查節點的狀態︰
        </para>
@@ -681,24 +685,24 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       將 clvmd 資源做為複製品包括在 Pacemaker 組態中，並使之依賴於 DLM 複製品資源。如需詳細指示，請參閱<xref linkend="pro-ha-clvm-dlmresource"/>。繼續之前，請先確定已在叢集中成功啟動這些資源。您可以使用 <command>crm_mon</command> 或 Web 介面檢查執行中的服務。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>pvcreate</command> 指令為 LVM 備妥實體磁碟區。例如，在 <filename>/dev/drbd_r0</filename> 裝置上使用如下指令︰
      </para>
 <screen><prompt role="root">root # </prompt><command>pvcreate</command> /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       建立叢集感知磁碟區群組︰
      </para>
 <screen><prompt role="root">root # </prompt><command>vgcreate</command> --clustered y myclusterfs /dev/drbd_r0</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根據需要建立邏輯磁碟區。您有時可能需要變更邏輯磁碟區的大小。例如，使用以下指令建立一個 4 GB 的邏輯磁碟區：
      </para>
@@ -706,7 +710,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       
       現在，VG 中的邏輯磁碟區便可做為掛接的檔案系統或原始用途使用。請確保使用它們的服務具有正確的相依性，這樣才能在啟動 VG 後對它們進行並存和排序處理。
@@ -716,9 +720,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     完成這些組態設定步驟後，便能像在任何獨立工作站上一般進行 LVM2 組態設定。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-clvm-drbd">
+  </section>
+ </section>
+ <section xml:id="sec-ha-clvm-drbd">
   <title>明確設定適合的 LVM2 裝置</title>
 
   <para>
@@ -734,17 +738,17 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      編輯 <filename>/etc/lvm/lvm.conf</filename> 檔案並搜尋以 <literal>filter</literal> 開頭的行。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      該處的模式將被視為正規表示式進行處理。前置 <quote>a</quote> 表示接受要掃描的裝置模式，前置 <quote>r</quote> 表示拒絕依照該裝置模式的裝置。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要移除名為 <filename>/dev/sdb1</filename> 的裝置，請將下列表示式新增至過濾器規則：
     </para>
@@ -759,22 +763,22 @@ Please see LICENSE.txt for this document's license.
 <screen>filter = [ "a|/dev/drbd.*|", "a|/dev/.*/by-id/dm-uuid-mpath-.*|", "r/.*/" ]</screen>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      寫入組態檔案並將其複製到所有叢集節點。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-clvm-more">
+ </section>
+ <section xml:id="sec-ha-clvm-more">
   <title>更多資訊</title>
 
   <para>
-   完整資訊可參閱 Pacemaker 郵寄清單 (網址為 <ulink url="http://www.clusterlabs.org/wiki/Help:Contents"/>)。
+   完整資訊可參閱 Pacemaker 郵寄清單 (網址為 <link xlink:href="http://www.clusterlabs.org/wiki/Help:Contents"/>)。
   </para>
 
   <para>
-   官方 cLVM FAQ 可在 <ulink url="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/> 中找到。
+   官方 cLVM FAQ 可在 <link xlink:href="http://sources.redhat.com/cluster/wiki/FAQ/CLVM"/> 中找到。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_concepts.xml
+++ b/zh_TW/xml/ha_concepts.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_concepts.xml" id="cha-ha-concepts">
- <title>產品綜覽</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_concepts.xml" xml:id="cha-ha-concepts"><title>產品綜覽</title><info><abstract>
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 是一個採用開放原始碼叢集技術的整合式套裝軟體，它可讓您實作高可用性的實體和虛擬 Linux 叢集，並可避免單一故障點。該套裝軟體可確保資料、應用程式和服務等重要網路資源的高可用性及可管理性。因此，可協助您保持業務持續運作，保護資料完整性，並可降低關鍵任務 Linux 工作負載的意外停機時間。
   </para>
@@ -23,21 +25,23 @@ Please see LICENSE.txt for this document's license.
   <para>
    High Availability Extension 叢集內容中使用的一些常見詞彙，可以在<xref linkend="gl-heartb"/> 中找到相關說明。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-availability">
+ 
+ 
+ <section xml:id="sec-ha-availability">
   <title>以附加產品/延伸形式提供</title>
   <para>High Availability Extension 做為 SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 的附加產品提供。對地理位置分散的叢集 (地理叢集) 的支援是以 High Availability Extension 的一個獨立延伸形式透提供的，稱為 Geo Clustering for SUSE Linux Enterprise High Availability Extension。 </para>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-features">
+ <section xml:id="sec-ha-features">
   <title>主要功能</title>
 
   <para>
    <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 可協助您確保和管理網路資源的可用性。下面幾節重點介紹了部分主要功能：
   </para>
 
-  <sect2 id="sec-ha-features-scenarios">
+  <section xml:id="sec-ha-features-scenarios">
    <title>眾多叢集情境</title>
    <para>
     High Availability Extension 支援以下情境︰
@@ -77,30 +81,30 @@ Please see LICENSE.txt for this document's license.
    <para>
     叢集最多可以包含 32 個 Linux 伺服器。可以使用叢集內的任一伺服器重新啟動同一叢集中之失敗伺服器中的資源 (應用程式、服務、IP 位址和檔案系統)。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-flexibility">
+  <section xml:id="sec-ha-features-flexibility">
    <title>靈活性</title>
    <para>
     High Availability Extension 附帶 Corosync/OpenAIS 訊息傳送與成員層及 Pacemaker 叢集資源管理員。使用 Pacemaker，管理員可以持續監控其資源的狀態，管理相依性，並能根據可靈活設定的多種規則自動停止和啟動服務。High Availability Extension 可讓您對叢集量身打造，以包含滿足貴組織需求的特定應用程式和硬體架構。時間相關組態可讓服務在指定時間自動移轉回已修復節點。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-storage">
+  <section xml:id="sec-ha-features-storage">
    <title>儲存與資料複製</title>
    <para>
     使用 High Availability Extension，您可以視需要動態指定和重新指定伺服器儲存。它支援光纖通道或 iSCSI 儲存區域網路 (SAN)。還支援共享磁碟系統，但這些系統並非必要系統。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 還隨附了叢集感知檔案系統與磁碟區管理員 (OCFS2) 及叢集化邏輯磁碟區管理員 (cLVM)。對於資料複製，可以使用 DRBD*，將高可用性服務的資料自叢集的使用中節點鏡像複製到待命節點。此外，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 還支援一種用於 Samba 叢集的技術︰CTDB (叢集化簡單資料庫，Clustered Trivial Database)。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-virtualized">
+  <section xml:id="sec-ha-features-virtualized">
    <title>支援虛擬化環境</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 支援包含實體與虛擬 Linux 伺服器的混合叢集。SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 附帶了 Xen (一種開放原始碼虛擬化監管程式) 和 KVM (核心虛擬機器，Kernel-based Virtual Machine)，後者是 Linux 系統的虛擬化軟體，以硬體虛擬化延伸為基礎。High Availability Extension 中的叢集資源管理員可辨識、監控和管理虛擬伺服器以及實體伺服器中執行的服務。叢集可以將訪客系統做為服務進行管理。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-geo">
+  <section xml:id="sec-ha-features-geo">
    <title>本地叢集、城際叢集與地理叢集支援</title>
    <para> <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 已經過延伸，可支援多種不同的地理分佈情境。對地理位置分散的叢集 (地理叢集) 的支援是以 High Availability Extension 的一個獨立延伸形式透提供的，稱為 Geo Clustering for SUSE Linux Enterprise High Availability Extension。 </para>
    <variablelist>
@@ -132,16 +136,16 @@ Please see LICENSE.txt for this document's license.
    <para>
     各叢集節點之間的地理位置相隔越遠，可能干擾叢集所提供服務的高可用性的因素就越多。網路延遲、有限的頻寬和對儲存的存取是遠距離叢集面臨的主要挑戰。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-ra">
+  <section xml:id="sec-ha-features-ra">
    <title>資源代辦</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 中包含大量資源代辦，用於管理 Apache、IPv4、IPv6 等眾多資源。它還內建有適用於 IBM WebSphere Application Server 等廣受歡迎的協力廠商應用程式的資源代辦。如需產品隨附的 Open Cluster Framework (OCF) 資源代辦綜覽，請依照<xref linkend="sec-ha-manual-config-ocf"/>所述使用 <command>crm ra</command> 指令。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-features-tools">
+  <section xml:id="sec-ha-features-tools">
    <title>簡單易用的管理工具</title>
    <para>
     High Availability Extension 附帶一組功能強大的工具，可用於對叢集進行基本的安裝和設定，以及有效地設定組態和執行管理任務︰
@@ -198,9 +202,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-benefits">
+  </section>
+ </section>
+ <section xml:id="sec-ha-benefits">
   <title>優點</title>
 
   <para>
@@ -358,8 +362,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    例如，您可以手動將網站 A 或網站 B 從 Web 伺服器 1 移至叢集中的任一其他伺服器。此操作的使用案例包括，對 Web 伺服器 1 進行升級或執行排程維護，或者提高網站的效能或存取性。
   </para>
- </sect1>
- <sect1 id="sec-ha-clusterconfig">
+ </section>
+ <section xml:id="sec-ha-clusterconfig">
   <title>叢集組態：儲存</title>
 
   <para>
@@ -420,20 +424,20 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect1>
- <sect1 id="sec-ha-architecture">
+ </section>
+ <section xml:id="sec-ha-architecture">
   <title>結構</title>
 
   <para>
    本節將概要介紹 High Availability Extension 的結構。它識別並提供有關結構元件的資訊，並說明這些元件如何相互操作。
   </para>
 
-  <sect2 id="sec-ha-architecture-layers">
+  <section xml:id="sec-ha-architecture-layers">
    <title>結構層</title>
    <para>
     High Availability Extension 採用分層結構。<xref linkend="fig-ha-architecture" xrefstyle="FigureXRef"/> 說明不同的層及其相關的元件。
    </para>
-   <figure id="fig-ha-architecture">
+   <figure xml:id="fig-ha-architecture">
     <title>結構</title>
     <mediaobject>
      <imageobject role="fo">
@@ -444,19 +448,19 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-   <sect3 id="sec-ha-architecture-layers-messaging">
+   <section xml:id="sec-ha-architecture-layers-messaging">
     <title>訊息傳送與基礎架構層</title>
     <para>
      主要層或第一層為訊息傳送/基礎架構層，也稱為 Corosync/OpenAIS 層。此層包含送出含有<quote>I'm alive</quote>(我存在) 訊號及其他資訊之訊息的元件。High Availability Extension 的程式存放在訊息傳送/基礎架構層。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-allocation">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-allocation">
     <title>資源配置層</title>
     <para>
      下一層為資源配置層。此層最為複雜，由下列元件組成：
     </para>
     <variablelist>
-     <varlistentry id="vle-crm">
+     <varlistentry xml:id="vle-crm">
       <term>叢集資源管理員 (CRM)</term>
       <listitem>
        <para>
@@ -464,7 +468,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-cib">
+     <varlistentry xml:id="vle-cib">
       <term>叢集資訊庫 (CIB)</term>
       <listitem>
        <para>
@@ -472,7 +476,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-dc">
+     <varlistentry xml:id="vle-dc">
       <term>指定協調者 (DC)</term>
       <listitem>
        <para>
@@ -480,7 +484,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-pe-and-te">
+     <varlistentry xml:id="vle-pe-and-te">
       <term>規則引擎 (PE)</term>
       <listitem>
        <para>
@@ -488,7 +492,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </listitem>
      </varlistentry>
-     <varlistentry id="vle-lrm">
+     <varlistentry xml:id="vle-lrm">
       <term>本地資源管理員 (LRM)</term>
       <listitem>
        <para>
@@ -498,16 +502,16 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-   </sect3>
-   <sect3 id="sec-ha-architecture-layers-resources">
+   </section>
+   <section xml:id="sec-ha-architecture-layers-resources">
     <title>資源層</title>
     <para>
      最高層為資源層。資源層包含一或多個資源代辦 (RA)。資源代辦是用於啟動、停止和監控特定種類的服務 (資源) 的程式 (通常是外圍程序檔)。資源代辦僅可由 LRM 呼叫。協力廠商可以將他們自己的代辦包含在檔案系統中的已定義位置，從而為他們自己的軟體提供即裝即用的叢集整合功能。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-architecture-processflow">
+  <section xml:id="sec-ha-architecture-processflow">
    <title>程序流程</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 使用 Pacemaker 做為 CRM。CRM 被當做精靈 (<literal>crmd</literal>) 來實作，即在每個叢集節點上都有一個例項。Pacemaker 會選出一個 crmd 例項做為主要例項，以此來集中所有叢集決策。如果所選的 crmd 程序 (或它所在的節點) 失敗，則會建立一個新的 crmd 程序。
@@ -530,6 +534,6 @@ Please see LICENSE.txt for this document's license.
    <para>
     在某些情況下，可能需要關閉節點以保護共享資料或完成資源復原。為執行此操作，Pacemaker 提供了圍籬區隔子系統 stonithd。STONITH 是<quote>Shoot The Other Node In The Head</quote>的縮寫，通常透過一個遠端電源交換器來實作。在 Pacemaker 中，STONITH 裝置會模型化為資源 (並在 CIB 中進行設定)，以便輕鬆監控其是否發生故障。不過，stonithd 負責瞭解 STONITH 拓樸，因此，其用戶端只需發出圍籬區隔一個節點的要求，其餘的工作則由 stonithd 完成。
    </para>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_config_basics.xml
+++ b/zh_TW/xml/ha_config_basics.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_basics.xml" id="cha-ha-config-basics">
- <title>組態與管理基礎</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_basics.xml" xml:id="cha-ha-config-basics"><title>組態與管理基礎</title><info><abstract>
   <para>
    HA 叢集的主要目的是管理使用者服務。Apache Web 伺服器或資料庫便是使用者服務的典型範例。從使用者的角度來看，命令這些服務執某些特定操作，它們就會按要求執行。不過，對於叢集而言，它們只是可以啟動或停止的資源 — 服務的性質與叢集無關。
   </para>
@@ -15,18 +17,20 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章介紹一些設定資源和管理叢集時需瞭解的基本概念。後續章節將介紹如何使用 High Availability Extension 提供的各種管理工具執行主要的組態與管理任務。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-basics-global">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-basics-global">
   <title>全域叢集選項</title>
 
   <para>
    全域叢集選項控制叢集在遇到特定情況時的運作方式。這些選項分為不同的組，您可以使用 Hawk 與 <command>crm</command> 外圍程序等叢集管理工具來檢視和修改它們。
   </para>
 
-  <sect2 id="sec-ha-config-basics-global-all">
+  <section xml:id="sec-ha-config-basics-global-all">
    <title>綜覽</title>
    <para>
-    若想瞭解所有全域叢集選項及其預設值，請參閱 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Available Cluster Options</citetitle>」(可用的叢集選項) 一節。
+    若想瞭解所有全域叢集選項及其預設值，請參閱 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Available Cluster Options</citetitle>」(可用的叢集選項) 一節。
    </para>
    <para>
     一般情況下，可以保留預先定義的值。但是，為了讓叢集的關鍵功能正常運作，還需要在執行基本叢集設定後調整以下參數：
@@ -65,9 +69,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
-  <sect2 id="sec-ha-config-basics-global-quorum">
+  <section xml:id="sec-ha-config-basics-global-quorum">
    <title><literal>no-quorum-policy</literal> 選項</title>
    <para>
     此全域選項定義在叢集分割區沒有達到最低節點數 (節點多數不是該分割區的一部分) 時如何運作。
@@ -133,9 +137,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-global-stonith">
+  <section xml:id="sec-ha-config-basics-global-stonith">
    <title><literal>stonith-enabled</literal> 選項</title>
    <para>
     此全域選項定義是否套用圍籬區隔，以便允許 STONITH 裝置關閉故障節點以及其上資源無法停止的節點。此全域選項預設為 <literal>true</literal>，因為正常的叢集運作需要使用 STONITH 裝置。依據預設值，如果未定義 STONITH 資源，叢集將拒絕啟動任何資源。
@@ -150,16 +154,16 @@ Please see LICENSE.txt for this document's license.
      系統不支援沒有 STONITH 的叢集。
     </para>
    </important>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-resources">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-resources">
   <title>叢集資源</title>
 
   <para>
    做為叢集管理員，您需要為您叢集中的伺服器上執行的所有資源或應用程式建立叢集資源。叢集資源可包括網站、電子郵件伺服器、資料庫、檔案系統、虛擬機器，以及其他您希望使用者隨時都可以存取的伺服器型應用程式或服務。
   </para>
 
-  <sect2 id="sec-ha-config-basics-resources-management">
+  <section xml:id="sec-ha-config-basics-resources-management">
    <title>資源管理</title>
 
    <para>
@@ -197,9 +201,9 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-raclasses">
+  <section xml:id="sec-ha-config-basics-raclasses">
    <title>受支援的資源代辦類別</title>
    <para>
     對於每個新增的叢集資源，都需要定義資源代辦所遵循的標準。資源代辦會提取它們所提供的服務並向叢集提供準確的狀態，這樣叢集便可不理會其所管理的資源。當接收到啟動、停止或監控指令時，叢集會依賴資源代辦來做出恰當的反應。
@@ -212,18 +216,18 @@ Please see LICENSE.txt for this document's license.
      <term>Linux Standards Base (LSB) 程序檔</term>
      <listitem>
       <para>
-       LSB 資源代辦通常由作業系統/套裝作業系統提供，位於 <filename>/etc/init.d</filename>。若要與叢集一起使用，它們必須符合 LSB init 程序檔規格。例如，它們必須執行幾個動作，至少包含 <literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal> 和 <literal>status</literal>。如需詳細資訊，請參閱<ulink url="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>。
+       LSB 資源代辦通常由作業系統/套裝作業系統提供，位於 <filename>/etc/init.d</filename>。若要與叢集一起使用，它們必須符合 LSB init 程序檔規格。例如，它們必須執行幾個動作，至少包含 <literal>start</literal>、<literal>stop</literal>、<literal>restart</literal>、<literal>reload</literal>、<literal>force-reload</literal> 和 <literal>status</literal>。如需詳細資訊，請參閱<link xlink:href="http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html"/>。
       </para>
       <para>
        這些服務的組態尚未標準化。如果要將 LSB 程序檔與 High Availability 搭配使用，請確定您瞭解如何設定相關程序檔。相關資訊通常可以在 <filename>/usr/share/doc/packages/<replaceable>套件名稱</replaceable></filename>目錄中相關套件的文件內找到。
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-resources-ocf-ra">
+    <varlistentry xml:id="vle-ha-resources-ocf-ra">
      <term>Open Cluster Framework (OCF) 資源代辦</term>
      <listitem>
       <para>
-       OCF RA 代辦最適合與高可用性搭配使用，特別是在您需要多狀態資源或特殊監控功能的情況下。代辦通常位於 <filename>/usr/lib/ocf/resource.d/<replaceable>提供者</replaceable>/</filename> 內。它們的功能類似於 LSB 程序檔。但是，組態始終使用環境變數進行設定，因此它們更容易接受並處理參數。OCF 規格 (與資源代辦相關時) 位於 <ulink url="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/>。OCF 規格對於動作必須傳回的離開碼有著嚴格的定義，請參閱<xref linkend="sec-ha-errorcodes"/>。叢集完全遵循這些規格。 
+       OCF RA 代辦最適合與高可用性搭配使用，特別是在您需要多狀態資源或特殊監控功能的情況下。代辦通常位於 <filename>/usr/lib/ocf/resource.d/<replaceable>提供者</replaceable>/</filename> 內。它們的功能類似於 LSB 程序檔。但是，組態始終使用環境變數進行設定，因此它們更容易接受並處理參數。OCF 規格 (與資源代辦相關時) 位於 <link xlink:href="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/>。OCF 規格對於動作必須傳回的離開碼有著嚴格的定義，請參閱<xref linkend="sec-ha-errorcodes"/>。叢集完全遵循這些規格。 
       </para>
 
 
@@ -251,9 +255,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     High Availability Extension 隨附的代辦將寫入 OCF 規格。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-types">
+  <section xml:id="sec-ha-config-basics-resources-types">
    <title>資源類型</title>
    <para>
     以下是可建立的資源類型：
@@ -312,9 +316,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-templates">
+  <section xml:id="sec-ha-config-basics-resources-templates">
    <title>資源樣板</title>
    <para>
     如果您要建立大量具有相似組態的資源，定義資源樣板是最輕鬆的方法。定義資源樣板後，便可在基本資源或某些類型的條件約束中參考該樣板，如<xref linkend="sec-ha-config-basics-constraints-templates"/>所述。
@@ -338,19 +342,19 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-resources-advanced">
+  <section xml:id="sec-ha-config-basics-resources-advanced">
    <title>進階資源類型</title>
    <para>
     基本資源是最簡單的資源類型，因此設定很簡單，不過您的叢集組態可能還需要更進階的資源類型，例如群組、複製品或多狀態資源。
    </para>
-   <sect3 id="sec-ha-config-basics-resources-advanced-groups">
+   <section xml:id="sec-ha-config-basics-resources-advanced-groups">
     <title>群組</title>
     <para>
      有些叢集資源依存於其他元件或資源，它們要求每個元件或資源以特定順序啟動並與其相依的資源在同一伺服器上執行。若要簡化此組態，您可以使用叢集資源群組。
     </para>
-    <example id="ex-ha-config-resource-group">
+    <example xml:id="ex-ha-config-resource-group">
      <title>Web 伺服器的資源群組</title>
      <para>
       需要 IP 位址與檔案系統的 Web 伺服器就是資源群組的一個範例。在此範例中，每個元件都是組合成一個叢集資源群組中的獨立資源。資源群組將在一或多個伺服器上執行。若軟體或硬體出現異常，群組會容錯移轉至叢集中的另一個伺服器，這一點與個別叢集資源類似。
@@ -442,8 +446,8 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-clones">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-clones">
     <title>複製品</title>
     <para>
      您可能要讓某些資源同時在叢集的多個節點上執行。若要實現此目的，您必須將資源設定為複製品。STONITH 及叢集檔案系統 (如 OCFS2) 這些資源便可以設定為複製品。您可以複製所提供的任何資源。相關資源的資源代辦會為此操作提供支援。您甚至可以對複製品資源進行不同的設定，具體視代管它們的節點而定。
@@ -481,7 +485,7 @@ Please see LICENSE.txt for this document's license.
      複製品只能包含一個群組或一個一般資源。
     </para>
     <para>
-     設定資源監控或條件約束時，複製品的要求與簡單資源不同。如需詳細資料，請參閱 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Clones - Resources That Should be Active on Multiple Hosts</citetitle>」(複製品 - 應在多個主機上啟動的資源) 一節。
+     設定資源監控或條件約束時，複製品的要求與簡單資源不同。如需詳細資料，請參閱 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Clones - Resources That Should be Active on Multiple Hosts</citetitle>」(複製品 - 應在多個主機上啟動的資源) 一節。
     </para>
     <para>
      瞭解如何使用偏好的叢集管理工具建立複製品：
@@ -503,24 +507,24 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-resources-advanced-masters">
+   </section>
+   <section xml:id="sec-ha-config-basics-resources-advanced-masters">
     <title>多狀態資源</title>
     <para>
      多狀態資源是一種特殊的複製品。它們允許例項處於兩種中的其中一種操作模式 (稱為<literal>主要</literal>或<literal>從屬</literal>，不過您也可以依照自己的想法來命名這些模式)。多狀態資源只能包含一個群組或一個一般資源。
     </para>
     <para>
-     設定資源監控或條件約束時，多狀態資源的要求與簡單資源不同。如需詳細資料，請參閱 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Multi-state - Resources That Have Multiple Modes</citetitle>」(多狀態 - 有多種模式的資源) 一節。
+     設定資源監控或條件約束時，多狀態資源的要求與簡單資源不同。如需詳細資料，請參閱 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。詳情位於「<citetitle>Multi-state - Resources That Have Multiple Modes</citetitle>」(多狀態 - 有多種模式的資源) 一節。
     </para>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-meta-attr">
+  <section xml:id="sec-ha-config-basics-meta-attr">
    <title>資源選項 (中繼屬性)</title>
    <para>
     對於新增的每個資源，您都可以定義選項。叢集使用選項來決定資源的行為方式 — 它們會告知 CRM 如何處理特定資源。資源選項可透過 <command>crm_resource --meta</command> 指令或 Pacemaker GUI (如<xref linkend="pro-ha-config-gui-parameters"/> 所述) 來設定。您也可以使用 Hawk 來設定：<xref linkend="pro-ha-config-hawk-primitives"/>。
    </para>
-   <table id="tab-ha-basics-meta">
+   <table xml:id="tab-ha-basics-meta">
     <title>基本資源選項</title>
     <tgroup cols="3">
      <thead>
@@ -775,9 +779,9 @@ Please see LICENSE.txt for this document's license.
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-inst-attr">
+  <section xml:id="sec-ha-config-basics-inst-attr">
    <title>例項屬性 (參數)</title>
 
 
@@ -869,9 +873,9 @@ monitor_0     interval=5s timeout=20s</screen>
      請注意，群組、複製品和多狀態資源沒有例項屬性。但是，群組、複製品或多狀態資源的子代會繼承任何例項屬性集。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-operations">
+  <section xml:id="sec-ha-config-basics-operations">
    <title>資源操作</title>
    <para>
     叢集預設不會確保資源仍正常。若要指示叢集確保資源能正常運作，您需要在資源定義中新增監控操作。可為所有類別或資源代辦新增監控操作。若需更多資訊，請參閱<xref linkend="sec-ha-config-basics-monitoring"/>。
@@ -1050,9 +1054,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </tbody>
     </tgroup>
    </table>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-timeouts">
+  <section xml:id="sec-ha-config-basics-timeouts">
    <title>逾時值</title>
    <para>
     以下參數可能會影響資源的逾時值：
@@ -1112,38 +1116,38 @@ monitor_0     interval=5s timeout=20s</screen>
    </para>
    <procedure>
     <title>確定逾時值</title>
-    <step performance="required">
+    <step>
      <para>
       檢查啟動和停止資源所需的時間 (負載狀態下)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要，請新增  <varname>op_defaults</varname>  參數並相應地設定 (預設) 逾時值：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         例如，將 <literal>op_defaults</literal> 設定為 <literal>60</literal> 秒：
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt> op_defaults timeout=60</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         對於需要較長時間的資源，請單獨定義每個逾時值。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為資源設定操作時，請新增獨立的 <literal>start</literal> 和 <literal>stop</literal> 操作。使用 Hawk 設定操作時，它將為這些操作提供有用的逾時建議。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitoring">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitoring">
   <title>資源監控</title>
 
   <para>
@@ -1211,15 +1215,15 @@ monitor_0     interval=5s timeout=20s</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-config-basics-constraints">
+ </section>
+ <section xml:id="sec-ha-config-basics-constraints">
   <title>資源條件約束</title>
 
   <para>
    設定所有資源只是工作的一部分。即使叢集瞭解所有必需的資源，可能仍然無法正確地對其進行處理。資源條件約束可讓您指定資源可在哪些叢集節點上執行，載入資源的順序以及特定資源所依賴的其他資源。
   </para>
 
-  <sect2 id="sec-ha-config-basics-constraints-types">
+  <section xml:id="sec-ha-config-basics-constraints-types">
    <title>條件約束類型</title>
    <para>
     系統中的條件約束分為三種類型：
@@ -1251,16 +1255,16 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-   <sect3 id="sec-ha-config-basics-constraints-rscset">
+   <section xml:id="sec-ha-config-basics-constraints-rscset">
     <title>資源組</title>
 
     <para/>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints">
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints">
      <title>使用資源集定義條件約束</title>
      <para>
       您可以使用另一種形式來定義位置、並存或順序條件約束，即<literal>資源集</literal>，使用此方式，基本資源會全部歸到一個集中。以前，為了實現此目的，需要定義一個資源群組 (並不總是能準確反映出設計目的)，或者將每種關係定義為個別的條件約束。隨著資源和組合數量的增長，後一種方法會導致條件約束劇增。透過資源集進行設定不一定會降低繁瑣性，但更易於理解和維護，如以下範例中所示。
      </para>
-     <example id="ex-config-basic-resourceset-loc">
+     <example xml:id="ex-config-basic-resourceset-loc">
       <title>用於位置條件約束的資源集</title>
       <para>
        例如，可以在 crmsh 中使用資源集 (<varname>loc-alice</varname>) 的以下組態，將兩個虛擬 IP (<varname>vip1</varname>  和  <varname>vip2</varname>) 置於同一個節點  <varname>alice</varname> 上︰
@@ -1323,8 +1327,8 @@ monitor_0     interval=5s timeout=20s</screen>
      <para>
       資源集可以是排序的 (<literal>sequential=true</literal>)，也可以是未排序的 (<literal>sequential=false</literal>)。此外，您可以使用 <literal>require-all</literal> 屬性在 <literal>AND</literal> 與 <literal>OR</literal> 邏輯之間切換。
      </para>
-    </sect4>
-    <sect4 id="sec-ha-config-basics-constraints-rscset-constraints-dep">
+    </section>
+    <section xml:id="sec-ha-config-basics-constraints-rscset-constraints-dep">
      <title>用於無相依性之並存條件約束的資源集</title>
 
      <para>
@@ -1342,9 +1346,9 @@ monitor_0     interval=5s timeout=20s</screen>
        </para>
       </listitem>
      </itemizedlist>
-    </sect4>
-   </sect3>
-   <sect3 id="sec-ha-config-basics-constraints-more">
+    </section>
+   </section>
+   <section xml:id="sec-ha-config-basics-constraints-more">
     <title>更多資訊</title>
     <para>
      瞭解如何使用偏好的叢集管理工具建立各種條件約束。
@@ -1362,7 +1366,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </itemizedlist>
     <para>
-     如需設定條件約束的詳細資訊，以及有關順序與並存基本概念的詳細背景資訊，請參閱以下文件。您可以從 <ulink url="http://www.clusterlabs.org/doc/"/> 上取得這些文件：
+     如需設定條件約束的詳細資訊，以及有關順序與並存基本概念的詳細背景資訊，請參閱以下文件。您可以從 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上取得這些文件：
     </para>
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
@@ -1381,10 +1385,10 @@ monitor_0     interval=5s timeout=20s</screen>
       </para>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-scores">
+  <section xml:id="sec-ha-config-basics-constraints-scores">
    <title>分數與無限大</title>
    <para>
     定義條件約束時，還需要處理分數。所有類型的分數對於叢集的工作方式而言都是不可或缺的。實際上，從移轉資源到決定要將降級叢集中哪個資源停止的所有操作，都是透過某種方式對分數進行操作來實現。系統會對每個資源都計算分數，針對某個資源分數為負數的所有節點都不能執行該資源。計算完針對資源的分數之後，叢集會選擇分數最高的節點。
@@ -1412,9 +1416,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     定義資源條件約束時，您還要指定每個條件約束的分數。分數表示您要指定給此資源條件約束的值。系統會先套用分數較高的條件約束，然後再套用分數較低的條件約束。透過為指定資源建立不同分數的其他位置條件約束，即可指定資源將容錯移轉至之目標節點的順序。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-constraints-templates">
+  <section xml:id="sec-ha-config-basics-constraints-templates">
    <title>資源樣板和條件約束</title>
    <para>
     如果您定義了一個資源樣板 (請參閱<xref linkend="sec-ha-config-basics-resources-templates"/>)，則可以在以下類型的條件約束中參考該樣板：
@@ -1443,9 +1447,9 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     條件約束中參考的資源樣板代表由該樣板衍生的所有基本資源。也就是說，這些條件約束將適用於所有參考了資源樣板的基本資源。在條件約束中參考資源樣板是另外一種使用資源集的方式，這種方式能夠大大簡化叢集設定。如需有關資源集的詳細資料，請參閱<xref linkend="pro-ha-config-hawk-constraints-sets"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failover">
+  <section xml:id="sec-ha-config-basics-failover">
    <title>容錯移轉節點</title>
    <para>
     若資源失敗，系統會自動將其重新啟動。若無法在目前節點上重新啟動，或資源已在目前節點上失敗 <literal>N</literal> 次，則會嘗試容錯移轉至其他節點。每次資源失敗，其 failcount 值都會增加。您可以定義一個數值，讓資源在失敗該次數 (<literal>migration-threshold</literal>) 之後移轉至新節點。若叢集中有兩個以上的節點，則特定資源容錯移轉所至的節點由 High Availability 軟體來選擇。
@@ -1473,7 +1477,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-   <example id="ex-ha-config-basics-failover">
+   <example xml:id="ex-ha-config-basics-failover">
     <title>移轉限定值 — 程序流程</title>
     <para>
      例如，假設您已為資源 <literal>rsc1</literal> 設定位置條件約束，讓其偏向於在 <literal>alice</literal> 上執行。若資源在該節點上失敗，系統會檢查 <literal>migration-threshold</literal>，並將其與 failcount 進行比較。若 failcount &gt;= migration-threshold，則將資源移轉至優先設定次佳的節點。
@@ -1523,9 +1527,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-failback">
+  <section xml:id="sec-ha-config-basics-failback">
    <title>錯誤回復節點</title>
    <para>
     當原始節點恢復連接且位於叢集中時，資源可以錯誤回復至該節點。若不想讓資源錯誤回復至先前執行時所在的節點，或要為資源指定另一個錯誤回復節點，請變更其 <literal>resource stickiness</literal> 值。您可以在建立資源時或建立之後指定資源粘性。
@@ -1575,9 +1579,9 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-utilization">
+  <section xml:id="sec-ha-config-basics-utilization">
    <title>依據負載影響放置資源</title>
    <para>
     並非所有資源都相同。有些資源 (例如 Xen 客體作業系統) 要求代管它們的節點滿足其容量要求。如果放置資源後其所需的容量之和超過了提供的容量，資源效能便會下降 (甚至無法執行)。
@@ -1696,7 +1700,7 @@ monitor_0     interval=5s timeout=20s</screen>
      提供的配置策略效能最佳，它們雖然沒有使用複雜的啟發式解析程式，卻總能獲得最佳的配置效果。請確保資源的優先程度已正確設定，以便先排程最重要的資源。
     </para>
    </note>
-   <example id="ex-ha-config-basics-utilization">
+   <example xml:id="ex-ha-config-basics-utilization">
     <title>負載平衡放置的範例組態</title>
     <para>
      以下範例中說明了一個含四台虛擬機器的三節點叢集 (每個節點相同)。
@@ -1724,9 +1728,9 @@ property placement-strategy="minimal"</screen>
      如果一個節點失敗，表示可用的總記憶體太少，無法代管全部資源。<literal>xenA</literal> 與 <literal>xenD</literal> 會保證得到配置。但剩餘的兩個資源 <literal>xenB</literal> 與 <literal>xenC</literal> 中僅有一個會予以放置。由於他們的優先程度相同，因此結果會有多種。若要解決這種不確定的狀況，您需要為其中一個設定較高的優先程度。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-tags">
+  <section xml:id="sec-ha-config-basics-tags">
    <title>使用標記對資源分組</title>
 
    <para>
@@ -1747,9 +1751,9 @@ property placement-strategy="minimal"</screen>
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-remote">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-remote">
   <title>管理遠端主機上的服務</title>
 
 
@@ -1758,7 +1762,7 @@ property placement-strategy="minimal"</screen>
    在過去幾年中，監控和管理遠端主機上的服務已變得日益重要。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 透過監控外掛程式提供了細緻的監控遠端主機上之服務的功能。最近新增的 <literal>pacemaker_remote</literal> 服務現在允許 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 全面管理和監控遠端主機上的資源，就如同這些資源是真實的叢集節點一般，並且無需在遠端機器上安裝叢集堆疊。
   </para>
 
-  <sect2 id="sec-ha-config-basics-remote-nagios">
+  <section xml:id="sec-ha-config-basics-remote-nagios">
    <title>使用 Nagios 外掛程式監控遠端主機上的服務</title>
    <para>
     監控虛擬機器的操作可以借助 VM 代辦來執行 (該代辦僅檢查客體作業系統是否出現在 hypervisor 中)，也可以透過從 VirtualDomain 或 Xen 代辦中呼叫的外部程序檔執行。到目前為止，較精細的監控只能透過在虛擬機器中安裝整個 High Availability 堆疊來實現。
@@ -1790,7 +1794,7 @@ property placement-strategy="minimal"</screen>
    <para>
     將 Nagios 外掛程式設定為一個屬於資源容器 (一般是 VM) 的資源就是一個典型的使用案例。如果容器的任何資源發生故障，容器將會重新啟動。如需組態設定範例，請參閱<xref linkend="ex-ha-nagios-config"/>。此外，如果您要使用 Nagios 資源代辦來透過網路監控主機或服務，也可以將其設定為一般資源。
    </para>
-   <example id="ex-ha-nagios-config">
+   <example xml:id="ex-ha-nagios-config">
     <title>設定 Nagios 外掛程式的資源</title>
 <screen>primitive vm1 ocf:heartbeat:VirtualDomain \
   params hypervisor="qemu:///system" config="/etc/libvirt/qemu/vm1.xml" \
@@ -1798,11 +1802,11 @@ property placement-strategy="minimal"</screen>
      op stop interval="0" timeout="90" \
      op monitor interval="10" timeout="30"
   primitive vm1-sshd nagios:check_tcp \
-     params hostname="vm1" port="22" \<co id="co-nagios-hostname"/>
-     op start interval="0" timeout="120" \<co id="co-nagios-startinterval"/>
+     params hostname="vm1" port="22" \<co xml:id="co-nagios-hostname"/>
+     op start interval="0" timeout="120" \<co xml:id="co-nagios-startinterval"/>
      op monitor interval="10"
   group g-vm1-and-services vm1 vm1-sshd \
-     meta container="vm1"<co id="co-nagios-container"/></screen>
+     meta container="vm1"<co xml:id="co-nagios-container"/></screen>
     <calloutlist>
      <callout arearefs="co-nagios-hostname">
       <para>
@@ -1836,9 +1840,9 @@ property placement-strategy="minimal"</screen>
      系統考慮 VM 的移轉限定值時，會將服務的失敗計數考慮在內。
     </para>
    </example>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-basics-remote-pace-remote">
+  <section xml:id="sec-ha-config-basics-remote-pace-remote">
    <title>使用 <literal>pacemaker_remote</literal> 管理遠端節點上的服務</title>
    <para>
     使用 <literal>pacemaker_remote</literal> 服務可將高可用性叢集延伸到虛擬節點或遠端裸機。這些虛擬節點或遠端裸機無需執行叢集堆疊就能成為叢集的成員。
@@ -1887,11 +1891,11 @@ property placement-strategy="minimal"</screen>
     </listitem>
    </itemizedlist>
    <para>
-    <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>》(Pacemaker 遠端操作 — 將高可用性延伸至虛擬節點) 中介紹了關於 <literal>remote_pacemaker</literal> 服務的詳細資訊，包括多個使用案例和詳細的設定指示。
+    <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Remote—Extending High Availability into Virtual Nodes</citetitle>》(Pacemaker 遠端操作 — 將高可用性延伸至虛擬節點) 中介紹了關於 <literal>remote_pacemaker</literal> 服務的詳細資訊，包括多個使用案例和詳細的設定指示。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-basics-monitor-health">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-basics-monitor-health">
   <title>監控系統狀態</title>
 
 
@@ -1909,19 +1913,19 @@ property placement-strategy="minimal"</screen>
 
 
 
-  <procedure id="pro-ha-health-monitor">
+  <procedure xml:id="pro-ha-health-monitor">
    <title>設定系統狀態監控</title>
    <para>
     若要在節點用完磁碟空間時將資源從該節點中移走，請執行以下步驟：
    </para>
-   <step performance="required">
+   <step>
     <para>
      設定 <systemitem>ocf:pacemaker:SysInfo</systemitem> 資源：
     </para>
 <screen><?dbsuse-fo font-size="0.71em"?>
 
 primitive sysinfo ocf:pacemaker:SysInfo \ 
-     params disks="/tmp /var"<co id="co-disks"/> min_disk_free="100M"<co id="co-min-disk-free"/> disk_unit="M"<co id="co-disk-unit"/> \ 
+     params disks="/tmp /var"<co xml:id="co-disks"/> min_disk_free="100M"<co xml:id="co-min-disk-free"/> disk_unit="M"<co xml:id="co-disk-unit"/> \ 
      op monitor interval="15s"</screen>
     <calloutlist>
      <callout arearefs="co-disks">
@@ -1948,12 +1952,12 @@ primitive sysinfo ocf:pacemaker:SysInfo \
 
     </calloutlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      為完成資源組態設定，建立一個 <systemitem>ocf:pacemaker:SysInfo</systemitem> 複製品並在叢集的每個節點上將其啟動。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將 <systemitem>node-health-strategy</systemitem> 設為 <literal>migrate-on-red</literal>：
     </para>
@@ -1991,8 +1995,8 @@ primitive sysinfo ocf:pacemaker:SysInfo \
   <para>
    節點將恢復正常狀態，並且可以重新執行資源。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-basics-maint-mode">
+ </section>
+ <section xml:id="sec-ha-config-basics-maint-mode">
   <title>維護模式</title>
 
 
@@ -2057,14 +2061,14 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-basics-more">
+ <section xml:id="sec-ha-config-basics-more">
   <title>更多資訊</title>
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/"/>
+    <term><link xlink:href="http://crmsh.github.io/"/>
     </term>
     <listitem>
      <para>
@@ -2073,16 +2077,16 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://crmsh.github.io/documentation"/>
+    <term><link xlink:href="http://crmsh.github.io/documentation"/>
     </term>
     <listitem>
      <para>
-      提供關於 crm 外圍程序的多個文件，包括使用 crmsh 完成基本叢集設定的<citetitle>入門</citetitle>教學課程，以及 crm 外圍程序的綜合<citetitle>手冊</citetitle>。後者的網址為 <ulink url="http://crmsh.github.io/man-2.0/"/>。<ulink url="http://crmsh.github.io/start-guide/"/> 上提供了教學課程。
+      提供關於 crm 外圍程序的多個文件，包括使用 crmsh 完成基本叢集設定的<citetitle>入門</citetitle>教學課程，以及 crm 外圍程序的綜合<citetitle>手冊</citetitle>。後者的網址為 <link xlink:href="http://crmsh.github.io/man-2.0/"/>。<link xlink:href="http://crmsh.github.io/start-guide/"/> 上提供了教學課程。
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://clusterlabs.org/"/>
+    <term><link xlink:href="http://clusterlabs.org/"/>
     </term>
     <listitem>
      <para>
@@ -2091,7 +2095,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/> 
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/> 
     </term>
     <listitem>
      <para>
@@ -2122,7 +2126,7 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://linux-ha.org"/>
+    <term><link xlink:href="http://linux-ha.org"/>
     </term>
     <listitem>
      <para>
@@ -2131,5 +2135,5 @@ primitive sysinfo ocf:pacemaker:SysInfo \
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_config_cli.xml
+++ b/zh_TW/xml/ha_config_cli.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_cli.xml" id="cha-ha-manual-config">
- <title>設定和管理叢集資源 (指令行)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_cli.xml" xml:id="cha-ha-manual-config"><title>設定和管理叢集資源 (指令行)</title><info><abstract>
   <para>
    若要設定和管理叢集資源，請使用圖形使用者介面 (Pacemaker GUI) 或 <command>crm</command> 指令行公用程式。有關 GUI 這種方式，請參閱<xref linkend="cha-ha-configuration-gui"/>。
   </para>
@@ -15,7 +17,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章對指令行工具 <command>crm</command> 做了介紹，並對此工具、樣板的使用方式進行了概述，主要敘述了設定和管理叢集資源方面的資訊：建立基本與進階類型的資源 (群組與複製品)，設定條件約束，指定容錯移轉節點與錯誤回復節點，設定資源監控，啟動、清理或移除資源，以及手動移轉資源。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <note>
   <title>使用者權限</title>
   <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    請注意，您需要採用一種 <command>sudo</command> 不會要求提供密碼的方式設定 <filename>/etc/sudoers</filename>。
   </para>
  </note>
- <sect1 id="sec-ha-manual-config-crm">
+ <section xml:id="sec-ha-manual-config-crm">
   <title>crmsh — 綜覽</title>
 
   <para>
@@ -61,7 +65,7 @@ Please see LICENSE.txt for this document's license.
    </itemizedlist>
   </tip>
 
-  <sect2 id="sec-ha-manual-config-crm-help">
+  <section xml:id="sec-ha-manual-config-crm-help">
    <title>使用說明</title>
    <para>
     可以使用以下幾種方法來存取說明：
@@ -105,15 +109,15 @@ Please see LICENSE.txt for this document's license.
    <para>
     幾乎 <command>help</command> 子指令 (不要與 <option>--help</option> 選項混淆) 的所有輸出都會開啟一個文字檢視器。這個文字檢視器可讓您向上或向下捲動，更方便地閱讀說明文字。若要離開該文字檢視器，請按 <keycap>Q</keycap> 鍵。
    </para>
-   <tip id="tip-crm-tabcompletion">
+   <tip xml:id="tip-crm-tabcompletion">
     <title>在 Bash 和互動式外圍程序中使用 Tab 鍵補齊</title>
     <para>
      crmsh 不僅對互動式外圍程序支援 Tab 鍵補齊，在 Bash 中也能直接全面支援此功能。例如，輸入 <literal>crm help config</literal><keycap function="tab"/>，該字即會補齊，就像在互動式外圍程序中一樣。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-crm-run">
+  <section xml:id="sec-ha-manual-config-crm-run">
    <title>執行 crmsh 的子指令</title>
    <para>
     <command>crm</command> 指令本身的使用方式如下：
@@ -177,9 +181,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以下小節概述了 <command>crm</command> 工具的一些重要方面。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-ocf">
+  <section xml:id="sec-ha-manual-config-ocf">
    <title>顯示 OCF 資源代辦的相關資訊</title>
    <para>
     由於您始終都需要在叢集組態中處理資源代辦，因此 <command>crm</command> 工具包含了 <command>ra</command> 指令。使用該指令可以顯示資源代辦的相關資訊並對其進行管理 (如需其他資訊，另請參閱<xref linkend="sec-ha-config-basics-raclasses"/>)：
@@ -242,9 +246,9 @@ Operations' defaults (advisory minimum):
      前面的範例中使用了 <command>crm</command> 指令的內部外圍程序。但是，您不一定要使用該外圍程序。如果將相應的子指令新增至 <command>crm</command>，也可獲得同樣的結果。例如，在外圍程序中輸入 <command>crm</command> <option>ra list ocf</option> 可列出所有 OCF 資源代辦。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-template">
+  <section xml:id="sec-ha-manual-config-template">
    <title>使用組態樣板</title>
 
    <para>
@@ -256,32 +260,32 @@ Operations' defaults (advisory minimum):
    <para>
     以下程序說明如何建立一個簡單但功能齊備的 Apache 組態：
    </para>
-   <procedure id="pro-ha-manual-config-template">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-template">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       藉由組態樣板建立新的組態：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         切換至 <command>template</command> 子指令：
        </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>template</command></screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         列出可用的組態樣板：
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command> templates
 gfs2-base   filesystem  virtual-ip  apache   clvm     ocfs2    gfs2</screen>
       </step>
-      <step performance="required">
+      <step>
        <para>
         指定所需的組態樣板。由於現在需要 Apache 組態，因此請選擇 <literal>apache</literal> 樣板並將其命名為 <literal>g-intranet</literal>：
        </para>
@@ -291,19 +295,19 @@ INFO: pulling in template virtual-ip</screen>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定義參數：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         列出您建立的組態：
        </para>
 <screen><prompt role="custom">crm(live)configure template# </prompt><command>list</command>
 g-intranet</screen>
       </step>
-      <step id="st-config-cli-show" performance="required">
+      <step xml:id="st-config-cli-show">
        <para>
         顯示需要由您填寫的必要變更：
        </para>
@@ -312,7 +316,7 @@ ERROR: 23: required parameter ip not set
 ERROR: 61: required parameter id not set
 ERROR: 65: required parameter configfile not set</screen>
       </step>
-      <step id="st-config-cli-edit" performance="required">
+      <step xml:id="st-config-cli-edit">
        <para>
         啟用偏好的文字編輯器，填寫<xref linkend="st-config-cli-show"/> 中顯示為錯誤的所有行：
        </para>
@@ -321,7 +325,7 @@ ERROR: 65: required parameter configfile not set</screen>
 
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       顯示組態並檢查其是否有效 (視<xref linkend="st-config-cli-edit" xrefstyle="select:label"/> 中輸入的組態而定，可能會顯示粗體文字)：
      </para>
@@ -334,7 +338,7 @@ primitive apache ocf:heartbeat:apache \
 group <emphasis role="strong">g-intranet</emphasis> \
     apache virtual-ip</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       套用組態：
      </para>
@@ -342,7 +346,7 @@ group <emphasis role="strong">g-intranet</emphasis> \
 <prompt role="custom">crm(live)configure# </prompt><command>cd ..</command>
 <prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       將變更提交至 CIB：
      </para>
@@ -363,9 +367,9 @@ group <emphasis role="strong">g-intranet</emphasis> \
    <para>
     但是，之前的指令只是藉由組態樣板建立其組態，而不會套用或提交至 CIB。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-shadowconfig">
+  <section xml:id="sec-ha-manual-config-shadowconfig">
    <title>使用非正式組態進行測試</title>
    <para>
     非正式組態用於測試不同的組態案例。如果您已建立幾個非正式組態，則可以逐個進行測試以查看變更的效果。
@@ -374,13 +378,13 @@ group <emphasis role="strong">g-intranet</emphasis> \
     一般程序如下：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       建立新的非正式組態：
      </para>
@@ -390,7 +394,7 @@ INFO: myNewConfig shadow CIB created</screen>
       如果省略陰影 CIB 的名稱，則系統會建立暫時名稱 <literal>@tmp@</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要將目前的即時組態複製至您的非正式組態，請使用以下指令，否則請跳過此步驟：
      </para>
@@ -399,13 +403,13 @@ INFO: myNewConfig shadow CIB created</screen>
       之前的指令可讓您以後修改任何現有資源時更為方便。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       和平常一樣進行變更。建立非正式組態之後，所有變更即會套用至該組態。若要儲存所有變更，請使用以下指令：
      </para>
 <screen>crm(myNewConfig)# <command>commit</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果重新需要使用即時叢集組態，請使用以下指令切換回來：
      </para>
@@ -413,9 +417,9 @@ INFO: myNewConfig shadow CIB created</screen>
 <prompt role="custom">crm(live)# </prompt></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-debugging">
+  <section xml:id="sec-ha-manual-config-debugging">
    <title>組態變更除錯</title>
    <para>
     在將組態變更載入回叢集之前，建議您先使用 <command>ptest</command> 檢閱變更。<command>ptest</command> 指令可顯示提交變更後將發生之動作的圖表。您需要 <systemitem>graphviz</systemitem> 套件才能顯示圖表。以下範例是一份記錄，新增了監控操作：
@@ -431,9 +435,9 @@ primitive fence-bob stonith:apcsmart \
         op monitor interval="120m" timeout="60s"
 <prompt role="custom">crm(live)configure# </prompt><emphasis role="strong">ptest</emphasis>
 <prompt role="custom">crm(live)configure# </prompt>commit</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-diagram">
+  <section xml:id="sec-ha-manual-config-diagram">
    <title>叢集圖表</title>
    <para>
     若要輸出<xref linkend="fig-ha-cluster-diagram"/> 所示的叢集圖表，請使用指令 <command>crm</command> <command>configure graph</command>。該指令會在目前所在的視窗中顯示目前的組態，因此需要 X11。
@@ -442,10 +446,10 @@ primitive fence-bob stonith:apcsmart \
     如果您偏好使用可擴充向量圖形 (SVG)，請使用如下指令：
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure graph dot config.svg svg</screen>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 
- <sect1 id="sec-ha-config-crm-global">
+ <section xml:id="sec-ha-config-crm-global">
   <title>設定全域叢集選項</title>
 
   <para>
@@ -454,13 +458,13 @@ primitive fence-bob stonith:apcsmart \
 
   <procedure>
    <title>使用 <command>crm</command> 修改全域叢集選項</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 工具：
     </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用以下指令僅為包含兩個節點的叢集設定選項：
     </para>
@@ -473,7 +477,7 @@ primitive fence-bob stonith:apcsmart \
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      顯示您的變更：
     </para>
@@ -485,7 +489,7 @@ property $id="cib-bootstrap-options" \
    no-quorum-policy="ignore" \
    stonith-enabled="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      提交您的變更並離開：
     </para>
@@ -493,8 +497,8 @@ property $id="cib-bootstrap-options" \
 <prompt role="custom">crm(live)configure# </prompt><command>exit</command></screen>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-config-crm-resources">
+ </section>
+ <section xml:id="sec-ha-config-crm-resources">
   <title>設定叢集資源</title>
 
   <para>
@@ -505,19 +509,19 @@ property $id="cib-bootstrap-options" \
    有關您可以建立之資源類型的綜覽，請參閱<xref linkend="sec-ha-config-basics-resources-types"/>。
   </para>
 
-  <sect2 id="sec-ha-manual-config-create">
+  <section xml:id="sec-ha-manual-config-create">
    <title>建立叢集資源</title>
    <para>
     系統提供了三種適用於叢集的 RA (資源代辦)，如需背景資訊，請參閱<xref linkend="sec-ha-config-basics-raclasses"/>。若要將新資源新增至叢集，請執行以下步驟：
    </para>
-   <procedure id="pro-ha-manual-config-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-manual-config-create">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 工具：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       設定基本資源的 IP 位址：
      </para>
@@ -527,13 +531,13 @@ property $id="cib-bootstrap-options" \
       以上指令設定名為 <literal>myIP</literal> 的<quote>原始</quote>IP 位址。您需要選擇類別 (此處為 <literal>ocf</literal>)、提供者 (<literal>heartbeat</literal>) 和類型 (<literal>IPaddr</literal>)。此外，此基本資源還需要其他參數，例如 IP 位址。將位址變更為您的設定。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       顯示並檢閱已進行的變更：
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>show</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       提交變更，使之生效：
      </para>
@@ -541,11 +545,11 @@ property $id="cib-bootstrap-options" \
     </step>
    </procedure>
 
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-config-rsc-template">
+  <section xml:id="sec-ha-manual-config-rsc-template">
    <title>建立資源樣板</title>
    <para>
     如果您要建立多個具有相似組態的資源，資源樣板可以簡化此任務。另請參閱<xref linkend="sec-ha-config-basics-constraints-templates"/> 以瞭解一些基本的背景資訊。請勿將它們與<xref linkend="sec-ha-manual-config-template"/> 中所述的<quote>normal</quote>樣板相混淆。請使用 <command>rsc_template</command> 指令熟悉相應語法：
@@ -588,23 +592,23 @@ usage: rsc_template &lt;name&gt; [&lt;class&gt;:[&lt;provider&gt;:]]&lt;type&gt;
    <para>
     在條件約束中可以參考資源樣板，來代表所有由該樣板衍生的基本資源。這有助於產生更加簡明、清晰的叢集組態。除了位置條件約束以外，其他所有條件約束中均允許參考資源樣板。並存條件約束不可包含一個以上的樣板參考。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-manual-create-stonith">
+  <section xml:id="sec-ha-manual-create-stonith">
    <title>建立 STONITH 資源</title>
    <para>
     從 <command>crm</command> 角度看，STONITH 裝置只是另一個資源。若要建立 STONITH 資源，請執行下列步驟：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用如下指令取得所有 STONITH 類型清單：
      </para>
@@ -622,7 +626,7 @@ ipmilan                    meatware                   nw_rpc100s
 rcd_serial                 rps10                      suicide
 wti_mpc                    wti_nps</screen>
     </step>
-    <step id="st-ha-manual-create-stonith-type" performance="required">
+    <step xml:id="st-ha-manual-create-stonith-type">
      <para>
       從上面的清單中選擇一種 STONITH 類型並檢視可能的選項清單。使用以下指令：
      </para>
@@ -641,7 +645,7 @@ hostname (string): Hostname
     The name of the host to be managed by this STONITH device.
 ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <literal>stonith</literal> 類別、您在<xref linkend="st-ha-manual-create-stonith-type" xrefstyle="select:label nopage"/> 中所選的類型，以及所需的相應參數來建立 STONITH 資源，例如：
      </para>
@@ -653,9 +657,9 @@ hostname (string): Hostname
     op monitor interval=60m timeout=120s  </screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-constraints">
+  <section xml:id="sec-ha-manual-config-constraints">
    <title>設定資源條件約束</title>
    <para>
     設定所有資源只是工作的一部分。即使叢集瞭解所有必需的資源，可能仍然無法正確地對其進行處理。例如，儘量不要在 DRBD 的從屬節點上掛接檔案系統 (實際上，對 DRBD 執行此操作將會失敗)。定義相關條件約束，讓此類資訊適用於叢集。
@@ -663,7 +667,7 @@ hostname (string): Hostname
    <para>
     如需條件約束的詳細資訊，請參閱<xref linkend="sec-ha-config-basics-constraints"/>。
    </para>
-   <sect3 id="sec-ha-manual-config-constraints-locational">
+   <section xml:id="sec-ha-manual-config-constraints-locational">
     <title>位置條件約束</title>
     <para>
      <command>location</command> 指令定義資源可在、不可在或偏好在哪些節點上執行。
@@ -696,8 +700,8 @@ hostname (string): Hostname
      在某些情況下，為 <command>location</command> 指令使用資源模式會有效且方便得多。資源模式是兩個斜線之間的規則運算式。例如，使用以下指令可使上述的虛擬 IP 位址全部都相符：
     </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>location</command>  loc-alice /vip.*/ inf: alice</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-collocational">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-collocational">
     <title>並存條件約束</title>
     <para>
      <command>colocation</command> 指令用於定義應在相同或不同主機上執行的資源。
@@ -713,8 +717,8 @@ hostname (string): Hostname
     <para>
      對於主要從屬組態，除本地執行資源之外，還必須瞭解目前節點是否為主要節點。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-weak-bond">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-weak-bond">
     <title>並存無相依性的資源集</title>
 
     <para>
@@ -727,8 +731,8 @@ hostname (string): Hostname
     <para>
      實作 <command>weak-bond</command> 會使用指定的資源自動建立一個虛構資源和並存條件約束。
     </para>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-ordering">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-ordering">
     <title>順序條件約束</title>
     <para>
      <command>Order</command> 指令定義動作順序。
@@ -741,8 +745,8 @@ hostname (string): Hostname
     </para>
 
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> nfs_after_filesystem mandatory: filesystem_resource nfs_group</screen>
-   </sect3>
-   <sect3 id="sec-ha-manual-config-constraints-example">
+   </section>
+   <section xml:id="sec-ha-manual-config-constraints-example">
     <title>範例組態的條件約束</title>
     <para>
      如果沒有其他條件約束，本節中所用的範例可能不會起作用。所有資源皆必須與 DRBD 資源的主要資源在同一機器上執行，這是基本要求。在任何其他資源啟動之前，DRBD 資源必須成為主要資源。若 DRBD 裝置不是主要資源，嘗試掛接該裝置時必定失敗。以下條件約束必須滿足：
@@ -777,10 +781,10 @@ hostname (string): Hostname
     drbd_resource:promote filesystem_resource:start</screen>
      </listitem>
     </itemizedlist>
-   </sect3>
-  </sect2>
+   </section>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failover">
+  <section xml:id="sec-ha-manual-config-failover">
    <title>指定資源容錯移轉節點</title>
    <para>
     若要判斷資源容錯移轉，請使用 meta 屬性 migration-threshold。如果所有節點上的 failcount 都超出了 migration-threshold，資源將一直處於停止狀態。例如：
@@ -796,9 +800,9 @@ hostname (string): Hostname
    <para>
     如需綜覽，請參閱<xref linkend="sec-ha-config-basics-failover"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-failback">
+  <section xml:id="sec-ha-manual-config-failback">
    <title>指定資源錯誤回復節點 (資源粘性)</title>
      <para>
     當原始節點恢復連接且位於叢集中時，資源可以錯誤回復至該節點。若不想讓資源錯誤回復至先前執行時所在的節點，或要為資源指定另一個錯誤回復節點，請變更其 <literal>resource stickiness</literal> 值。您可以在建立資源時或建立之後指定資源粘性。
@@ -806,9 +810,9 @@ hostname (string): Hostname
    <para>
     如需綜覽，請參閱<xref linkend="sec-ha-config-basics-failback"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-utilization">
+  <section xml:id="sec-ha-manual-config-utilization">
    <title>根據負載影響設定資源的配置</title>
    <para>
     某些資源可能有特定的容量要求，例如最低記憶體容量。如果不符合其要求，這些資源可能無法完全啟動，或者執行時效能會降低。
@@ -846,13 +850,13 @@ hostname (string): Hostname
    </para>
    <procedure>
     <title>使用 <command>crm</command> 新增或修改使用率屬性</title>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要指定節點<emphasis>提供</emphasis>的容量，請使用以下指令，並以您的節點名稱取代佔位符 <replaceable>NODE_1</replaceable>：
      </para>
@@ -862,7 +866,7 @@ hostname (string): Hostname
       透過設定以上的值，我們假設 <replaceable>NODE_1</replaceable> 為資源提供 16GB 的記憶體和 8 個 CPU 核心。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要指定資源<emphasis>需要</emphasis>的容量，請使用：
      </para>
@@ -872,7 +876,7 @@ hostname (string): Hostname
       如此，資源會佔用 nodeA 的 4096 個記憶體單元和 4 個 CPU 單元。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>property</command> 指令設定配置策略：
      </para>
@@ -924,7 +928,7 @@ hostname (string): Hostname
     </para>
    </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在離開 crmsh 之前，提交您的變更：
      </para>
@@ -956,9 +960,9 @@ hostname (string): Hostname
    <para>
     如果一個節點失敗，表示可用的總記憶體太少，無法代管全部資源。如此會確保 xenA 及 xenD 都會予以配置。但 xenB 與 xenC 只有其中一個會予以配置，因為它們的優先程度相同，因此結果尚不確定。若要解決這種不確定的狀況，您需要為其中一個設定較高的優先程度。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-monitor">
+  <section xml:id="sec-ha-manual-config-monitor">
    <title>設定資源監控</title>
 
    <para>
@@ -976,21 +980,21 @@ hostname (string): Hostname
    <para>
     如需綜覽，請參閱<xref linkend="sec-ha-config-basics-monitoring"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-group">
+  <section xml:id="sec-ha-manual-config-group">
    <title>設定叢集資源群組</title>
 
    <para>
     叢集其中一個最常見的元素是需要存放在一起的一組資源。請按照順序啟動它們，停止時採用相反順序。若要簡化此組態，您可以使用群組。以下範例將建立兩個基本資源 (一個 IP 位址和一個電子郵件資源)：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以系統管理員身分執行 <command>crm</command> 指令。提示變更為 <literal>crm(live)</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       設定基本資源：
      </para>
@@ -1000,7 +1004,7 @@ hostname (string): Hostname
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Email lsb:exim \
    params id=p.lsb-exim</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       以正確的順序按照相應的識別碼對基本資源分組：
      </para>
@@ -1019,9 +1023,9 @@ hostname (string): Hostname
    <para>
     如需綜覽，請參閱<xref linkend="sec-ha-config-basics-resources-advanced-groups"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-clone">
+  <section xml:id="sec-ha-manual-config-clone">
    <title>設定複製品資源</title>
 
    <para>
@@ -1031,46 +1035,46 @@ hostname (string): Hostname
    <para>
     如需所複製之資源的詳細資訊，請參閱<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>。
    </para>
-   <sect3 id="sec-ha-manual-config-clone-anonymous">
+   <section xml:id="sec-ha-manual-config-clone-anonymous">
     <title>建立匿名複製品資源</title>
     <para>
      若要建立匿名複製品資源，首先要建立一個基本資源，然後使用 <command>clone</command> 指令參考該資源。執行下列操作︰
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        設定基本資源，例如：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>primitive</command> Apache lsb:apache</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        複製基本資源：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>clone</command> cl-apache Apache </screen>
      </step>
     </procedure>
-   </sect3>
+   </section>
 
-   <sect3 id="sec-ha-manual-config-clone-stateful">
+   <section xml:id="sec-ha-manual-config-clone-stateful">
     <title>建立可設定狀態的/多狀態的複製品資源</title>
     <para>
      若要建立可設定狀態的複製品資源，首先要建立一個基本資源，然後再建立多狀態資源。多狀態資源至少必須支援升級和降級操作。
     </para>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
       </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        設定基本資源。視需要變更間隔：
       </para>
@@ -1078,62 +1082,62 @@ hostname (string): Hostname
     op monitor interval=60 \
     op monitor interval=61 role=Master</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        建立多狀態資源：
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>ms</command> ms-rsc my-rsc</screen>
      </step>
     </procedure>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-crm">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-crm">
   <title>管理叢集資源</title>
 
   <para>
    除了能夠設定叢集資源外，<command>crm</command> 工具還可讓您管理現有資源。以下小節對此進行了概述。
   </para>
 
-  <sect2 id="sec-ha-manual-config-start">
+  <section xml:id="sec-ha-manual-config-start">
    <title>啟動新的叢集資源</title>
    <para>
     若要啟動新的叢集資源，您需要相應的識別碼。請執行下列步驟：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       切換至資源層級：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>resource</command></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用 <command>start</command> 啟動資源，然後按 <keycap function="tab"/> 鍵顯示所有已知資源：
      </para>
 <screen><prompt role="custom">crm(live)resource# </prompt><command>start</command> <replaceable>ID</replaceable></screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cleanup">
+  <section xml:id="sec-ha-manual-config-cleanup">
    <title>清理資源</title>
    <para>
     若資源失敗，系統會自動將其重新啟動，但每次失敗都會增加資源的 failcount。如果已對該資源設定 <literal>migration-threshold</literal>，則一旦失敗次數達到該移轉限定值，就不再允許該節點執行該資源。
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       開啟外圍程序並以 <systemitem class="username">root</systemitem> 使用者身分登入。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       取得所有資源的清單：
      </para>
@@ -1144,28 +1148,28 @@ Resource Group: dlm-clvm:1
          clvm:1 (ocf::lvm2:clvmd) Started
          cmirrord:1     (ocf::lvm2:cmirrord) Started</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       例如，若要清理資源 <literal>dlm</literal>：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource cleanup dlm</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-remove">
+  <section xml:id="sec-ha-manual-config-remove">
    <title>移除叢集資源</title>
    <para>
     執行下列步驟可以移除叢集資源：
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分登入並啟動 <command>crm</command> 互動式外圍程序：
      </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> configure</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       執行下列指令以取得資源清單：
      </para>
@@ -1175,22 +1179,22 @@ Resource Group: dlm-clvm:1
      </para>
 <screen>myIP    (ocf::IPaddr:heartbeat) ...</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       刪除具有相應識別碼的資源 (此操作還隱含 <command>commit</command> 動作)：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> delete <replaceable>YOUR_ID</replaceable></screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       提交變更：
      </para>
 <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-migrate">
+  <section xml:id="sec-ha-manual-config-migrate">
    <title>移轉叢集資源</title>
    <para>
     雖然資源設定為在遇到硬體或軟體故障時自動容錯移轉 (或移轉) 至叢集的其他節點，但您也可以使用 Pacemaker GUI 或指令行將資源手動移至叢集中的另一個節點。
@@ -1200,9 +1204,9 @@ Resource Group: dlm-clvm:1
    </para>
 <screen><prompt role="root">root # </prompt><command>crm</command> resource
 <prompt role="custom">crm(live)resource# </prompt><command>migrate</command> ipaddress1 bob</screen>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-tag">
+  <section xml:id="sec-ha-manual-config-tag">
    <title>分組/標記資源</title>
 
    <para>
@@ -1223,9 +1227,9 @@ Resource Group: dlm-clvm:1
     <para>標記 (用於對資源分組) 和某些 ACL 功能僅適用於 <literal>pacemaker-2.0</literal> 或更高的 CIB 語法版本。如需檢查這一點以及升級 CIB 版本的詳細資料，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>高可用性指南</citetitle>》中「<citetitle>從 SLE HA 11 SP3 升級到 SLE HA 11 SP4</citetitle>」一節所述的指示。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-manual-config-cli-maint-mode">
+  <section xml:id="sec-ha-manual-config-cli-maint-mode">
    <title>使用維護模式</title>
 
    
@@ -1287,10 +1291,10 @@ Resource Group: dlm-clvm:1
    <para>
     如需處於維護模式的資源和叢集會發生之情況的詳細資料，請參閱<xref linkend="sec-ha-config-basics-maint-mode"/>。
    </para>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
- <sect1 id="sec-ha-config-crm-setpwd">
+ <section xml:id="sec-ha-config-crm-setpwd">
   <title>設定獨立於 <filename>cib.xml</filename> 的密碼</title>
 
   <para>
@@ -1322,9 +1326,9 @@ linux</screen>
   <para>
    請注意，各節點之間需要同步參數；<command>crm resource secret</command> 指令將會負責該任務。強烈建議您只使用此指令來管理機密參數。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-config-crm-history">
+ <section xml:id="sec-ha-config-crm-history">
   <title>擷取歷程資訊</title>
 
   <para>
@@ -1381,7 +1385,7 @@ linux</screen>
 
 
   <para>
-   如需更多範例以及如何建立時間範圍的資訊，請參閱 <ulink url="http://labix.org/python-dateutil"/>。
+   如需更多範例以及如何建立時間範圍的資訊，請參閱 <link xlink:href="http://labix.org/python-dateutil"/>。
   </para>
 
   <para>
@@ -1429,8 +1433,8 @@ INFO: fetching new logs, please wait ...</screen>
   </para>
 
 <screen><prompt role="custom">crm(live)history# </prompt><command>transition</command> -1 nograph</screen>
- </sect1>
- <sect1 id="sec-ha-config-crm-more">
+ </section>
+ <section xml:id="sec-ha-config-crm-more">
   <title>更多資訊</title>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -1441,7 +1445,7 @@ INFO: fetching new logs, please wait ...</screen>
    </listitem>
    <listitem>
     <para>
-     在 <ulink url="http://crmsh.github.io/documentation"/> 中瀏覽上游專案文件。
+     在 <link xlink:href="http://crmsh.github.io/documentation"/> 中瀏覽上游專案文件。
     </para>
    </listitem>
    <listitem>
@@ -1450,5 +1454,5 @@ INFO: fetching new logs, please wait ...</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_config_example.xml
+++ b/zh_TW/xml/ha_config_example.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_config_example.xml" id="cha-ha-config-example">
- <title>OCFS2 與 cLVM 的範例組態</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_example.xml" xml:id="cha-ha-config-example"><title>OCFS2 與 cLVM 的範例組態</title><info/>
+ 
  <para>
   下面是一個範例組態，可幫助您設定用於 OCFS2、cLVM 或以上兩者的資源。下面的組態不是完整的叢集組態，只是一部分摘錄內容，其中包含了 OCFS2 與 cLVM 所需的所有資源，但省略了您也許會需要的其他資源。您可能需要根據您的特定環境對一些屬性與屬性值進行調整。
  </para>
- <example id="ex-ha-config-ocfs2-clvm">
+ <example xml:id="ex-ha-config-ocfs2-clvm">
   <title>OCFS2 與 cLVM 的叢集組態</title>
 
 <screen>primitive clvm ocf:lvm2:clvmd \

--- a/zh_TW/xml/ha_config_gui.xml
+++ b/zh_TW/xml/ha_config_gui.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_gui.xml" id="cha-ha-configuration-gui">
- <title>設定和管理叢集資源 (GUI)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_gui.xml" xml:id="cha-ha-configuration-gui"><?dbfo-need height="20em"?><?dbfo-need height="20em"?><title>設定和管理叢集資源 (GUI)</title><info><abstract>
   <para>
    本章對 Pacemaker GUI 做了介紹，說明設定和管理叢集資源時所需執行的基本任務：修改全域叢集選項，建立基本與進階類型的資源 (群組和複製品)，設定條件約束，指定容錯移轉節點與錯誤回復節點，設定資源監控，啟動、清理或移除資源，以及手動移轉資源。
   </para>
- </abstract>
+ </abstract></info>
+ 
+ 
  <para>
   GUI 支援由兩個套件提供：<systemitem class="resource">pacemaker-mgmt</systemitem> 套件包含 GUI 的後端 (<systemitem class="daemon">mgmtd</systemitem> 精靈)。該套件必須安裝在您要使用 GUI 連接的所有叢集節點上。在要執行 GUI 的每一台機器上安裝 <systemitem class="resource">pacemaker-mgmt-client</systemitem> 套件。
  </para>
@@ -27,17 +31,17 @@ Please see LICENSE.txt for this document's license.
    在您要使用 Pacemaker GUI 與之連接的所有節點上執行此操作。
   </para>
  </note>
-<?dbfo-need height="20em"?>
 
 
- <sect1 id="sec-ha-configuration-gui-intro">
+
+ <section xml:id="sec-ha-configuration-gui-intro">
   <title>Pacemaker GUI — 綜覽</title>
 
   <para>
    若要啟動 Pacemaker GUI，請在指令行中輸入 <command>crm_gui</command>。若要存取組態與管理選項，須登入叢集。
   </para>
 
-  <sect2 id="sec-ha-configuration-gui-intro-connect">
+  <section xml:id="sec-ha-configuration-gui-intro-connect">
    <title>登入叢集</title>
    <para>
     若要連接至叢集，請選取<menuchoice><guimenu>連接</guimenu><guimenu>登入</guimenu></menuchoice>。依預設，<guimenu>伺服器</guimenu>欄位會顯示 localhost 的 IP 位址，以及做為<guimenu>使用者名稱</guimenu>的 <systemitem>hacluster</systemitem>。輸入使用者密碼以繼續。
@@ -56,13 +60,13 @@ Please see LICENSE.txt for this document's license.
    <para>
     若要從遠端執行 Pacemaker GUI，請輸入做為<guimenu>伺服器</guimenu>之叢集節點的 IP 位址。對於<guimenu>使用者名稱</guimenu>，您也可以使用屬於 <systemitem>haclient</systemitem> 群組的任何其他使用者來連接叢集。
    </para>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-gui-intro-main">
+  <section xml:id="sec-ha-configuration-gui-intro-main">
    <title>主視窗</title>
    <para>
     連接之後，主視窗即會開啟：
@@ -134,9 +138,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     以下幾節將引導您完成設定叢集選項與資源時需要執行的主要任務，並介紹如何使用 Pacemaker GUI 管理資源。除非另有說明，逐步指示反映的是在簡單模式下執行的程序。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-global">
   <title>設定全域叢集選項</title>
 
   <para>
@@ -156,29 +160,29 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-gui-global">
+  <procedure xml:id="pro-ha-config-gui-global">
    <title>修改全域叢集選項</title>
-   <step performance="required">
+   <step>
     <para>
      啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<menuchoice><guimenu>檢視</guimenu><guimenu>簡單模式</guimenu></menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側窗格中，選取<guimenu>CRM 組態</guimenu>以檢視全域叢集選項及其目前值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根據叢集要求，將<guimenu>無最低節點數規則</guimenu>設定為適當值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您出於某些原因需要停用圍籬區隔，請取消選取<guimenu>stonith-enabled</guimenu>。
     </para>
@@ -189,7 +193,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>套用</guimenu>確認您的變更。
     </para>
@@ -199,11 +203,11 @@ Please see LICENSE.txt for this document's license.
   <para>
    您可以隨時切換回所有選項的預設值，只需在左側窗格中選取<guimenu>CRM 組態</guimenu>，然後按一下<guimenu>預設值</guimenu>。
   </para>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-config-gui-resources">
+
+ <section xml:id="sec-ha-config-gui-resources">
   <title>設定叢集資源</title>
 
   <para>
@@ -214,44 +218,44 @@ Please see LICENSE.txt for this document's license.
    有關您可以建立之資源類型的綜覽，請參閱<xref linkend="sec-ha-config-basics-resources-types"/>。
   </para>
 
-  <sect2 id="sec-ha-configuration-create">
+  <section xml:id="sec-ha-configuration-create">
    <title>建立簡單叢集資源</title>
    <para>
     若要建立最基本的資源類型，請執行下列步驟：
    </para>
-   <procedure id="pro-ha-config-gui-primitives">
+   <procedure xml:id="pro-ha-config-gui-primitives">
     <title>新增基本資源</title>
-    <step id="st-ha-configuration-create-start" performance="required">
+    <step xml:id="st-ha-configuration-create-start">
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>基本資源</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一個對話方塊中，設定資源的以下參數：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         輸入資源的唯一 <guimenu>ID</guimenu>。
        </para>
       </step>
-      <step id="step-ha-config-gui-primitives-start" performance="required">
+      <step xml:id="step-ha-config-gui-primitives-start">
        <para>
         在<guimenu>類別</guimenu>清單中，選取您要針對該資源使用的資源代辦類別：<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>服務</guimenu> 或 <guimenu>stonith</guimenu>。如需詳細資訊，請參閱<xref linkend="sec-ha-config-basics-raclasses"/>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果選取了<guimenu>ocf</guimenu>類別，還需要指定 OCF 資源代辦的<guimenu>提供者</guimenu>。OCF 規格允許多個廠商提供相同的資源代辦。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>類型</guimenu>清單中，選取要使用的資源代辦 (例如<guimenu>IPaddr</guimenu>或<guimenu>Filesystem</guimenu>)。此資源代辦的簡要描述會顯示在下方。
        </para>
@@ -259,12 +263,12 @@ Please see LICENSE.txt for this document's license.
         <guimenu>類型</guimenu>清單中顯示的選項取決於您所選的<guimenu>類別</guimenu>(對於 OCF 資源，還取決於<guimenu>提供者</guimenu>)。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>選項</guimenu>下方，設定<guimenu>資源的初始狀態</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         若要讓叢集監控資源是否正常，請啟用<guimenu>新增監控操作</guimenu>。
        </para>
@@ -281,12 +285,12 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按<guimenu>下一步</guimenu>。下一個視窗會顯示您已為該資源定義的參數摘要。其中會列出該資源所需的所有<guimenu>例項屬性</guimenu>。您需要對它們進行編輯，以將其設定為適當的值。依您的部署與設定而定，您可能還需要新增其他屬性。如需如何執行此操作的詳細資料，請參閱<xref linkend="pro-ha-config-gui-parameters"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>套用</guimenu>以完成該資源的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的資源。
      </para>
@@ -312,14 +316,14 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <procedure id="pro-ha-config-gui-parameters">
+   <procedure xml:id="pro-ha-config-gui-parameters">
     <title>新增或修改中繼屬性與例項屬性</title>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主視窗中，按一下左側窗格中的<guimenu>資源</guimenu>，以檢視已為叢集設定的資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中，選取要修改的資源，然後按一下<guimenu>編輯</guimenu>(或在該資源上連按兩下)。下一個視窗會顯示基本的資源參數，以及已為該資源定義的<guimenu>中繼屬性</guimenu>、<guimenu>例項屬性</guimenu>或<guimenu>操作</guimenu>。
      </para>
@@ -334,27 +338,27 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要新增新的中繼屬性或例項屬性，請選取相應的索引標籤並按一下<guimenu>新增</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取要新增之屬性的<guimenu>名稱</guimenu>。一個簡要<guimenu>描述</guimenu>即會顯示。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       視需要指定屬性<guimenu>值</guimenu>。若不指定，系統將使用該屬性的預設值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>確定</guimenu>以確認所做的變更。索引標籤上隨即會顯示新增的或修改的屬性。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該資源的組態設定。組態對話方塊會關閉，同時主視窗會顯示修改的資源。
      </para>
@@ -372,9 +376,9 @@ Please see LICENSE.txt for this document's license.
      顯示 XML 程式碼的編輯器可讓您<guimenu>輸入</guimenu>或<guimenu>輸出</guimenu>XML 元素，或手動編輯 XML 程式碼。
     </para>
    </tip>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-stonith">
+  <section xml:id="sec-ha-configuration-stonith">
    <title>建立 STONITH 資源</title>
    <important>
     <title>沒有 STONITH 則不提供支援</title>
@@ -385,56 +389,56 @@ Please see LICENSE.txt for this document's license.
    <para>
     依預設，全域叢集選項 <literal>stonith-enabled</literal> 設定為 <literal>true</literal>：如果未定義 STONITH 資源，叢集將拒絕啟動任何資源。若要完成 STONITH 設定，您需要設定一或多個 STONITH 資源。儘管 STONITH 的設定與其他資源相似，但它們的行為在某些方面有所不同。如需詳細資料，請參閱<xref linkend="sec-ha-fencing-config"/>。
    </para>
-   <procedure id="pro-ha-config-gui-stonith">
+   <procedure xml:id="pro-ha-config-gui-stonith">
     <title>新增 STONITH 資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>基本資源</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一個對話方塊中，設定資源的以下參數：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         輸入資源的唯一 <guimenu>ID</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>類別</guimenu>清單中，選取資源代辦類別<guimenu>stonith</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         從<guimenu>類型</guimenu>清單中，選取用於控制 STONITH 裝置的 STONITH 外掛程式。此外掛程式的簡要描述會顯示在下方。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>選項</guimenu>下方，設定<guimenu>資源的初始狀態</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         若要讓叢集監控圍籬區隔裝置，請啟用<guimenu>新增監控操作</guimenu>。若需更多資訊，請參閱<xref linkend="sec-ha-fencing-monitor"/>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按<guimenu>下一步</guimenu>。下一個視窗會顯示您已為該資源定義的參數摘要。其中會列出選定 STONITH 外掛程式所需的所有<guimenu>例項屬性</guimenu>。您需要對它們進行編輯，以將其設定為適當的值。依您的部署與設定而定，您可能還需要新增其他屬性或監控操作。如需如何執行此操作的詳細資料，請參閱<xref linkend="pro-ha-config-gui-parameters"/> 與<xref linkend="sec-ha-configuration-monitor"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>套用</guimenu>以完成該資源的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的資源。
      </para>
@@ -443,90 +447,90 @@ Please see LICENSE.txt for this document's license.
    <para>
     若要完成圍籬區隔組態，請新增條件約束或使用複製品，或同時使用這兩種方式。如需詳細資訊，請參閱<xref linkend="cha-ha-fencing"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-gui-templates">
+  <section xml:id="sec-ha-config-gui-templates">
    <title>使用資源樣板</title>
    <para>
     如果您要建立多個具有相似組態的資源，定義資源樣板是最輕鬆的方法。定義資源樣板後，您可以在基本資源或某些類型的條件約束中參考該樣板：如需有關資源樣板功能和用法的詳細資訊，請參閱<xref linkend="sec-ha-config-basics-constraints-templates"/>。
    </para>
-   <procedure id="pro-ha-config-gui-templates-create">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-templates-create">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>樣板</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為樣板輸入唯一的<guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       像指定基本資源一樣指定資源樣板。請依照<xref linkend="pro-ha-config-gui-primitives" xrefstyle="select:label title nopage"/> 中的說明從<xref linkend="step-ha-config-gui-primitives-start" xrefstyle="select:label"/> 開始。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根據需要設定了所有參數後，請按一下<guimenu>套用</guimenu>完成該資源樣板的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的資源樣板。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-templates-use">
+   <procedure xml:id="pro-ha-config-gui-templates-use">
     <title>參考資源樣板</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要在基本資源中參考新建的資源樣板，請執行以下步驟：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>基本資源</guimenu></menuchoice>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         輸入唯一的<guimenu>ID</guimenu>，並指定<guimenu>類別</guimenu>、<guimenu>提供者</guimenu>和<guimenu>類型</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         選取要參考的<guimenu>樣板</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         如果要設定從樣板衍生的特定例項屬性、操作或中繼屬性，請繼續依照<xref linkend="pro-ha-config-gui-primitives"/> 所述設定資源。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要在並存條件約束或順序條件約束中參考新建的資源樣板：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         分別依照<xref linkend="pro-ha-config-gui-constraints-collocation"/> 或<xref linkend="pro-ha-config-gui-constraints-order"/> 所述設定條件約束。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         對於並存條件約束，<guimenu>資源</guimenu>下拉式選單中會顯示已設定之所有資源及資源樣板的 ID。請從該清單中選取要參考的樣板。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         同樣，對於順序條件約束，<guimenu>首先</guimenu>和<guimenu>其次</guimenu>下拉式選單中會顯示資源和資源樣板。請從該清單中選取要參考的樣板。
        </para>
@@ -534,9 +538,9 @@ Please see LICENSE.txt for this document's license.
      </substeps>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-constraints">
+  <section xml:id="sec-ha-configuration-constraints">
    <title>設定資源條件約束</title>
    <para>
     設定所有資源只是工作的一部分。即使叢集瞭解所有必需的資源，可能仍然無法正確地對其進行處理。資源條件約束可讓您指定資源可在哪些叢集節點上執行，載入資源的順序以及特定資源所依賴的其他資源。
@@ -550,45 +554,45 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-constraints-location">
+   <procedure xml:id="pro-ha-config-gui-constraints-location">
     <title>新增或修改位置條件約束</title>
-    <step id="step-ha-configuration-constraints-start" performance="required">
+    <step xml:id="step-ha-configuration-constraints-start">
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主視窗中，按一下左側窗格中的<guimenu>條件約束</guimenu>，以檢視已為叢集設定的條件約束。
      </para>
     </step>
-    <step id="step-ha-configuration-constraints-stop" performance="required">
+    <step xml:id="step-ha-configuration-constraints-stop">
      <para>
       在左側窗格中，選取<guimenu>條件約束</guimenu>，然後按一下<guimenu>新增</guimenu>。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<guimenu>資源位置</guimenu>，然後按一下<guimenu>確定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入條件約束的唯一<guimenu>ID</guimenu>。在您修改現有的條件約束時，其 ID 已定義好，會顯示在組態對話方塊中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取要對其定義條件約束的<guimenu>資源</guimenu>。清單會顯示已為叢集設定之所有資源的 ID。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為條件約束設定<guimenu>分數</guimenu>。正值表示資源可以在您於下方指定的<guimenu>節點</guimenu>上執行。負值表示資源不應在該節點上執行。將分數設定為 <literal>INFINITY</literal> 會強制資源在該節點上執行。分數設定為 <literal>-INFINITY</literal> 表示資源不得在該節點上執行。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為條件約束選取<guimenu>節點</guimenu>。
      </para>
@@ -603,47 +607,47 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       若將<guimenu>節點</guimenu>與<guimenu>分數</guimenu>欄位留為空白，您也可以透過按一下<menuchoice><guimenu>新增</guimenu><guimenu>規則</guimenu></menuchoice>來新增規則。若要新增生命期間，只需按一下<menuchoice><guimenu>新增</guimenu><guimenu>生命期間</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該條件約束的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的或修改的條件約束。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-collocation">
+   <procedure xml:id="pro-ha-config-gui-constraints-collocation">
     <title>新增或修改並存條件約束</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主視窗中，按一下左側窗格中的<guimenu>條件約束</guimenu>，以檢視已為叢集設定的條件約束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>條件約束</guimenu>，然後按一下<guimenu>新增</guimenu>。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<guimenu>資源並存</guimenu>，然後按一下<guimenu>確定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入條件約束的唯一<guimenu>ID</guimenu>。在您修改現有的條件約束時，其 ID 已定義好，會顯示在組態對話方塊中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取做為並存來源的<guimenu>資源</guimenu>。清單會顯示已為叢集設定之所有資源和資源樣板的 ID。
      </para>
@@ -651,23 +655,23 @@ Please see LICENSE.txt for this document's license.
       若無法符合條件約束的要求，叢集可能會決定不允許執行該資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       
       若將<guimenu>資源</guimenu>及<guimenu>與資源</guimenu>欄位留為空白，您也可以透過按一下<menuchoice><guimenu>新增</guimenu><guimenu>資源集</guimenu></menuchoice>來新增資源集。若要新增生命期間，只需按一下<menuchoice><guimenu>新增</guimenu><guimenu>生命期間</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>與資源</guimenu>中，定義並存目標。叢集會先決定放置此資源的位置，然後決定放置<guimenu>資源</guimenu>欄位中之資源的位置。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定義<guimenu>分數</guimenu>以決定兩個資源間的位置關係。正值表示資源應該在同一個節點上執行。負值表示資源不應該在同一個節點上執行。將分數設定為 <literal>INFINITY</literal> 會強制資源在同一節點上執行。分數設定為 <literal>-INFINITY</literal> 表示資源不得在同一節點上執行。該分數會結合其他因素來決定將資源配置於何處。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如有需要，請指定其他參數，例如<guimenu>資源角色</guimenu>。
      </para>
@@ -675,46 +679,46 @@ Please see LICENSE.txt for this document's license.
       根據所選的參數與選項，系統會顯示一條簡要<guimenu>描述</guimenu>，說明您目前所設定之並存條件約束的效果。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該條件約束的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的或修改的條件約束。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-config-gui-constraints-order">
+   <procedure xml:id="pro-ha-config-gui-constraints-order">
     <title>新增或修改順序條件約束</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主視窗中，按一下左側窗格中的<guimenu>條件約束</guimenu>，以檢視已為叢集設定的條件約束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>條件約束</guimenu>，然後按一下<guimenu>新增</guimenu>。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<guimenu>資源順序</guimenu>，然後按一下<guimenu>確定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入條件約束的唯一<guimenu>ID</guimenu>。在您修改現有的條件約束時，其 ID 已定義好，會顯示在組態對話方塊中。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用<guimenu>首先</guimenu>，定義<guimenu>接著</guimenu>所指定之資源允許啟動之前必須先啟動的資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用<guimenu>接著</guimenu>，定義在<guimenu>首先</guimenu>資源啟動之後將要啟動的資源。
      </para>
@@ -722,24 +726,24 @@ Please see LICENSE.txt for this document's license.
       根據所選的參數與選項，系統會顯示一條簡要<guimenu>描述</guimenu>，說明要設定之順序條件約束的效果。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       視需要定義其他參數，例如：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         指定<guimenu>分數</guimenu>。若大於零，則條件約束為強制性；否則僅做為建議。預設值為 <literal>INFINITY</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         指定<guimenu>對稱式</guimenu>的值。若為 <literal>true</literal>，則停止資源時使用相反順序。預設值為 <literal>true</literal>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該條件約束的組態設定。組態對話方塊會關閉，同時主視窗會顯示新增的或修改的條件約束。
      </para>
@@ -759,9 +763,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failover">
+  <section xml:id="sec-ha-configuration-failover">
    <title>指定資源容錯移轉節點</title>
    <para>
     若資源失敗，系統會自動將其重新啟動。若在目前節點上無法將其重新啟動，或資源已在目前節點上失敗 N 次，則資源會嘗試容錯移轉至其他節點。您可以定義一個數值，讓資源在失敗該次數 (<literal>migration-threshold</literal>) 之後移轉至新節點。若叢集中有兩個以上的節點，則特定資源容錯移轉所至的節點由 High Availability 軟體來選擇。
@@ -769,24 +773,24 @@ Please see LICENSE.txt for this document's license.
    <para>
     不過，您可以執行以下步驟來指定資源將容錯移轉所至的節點：
    </para>
-   <procedure id="pro-ha-config-gui-failover">
-    <step performance="required">
+   <procedure xml:id="pro-ha-config-gui-failover">
+    <step>
      <para>
       依<xref linkend="pro-ha-config-gui-constraints-location"/> 中所述為該資源設定位置條件約束。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       依<xref linkend="pro-ha-config-gui-parameters"/> 中所述將 <literal>migration-threshold</literal> 中繼屬性新增至該資源，並為該 migration-threshold 輸入<guimenu>值</guimenu>。該值應該為小於 INFINITY 的正數。
      </para>
 
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要讓資源的 failcount 自動過期，請依<xref linkend="pro-ha-config-gui-parameters"/> 中所述將 <literal>failure-timeout</literal> 中繼屬性新增至該資源，並為該 failure-timeout 輸入<guimenu>值</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要指定具有資源優先設定的其他容錯移轉節點，請建立其他位置條件約束。
      </para>
@@ -798,9 +802,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     您也可以隨時手動清理資源的 failcount，而不是等待資源的 failcount 自動過期。如需詳細資料，請參閱<xref linkend="sec-ha-configuration-cleanup"/>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-failback">
+  <section xml:id="sec-ha-configuration-failback">
    <title>指定資源錯誤回復節點 (資源粘性)</title>
    <para>
     當原始節點恢復連接且位於叢集中時，資源可以錯誤回復至該節點。若不想讓資源錯誤回復至其在容錯移轉之前所處的節點，或要為資源指定另一個要錯誤回復至的節點，您必須變更其資源粘性的值。您可以在建立資源時或建立之後指定資源粘性。
@@ -811,9 +815,9 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-stickiness">
+   <procedure xml:id="pro-ha-config-gui-stickiness">
     <title>指定資源粘性</title>
-    <step performance="required">
+    <step>
      <para>
       依<xref linkend="pro-ha-config-gui-parameters"/> 中所述將 <literal>resource-stickiness</literal> 中繼屬性新增至資源。
      </para>
@@ -828,15 +832,15 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對於 resource-stickiness 的<guimenu>值</guimenu>，請指定介於 <literal>-INFINITY</literal> 與 <literal>INFINITY</literal> 之間的值。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-utilization">
+  <section xml:id="sec-ha-configuration-utilization">
    <title>根據負載影響設定資源的配置</title>
    <para>
     並非所有資源都相同。有些資源 (例如 Xen 客體作業系統) 要求代管它們的節點滿足其容量要求。如果放置資源後其所需的容量之和超過了提供的容量，資源效能便會下降 (甚至無法執行)。
@@ -867,66 +871,66 @@ Please see LICENSE.txt for this document's license.
    <para>
     若要手動設定資源的要求和節點提供的容量，請依<xref linkend="pro-ha-config-gui-capacity"/> 所述繼續。您可以依據自己的偏好命名使用率屬性，依據組態需要定義任意數量的名稱/值對。
    </para>
-   <procedure id="pro-ha-config-gui-capacity">
+   <procedure xml:id="pro-ha-config-gui-capacity">
     <title>新增或修改使用率屬性</title>
     <para>
      在以下範例中，假設您已擁有叢集節點和資源的基本組態，現在還想要設定特定節點提供的容量和特定資源需要的容量。新增各使用率屬性的程序基本相同，只有在執行<xref linkend="step-ha-config-gui-capacity-node"/> 和<xref linkend="step-ha-config-gui-capacity-resource"/> 時有些不同。
     </para>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-node" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-node">
      <para>
       若要指定節點<emphasis>提供</emphasis>的容量：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左側窗格中，按一下<guimenu>節點</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在右側窗格中，選取要設定其容量的節點，然後按一下<guimenu>編輯</guimenu>。
        </para>
       </step>
      </substeps>
     </step>
-    <step id="step-ha-config-gui-capacity-resource" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-resource">
      <para>
       若要指定資源<emphasis>需要</emphasis>的容量：
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         在左側窗格中，按一下<guimenu>資源</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在右側窗格中，選取要設定其容量的資源，然後按一下<guimenu>編輯</guimenu>。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<guimenu>使用率</guimenu>索引標籤，然後按一下<guimenu>新增</guimenu>以新增使用率屬性。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-name" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-name">
      <para>
       輸入新屬性的<guimenu>名稱</guimenu>。您可以根據自己的偏好命名使用率屬性。
      </para>
     </step>
-    <step id="step-ha-config-gui-capacity-attr-value" performance="required">
+    <step xml:id="step-ha-config-gui-capacity-attr-value">
      <para>
       輸入屬性的<guimenu>值</guimenu>，然後按一下<guimenu>確定</guimenu>。屬性值必須為整數。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果需要更多使用率屬性，請重複<xref linkend="step-ha-config-gui-capacity-attr-name"/> 至<xref linkend="step-ha-config-gui-capacity-attr-value"/>。
      </para>
@@ -934,7 +938,7 @@ Please see LICENSE.txt for this document's license.
       <guimenu>使用率</guimenu>索引標籤顯示您已為該節點或資源定義的使用率屬性摘要。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果按需要設定了所有參數，請按一下<guimenu>確定</guimenu>關閉組態對話方塊。
      </para>
@@ -943,7 +947,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     <xref linkend="fig-ha-config-gui-capacit-node"/> 顯示了一個節點的組態，該節點為其上執行的資源提供 8 個 CPU 和 16 GB 記憶體：
    </para>
-   <figure id="fig-ha-config-gui-capacit-node">
+   <figure xml:id="fig-ha-config-gui-capacit-node">
     <title>節點容量的範例組態</title>
     <mediaobject>
      <imageobject role="fo">
@@ -957,7 +961,7 @@ Please see LICENSE.txt for this document's license.
    <para>
     其上一個資源需要 4096 KB 記憶體和 4 個 CPU 的節點的範例組態如下所示：
    </para>
-   <figure id="fig-ha-config-gui-capacit-resource">
+   <figure xml:id="fig-ha-config-gui-capacit-resource">
     <title>資源容量的範例組態</title>
     <mediaobject>
      <imageobject role="fo">
@@ -971,68 +975,68 @@ Please see LICENSE.txt for this document's license.
    <para>
     (手動或自動) 設定完節點提供的容量和資源需要的容量後，須在全域叢集選項中設定配置策略，否則容量組態不會生效。可以使用幾個策略來排程負載：例如，您可將負載集中於最少的節點上，或在所有可用的節點上平均分攤。若需更多資訊，請參閱<xref linkend="sec-ha-config-basics-utilization"/>。
    </para>
-   <procedure id="pro-ha-config-gui-placement">
+   <procedure xml:id="pro-ha-config-gui-placement">
     <title>設定配置策略</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取<menuchoice><guimenu>檢視</guimenu><guimenu>簡單模式</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>CRM 組態</guimenu>以檢視全域叢集選項及其目前值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       根據要求將<guimenu>配置策略</guimenu>設定為適當的值。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果因某些原因需要停用圍籬區隔，請取消選取「<literal>已啟用 STONITH</literal>」。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>套用</guimenu>確認您的變更。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 <?dbfo-need height="20em"?>
 
 
 
-  <sect2 id="sec-ha-configuration-monitor">
+  <section xml:id="sec-ha-configuration-monitor">
    <title>設定資源監控</title>
    <para>
     High Availability Extension 不僅可以偵測節點故障，還可以偵測節點上個別資源發生故障的時間。若要確定資源是否正在執行，必須設定針對該資源的資源監控。資源監控包括指定逾時與/或啟動延遲值以及間隔。該間隔會告知 CRM 應檢查資源狀態的頻率。您還可以設定特定參數，例如為 <literal>start</literal> 或 <literal>stop</literal> 操作設定 <literal>Timeout</literal>。
    </para>
-   <procedure id="pro-ha-config-gui-operations">
+   <procedure xml:id="pro-ha-config-gui-operations">
     <title>新增或修改監控操作</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Pacemaker GUI 主視窗中，按一下左側窗格中的<guimenu>資源</guimenu>，以檢視已為叢集設定的資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中，選取要修改的資源，然後按一下<guimenu>編輯</guimenu>。下一個視窗會顯示基本的資源參數，以及已為該資源定義的中繼屬性、例項屬性及操作。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要新增新的監控操作，請選取相應的索引標籤，然後按一下<guimenu>新增</guimenu>。
      </para>
@@ -1042,7 +1046,7 @@ Please see LICENSE.txt for this document's license.
     </step>
 
 
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>名稱</guimenu>中，選取要執行的動作，例如「<literal>監控</literal>」、「<literal>啟動</literal>」，或<guimenu>停止</guimenu>。
      </para>
@@ -1060,17 +1064,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>逾時</guimenu>欄位中輸入值 (以秒計)。操作在經過指定的逾時期間之後會被視為 <literal>failed</literal>。PE 將會決定需要採取的措施，或執行您在監控操作的<guimenu>失敗時</guimenu>欄位中指定的動作。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       視需要展開<guimenu>選擇性</guimenu>區段，然後新增參數，例如<guimenu>失敗時</guimenu>(此動作失敗時應採取何措施？) 或<guimenu>必要</guimenu>(執行此動作之前需要符合哪些條件？)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該資源的組態設定。組態對話方塊會關閉，同時主視窗會顯示修改的資源。
      </para>
@@ -1093,9 +1097,9 @@ Please see LICENSE.txt for this document's license.
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-group">
+  <section xml:id="sec-ha-configuration-group">
    <title>設定叢集資源群組</title>
    <para>
     某些叢集資源依賴於其他元件或資源，要求每個元件或資源以特定順序啟動，並在同一個伺服器上執行。若要簡化此組態，您可以使用群組。
@@ -1109,39 +1113,39 @@ Please see LICENSE.txt for this document's license.
      群組至少須包含一個資源，否則組態視為無效。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-group">
+   <procedure xml:id="pro-ha-config-gui-group">
     <title>新增資源群組</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>群組</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入群組的唯一<guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>選項</guimenu>下方，設定<guimenu>資源的初始狀態</guimenu>，然後按<guimenu>下一步</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一步中，您可以將基本資源新增為群組的子資源。建立這些資源的方式與<xref linkend="pro-ha-config-gui-primitives"/> 中所述方式類似。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>套用</guimenu>以完成該基本資源的組態設定。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一個視窗中，您可以再次選擇<guimenu>基本資源</guimenu>並按一下<guimenu>確定</guimenu>，繼續為群組新增子資源。
      </para>
@@ -1149,12 +1153,12 @@ Please see LICENSE.txt for this document's license.
       如果不想為群組新增更多基本資源，請按一下<guimenu>取消</guimenu>。下一個視窗會顯示已為該群組定義的參數摘要。其中會列出群組的<guimenu>中繼屬性</guimenu>與<guimenu>基本資源</guimenu>。<guimenu>基本資源</guimenu>索引標籤中資源的位置表示該資源在叢集中的啟動順序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       由於群組中資源的順序很重要，因此請使用<guimenu>向上</guimenu>與<guimenu>向下</guimenu>按鈕，對群組中的<guimenu>基本資源</guimenu>進行排序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要設定了所有參數後，請按一下<guimenu>確定</guimenu>以完成該群組的組態設定。組態對話方塊會關閉，同時主視窗會顯示新建的或修改的群組。
      </para>
@@ -1177,76 +1181,76 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-   <procedure id="pro-ha-config-gui-group-modify">
+   <procedure xml:id="pro-ha-config-gui-group-modify">
     <title>將資源新增至現存群組</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，切換至<guimenu>資源</guimenu>檢視窗，然後在右側窗格中選取要修改的群組，並按一下<guimenu>編輯</guimenu>。下一個視窗會顯示基本的群組參數，以及已為該資源定義的中繼屬性與基本資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>基本資源</guimenu>索引標籤，然後按一下<guimenu>新增</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一個對話方塊中，設定以下參數以將 IP 位址新增為群組的子資源：
      </para>
      <substeps performance="required">
-      <step id="step-ha-config-gui-group-prim-start" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-start">
        <para>
         輸入唯一的<guimenu>ID</guimenu>，例如 <literal>my_ipaddress</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>類別</guimenu>清單中，選取<guimenu>ocf</guimenu>做為資源代辦類別。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         對於 OCF 資源代辦的<guimenu>提供者</guimenu>，選取<guimenu>heartbeat</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>類型</guimenu>清單中，選取<guimenu>IPaddr</guimenu>做為資源代辦。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         按<guimenu>下一步</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>例項屬性</guimenu>索引標籤中，選取<guimenu>IP</guimenu>項目並按一下<guimenu>編輯</guimenu>(或在<guimenu>IP</guimenu>項目上連按兩下)。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         在<guimenu>值</guimenu>中輸入所需的 IP 位址，例如 <literal>192.168.1.180</literal>。
        </para>
       </step>
-      <step id="step-ha-config-gui-group-prim-stop" performance="required">
+      <step xml:id="step-ha-config-gui-group-prim-stop">
        <para>
         按一下<guimenu>確定</guimenu>與<guimenu>套用</guimenu>。群組組態對話方塊會顯示新增的基本資源。
        </para>
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       再按一下<guimenu>新增</guimenu>以新增下一個子資源 (檔案系統與 Web 伺服器)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為每個子資源設定相應的參數 (類似於步驟<xref linkend="step-ha-config-gui-group-prim-start"/> 至<xref linkend="step-ha-config-gui-group-prim-stop"/>)，直到您已設定此群組的所有子資源。
      </para>
@@ -1264,25 +1268,25 @@ Please see LICENSE.txt for this document's license.
       由於我們是依照子資源在叢集中的啟動順序對其進行設定，因此<guimenu>基本資源</guimenu>索引標籤中的順序已經是正確的。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若需要變更群組的資源順序，請使用<guimenu>向上</guimenu>與<guimenu>向下</guimenu>按鈕對<guimenu>基本資源</guimenu>索引標籤中的資源進行排序。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要從群組中移除某個資源，請在<guimenu>基本資源</guimenu>索引標籤中選取該資源，然後按一下<guimenu>移除</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>確定</guimenu>以完成該群組的組態設定。組態對話方塊會關閉，同時主視窗會顯示修改的群組。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-clone">
+  <section xml:id="sec-ha-configuration-clone">
    <title>設定複製品資源</title>
    <para>
     您可能要讓某些資源同時在叢集的多個節點上執行。若要實現此目的，您必須將資源設定為複製品。STONITH 及叢集檔案系統 (如 OCFS2) 這些資源便可以設定為複製品。您可以複製所提供的任何資源。相關資源的資源代辦會為此操作提供支援。您甚至可以對複製品資源進行不同的設定，具體視代管它們的節點而定。
@@ -1290,47 +1294,47 @@ Please see LICENSE.txt for this document's license.
    <para>
     如需可用複製品的綜覽，請參閱<xref linkend="sec-ha-config-basics-resources-advanced-clones"/>。
    </para>
-   <procedure id="pro-ha-config-gui-clone">
+   <procedure xml:id="pro-ha-config-gui-clone">
     <title>新增或修改複製品</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，選取<guimenu>資源</guimenu>並按一下<menuchoice><guimenu>新增</guimenu><guimenu>複製</guimenu></menuchoice>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入複製品的唯一<guimenu>ID</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>選項</guimenu>下方，設定<guimenu>資源的初始狀態</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       啟用要為複製設定的相應選項，然後按<guimenu>下一步</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在下一步中，您可以新增<guimenu>基本資源</guimenu>或<guimenu>群組</guimenu>做為複製品的子資源。建立這些資源的方式與<xref linkend="pro-ha-config-gui-primitives"/> 或<xref linkend="pro-ha-config-gui-group"/> 中所述方式類似。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按需要在複製品組態對話方塊中設定了所有參數後，請按一下<guimenu>套用</guimenu>以完成該複製品的組態設定。
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-gui-manage">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-gui-manage">
   <title>管理叢集資源</title>
 
   <para>
@@ -1349,7 +1353,7 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <sect2 id="sec-ha-configuration-start">
+  <section xml:id="sec-ha-configuration-start">
    <title>啟動資源</title>
    <para>
     啟動叢集資源之前，請先確定該資源已正確設定。例如，如果想要使用 Apache 伺服器做為叢集資源，請先設定 Apache 伺服器並完成 Apache 組態設定，然後在叢集中啟動各個資源。
@@ -1369,27 +1373,27 @@ Please see LICENSE.txt for this document's license.
    <para>
     在使用 Pacemaker GUI 建立資源的過程中，您可以使用 <literal>target-role</literal> 中繼屬性設定資源的初始狀態。若將其值設定為 <literal>stopped</literal>，則資源建立後不會自動啟動。
    </para>
-   <procedure id="pro-ha-config-gui-start">
+   <procedure xml:id="pro-ha-config-gui-start">
     <title>啟動新資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中的資源上按一下滑鼠右鍵，然後從快顯功能表中選取<guimenu>啟動</guimenu>(或使用工具列中的<guimenu>啟動資源</guimenu>圖示)。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-cleanup">
+  <section xml:id="sec-ha-configuration-cleanup">
    <title>清理資源</title>
    <para>
     若資源失敗，系統會自動將其重新啟動，但每次失敗都會增加資源的 failcount。您可以使用 Pacemaker GUI 檢視某個資源的失敗計數，只需在左側窗格中按一下<guimenu>管理</guimenu>，然後在右側窗格中選取該資源。如果資源失敗，右側窗格的中間 (位於<guimenu>移轉限定值</guimenu>項目下方) 會顯示其<guimenu>失敗計數</guimenu>。
@@ -1400,33 +1404,33 @@ Please see LICENSE.txt for this document's license.
    <para>
     資源的 failcount 可自動重設 (若為資源設定 <literal>failure-timeout</literal> 選項)，也可按如下方式手動重設。
    </para>
-   <procedure id="pro-ha-config-gui-clean">
+   <procedure xml:id="pro-ha-config-gui-clean">
     <title>清理資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中的相應資源上按一下滑鼠右鍵，然後從快顯功能表中選取<guimenu>清理資源</guimenu>(或使用工具列中的<guimenu>清理資源</guimenu>圖示)。
      </para>
      <para>
-      如此會對指定節點上的指定資源執行指令 <command>crm_resource <option>-C</option></command> 與 <command>crm_failcount <option>-D</option></command>。
+      如此會對指定節點上的指定資源執行指令 <command>crm_resource </command> <option>-C</option> 與 <command>crm_failcount </command> <option>-D</option>。
      </para>
     </step>
    </procedure>
    <para>
     如需詳細資訊，請參閱 <command>crm_resource</command> 與 <command>crm_failcount</command> 的 man 頁面。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-remove">
+  <section xml:id="sec-ha-configuration-remove">
    <title>移除叢集資源</title>
    <para>
     如果需要從叢集移除資源，請按照下面的程序操作，以免出現組態錯誤：
@@ -1438,59 +1442,59 @@ Please see LICENSE.txt for this document's license.
      若有條件約束正在參考叢集資源的 ID，則不能移除叢集資源。若無法刪除某個資源，請檢查參考該資源 ID 的位置，先從條件約束中移除該資源。
     </para>
    </note>
-   <procedure id="pro-ha-config-gui-rm">
+   <procedure xml:id="pro-ha-config-gui-rm">
     <title>移除叢集資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取右側窗格中的相應資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       依照<xref linkend="pro-ha-config-gui-clean"/> 中的說明在所有節點上清理該資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>停止</guimenu>資源。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       移除與該資源相關的所有條件約束，否則將無法移除資源。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-migrate">
+  <section xml:id="sec-ha-configuration-migrate">
    <title>移轉叢集資源</title>
    <para>
     如<xref linkend="sec-ha-configuration-failover"/> 所述，當軟體或硬體發生故障時，叢集會自動對資源進行容錯移轉 (移轉)，具體情況視您可以定義的特定參數 (例如移轉限定值或資源粘性) 而定。除此之外，您也可以手動將資源移轉至叢集中的其他節點。
    </para>
-   <procedure id="pro-ha-config-gui-migrate">
+   <procedure xml:id="pro-ha-config-gui-migrate">
     <title>手動移轉資源</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中的相應資源上按一下滑鼠右鍵，然後選取<guimenu>移轉資源</guimenu>。
      </para>
@@ -1505,17 +1509,17 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </informalfigure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在新視窗中，在<guimenu>至節點</guimenu>中選取要將資源移至的節點。如此會建立一個位置條件約束，其目的節點的分數為 <literal>INFINITY</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若只想暫時移轉資源，請啟用<guimenu>持續時間</guimenu>，並輸入資源移轉至新節點後應保留的時間。經過這段持續時間之後，資源<emphasis>可以</emphasis>移回其原始位置，也可以保留在目前的位置 (具體取決於資源粘性)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果資源無法移轉 (若資源粘性及條件約束的總分大於目前節點上的 <literal>INFINITY</literal>)，請啟用<guimenu>強制</guimenu>選項。如此會為目前位置建立規則以及一個 <literal>-INFINITY</literal> 分數，以強制資源移動。
      </para>
@@ -1525,7 +1529,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>確定</guimenu>以確認移轉。
      </para>
@@ -1534,55 +1538,55 @@ Please see LICENSE.txt for this document's license.
    <para>
     若要讓資源回到原來的狀態，請執行下列步驟：
    </para>
-   <procedure id="pro-ha-config-gui-migrate-back">
+   <procedure xml:id="pro-ha-config-gui-migrate-back">
     <title>清除移轉條件約束</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中的相應資源上按一下滑鼠右鍵，然後選取<guimenu>清除移轉條件約束</guimenu>。
      </para>
      <para>
-      此過程會使用 <command>crm_resource <option>-U</option></command> 指令。資源<emphasis>可以</emphasis>移回其原始位置，也可以保留在目前的位置 (具體取決於資源粘性)。
+      此過程會使用 <command>crm_resource </command> <option>-U</option> 指令。資源<emphasis>可以</emphasis>移回其原始位置，也可以保留在目前的位置 (具體取決於資源粘性)。
      </para>
     </step>
    </procedure>
    <para>
-    如需詳細資訊，請參閱 <command>crm_resource</command> 的 man 頁面或 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。可參閱其中的「Resource Migration」(資源移轉) 一節。<citetitle/>
+    如需詳細資訊，請參閱 <command>crm_resource</command> 的 man 頁面或 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。可參閱其中的「Resource Migration」(資源移轉) 一節。<citetitle/>
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-configuration-mgmt-mode">
+  <section xml:id="sec-ha-configuration-mgmt-mode">
    <title>變更資源的管理模式</title>
    <para>
     資源由叢集管理時，不能對其進行變更 (在叢集外部)。若要維護個別資源，可將相應資源設定成 <literal>不受管理模式</literal>，這樣您便可在叢集外部修改資源。
    </para>
    <procedure>
     <title>變更資源的管理模式</title>
-    <step performance="required">
+    <step>
      <para>
       啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在左側窗格中，按一下<guimenu>管理</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在右側窗格中的相應資源上按一下滑鼠右鍵，然後從快顯功能表中選取<guimenu>不管理資源</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       完成該資源的維護任務之後，在右側窗格中的相應資源上再按一下滑鼠右鍵，然後選取<guimenu>管理資源</guimenu>。
      </para>
@@ -1591,6 +1595,6 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
- </sect1>
+  </section>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_config_hawk.xml
+++ b/zh_TW/xml/ha_config_hawk.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_config_hawk.xml" id="cha-ha-config-hawk">
- <title>設定和管理叢集資源 (Web 介面)</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_config_hawk.xml" xml:id="cha-ha-config-hawk"><title>設定和管理叢集資源 (Web 介面)</title><info><abstract>
   <para>
    除了 <command>crm</command> 指令行工具與 Pacemaker GUI 以外，High Availability Extension 還隨附了 HA Web Konsole (Hawk)，它是一個用於執行管理任務的 Web 使用者介面。利用它，您在非 Linux 機器上也可以監控並管理 Linux 叢集。此外，如果您的系統只提供了精簡的圖形使用者介面，那麼 Hawk 將是一個理想的解決方案。
   </para>
@@ -15,15 +17,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章對 Hawk 做了介紹，說明設定和管理叢集資源的基本任務：修改全域叢集選項，建立基本與進階類型的資源 (群組和複製品)，設定條件約束，指定容錯移轉節點與錯誤回復節點，設定資源監控，啟動、清理或移除資源，以及手動移轉資源。Hawk 會產生叢集報告 (<literal>hb_report</literal>)，以提供對叢集狀態的詳細分析。您可以檢視叢集歷程，或使用模擬器瞭解可能會發生的失敗情況。
   </para>
- </abstract>
- <sect1 id="sec-ha-config-hawk-intro">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-config-hawk-intro">
   <title>Hawk — 綜覽</title>
 
   <para>
    使用 Hawk 的 Web 介面，在非 Linux 機器上也可以監控和管理 Linux 叢集。此外，如果您的系統只提供了精簡的圖形使用者介面，那麼 Hawk 將是一個理想的解決方案。
   </para>
 
-  <sect2 id="sec-ha-config-hawk-intro-connect">
+  <section xml:id="sec-ha-config-hawk-intro-connect">
    <title>啟動 Hawk 及登入</title>
    <para>
     該 Web 介面包含在 <systemitem class="resource">hawk</systemitem> 套件中。您要使用 Hawk 與之連接的所有叢集節點上都必須安裝該套件，而在要透過 Hawk 存取某個叢集節點的機器上，只需有一個啟用了 JavaScript 和 Cookie 的 (圖形) 網頁瀏覽器即可建立連接。
@@ -34,20 +38,20 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果您已使用 <systemitem class="resource">sleha-bootstrap</systemitem> 套件中的程序檔設定了叢集，則 Hawk 服務現已啟動。此時，請跳過<xref linkend="pro-ha-hawk-service"/>並繼續執行<xref linkend="pro-ha-hawk-login"/>。
    </para>
-   <procedure id="pro-ha-hawk-service">
+   <procedure xml:id="pro-ha-hawk-service">
     <title>啟動 Hawk 服務</title>
-    <step performance="required">
+    <step>
      <para>
       在您要與之連接的節點上，開啟外圍程序並以 <systemitem class="username">root</systemitem> 身分登入。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入以下指令檢查服務的狀態
      </para>
 <screen><prompt role="root">root # </prompt>rchawk status</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果服務沒有執行，則使用以下指令將其啟動
      </para>
@@ -70,7 +74,7 @@ Please see LICENSE.txt for this document's license.
      請在您要使用 Hawk 與之連接的所有節點上執行此操作。
     </para>
    </note>
-   <procedure id="pro-ha-hawk-login">
+   <procedure xml:id="pro-ha-hawk-login">
     <title>登入 Hawk Web 介面</title>
     <para>
      Hawk Web 介面使用 HTTPS 通訊協定和連接埠 <literal>7630</literal>。
@@ -80,12 +84,12 @@ Please see LICENSE.txt for this document's license.
      <title>透過虛擬 IP 存取 Hawk</title>
      <para>如果您希望即使平時連接的叢集節點已關閉，您也可以存取 Hawk，您可以為 Hawk 設定一個虛擬 IP 位址 (<literal>IPaddr</literal> 或 <literal>IPaddr2</literal>) 做為叢集資源。該位址無需任何特殊組態設定。</para>
     </note>
-    <step performance="required">
+    <step>
      <para>
       在任一機器上，啟動網頁瀏覽器並確定已啟用 JavaScript 和 Cookie。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       輸入任一執行 Hawk Web 服務之叢集節點的 IP 位址或主機名稱做為 URL。或者，輸入叢集操作人員可能已設定為資源的任何虛擬 IP 位址：
      </para>
@@ -106,12 +110,12 @@ Please see LICENSE.txt for this document's license.
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在 Hawk 登入螢幕中，輸入 <systemitem class="username">hacluster</systemitem> 使用者 (或任何屬於群組 <systemitem class="groupname">haclient</systemitem> 的其他使用者) 的<guimenu>使用者名稱</guimenu>和<guimenu>密碼</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>登入</guimenu>。
      </para>
@@ -120,15 +124,15 @@ Please see LICENSE.txt for this document's license.
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-config-hawk-intro-main">
+  <section xml:id="sec-ha-config-hawk-intro-main">
    <title>主螢幕︰叢集狀態</title>
    
    <para>
     登入後，Hawk 會顯示<guimenu>叢集狀態</guimenu>螢幕。該螢幕會顯示最重要的全域叢集參數及叢集節點與資源之狀態的摘要。以下色碼用於顯示節點和資源的狀態：
    </para>
-   <itemizedlist id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
+   <itemizedlist xml:id="il-ha-config-hawk-colors" mark="bullet" spacing="normal">
     <title>Hawk 色碼</title>
     <listitem>
      <para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
      <para>
       <guimenu>叢集圖表</guimenu>。選取此項將以圖形顯示 CIB 中設定的節點及資源。該圖表還會顯示各資源與節點指定之間的順序及並存關係 (分數)。
      </para>
-     <figure id="fig-ha-cluster-diagram" pgwide="0">
+     <figure xml:id="fig-ha-cluster-diagram" pgwide="0">
       <title>Hawk — 叢集圖表</title>
       <mediaobject>
        <imageobject role="fo">
@@ -300,9 +304,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </note>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-config-hawk-global">
+  </section>
+ </section>
+ <section xml:id="sec-ha-config-hawk-global">
   <title>設定全域叢集選項</title>
 
   <para>
@@ -322,14 +326,14 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-config-hawk-global">
+  <procedure xml:id="pro-ha-config-hawk-global">
    <title>修改全域叢集選項</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>叢集內容</guimenu>以檢視全域叢集選項及目前值。Hawk 會顯示與 <guimenu>CRM 組態</guimenu>、<guimenu>資源預設值</guimenu>和<guimenu>操作預設值</guimenu>相關的最重要的參數。
 
@@ -346,17 +350,17 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根據您的叢集要求，調整<guimenu>CRM 組態</guimenu>。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        將 <guimenu>no-quorum-policy</guimenu> 設為適當的值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果您出於某些原因需要停用圍籬區隔，請取消選取<guimenu>stonith-enabled</guimenu>。
       </para>
@@ -367,41 +371,41 @@ Please see LICENSE.txt for this document's license.
        </para>
       </important>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要從 CRM 組態中移除某個內容，請按一下該內容旁邊的減號圖示。如果某個內容被刪除，叢集會將該內容視為具有預設值。如需預設值的詳細資料，請參閱 <xref linkend="sec-ha-config-basics-meta-attr"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要為 CRM 組態新增新的內容，請從下拉式方塊中選擇一個內容，然後按一下加號圖示。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您需要變更<guimenu>資源預設值</guimenu>或<guimenu>操作預設值</guimenu>，請執行下列步驟：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        若要變更已經顯示的預設值，請在相應的輸入欄位中編輯值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要新增新的資源預設值或操作預設值，請從空白下拉式清單中選擇一個項目，然後按一下加號圖示並輸入值。如果已定義預設值，Hawk 會自動提供這些預設值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要移除資源預設值或操作預設值，請按一下參數旁邊的減號圖示。如果沒有為<guimenu>資源預設值</guimenu>和<guimenu>操作預設值</guimenu>指定值，叢集會使用<xref linkend="sec-ha-config-basics-meta-attr"/> 及<xref linkend="sec-ha-config-basics-operations"/> 中所述的預設值。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      確認您的變更。
     </para>
@@ -409,10 +413,10 @@ Please see LICENSE.txt for this document's license.
   </procedure>
 
 
- </sect1>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_config_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
- <sect1 id="sec-ha-config-hawk-dashboard">
+ </section>
+ <xi:include href="ha_hawk_rsc_config_i.xml" parse="xml"/>
+ <xi:include href="ha_hawk_rsc_manage_i.xml" parse="xml"/>
+ <section xml:id="sec-ha-config-hawk-dashboard">
 
 
   <title>監控多個叢集</title>
@@ -425,7 +429,7 @@ Please see LICENSE.txt for this document's license.
    <guimenu>叢集儀表板</guimenu>中所顯示的叢集資訊儲存在永久的 cookie 中。這表示您需要決定要在<guimenu>叢集儀表板</guimenu>上檢視的 Hawk 例項，之後就必須永遠使用該例項。要實現此目的，執行 Hawk 的機器甚至不需要屬於任何叢集，它可以是獨立的、不相關的系統。
   </para>
 
-  <procedure id="pro-ha-config-hawk-dashboard">
+  <procedure xml:id="pro-ha-config-hawk-dashboard">
    <title>使用 Hawk 監控多個叢集</title>
    <itemizedlist mark="bullet" spacing="normal">
     <title>必要條件</title>
@@ -445,18 +449,18 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <step performance="required">
+   <step>
     <para>
      在要用於監控多個叢集的機器上啟動 Hawk Web 服務。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器，並輸入執行 Hawk 之機器的 IP 位址或主機名稱做為 URL：
     </para>
 <screen>https://<replaceable>IPaddress</replaceable>:7630/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 Hawk 登入螢幕中，按一下右上角的<guimenu>儀表板</guimenu>連結。
     </para>
@@ -474,12 +478,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入<guimenu>叢集名稱</guimenu>，用於在<guimenu>叢集儀表板</guimenu>中識別叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入其中一個叢集節點的<guimenu>主機名稱</guimenu>，然後確認變更。
     </para>
@@ -487,7 +491,7 @@ Please see LICENSE.txt for this document's license.
      <guimenu>叢集儀表板</guimenu>隨即開啟，並顯示您所新增之叢集的摘要。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要將更多叢集新增至該儀表板，請按一下加號圖示，然後輸入下一個叢集的詳細資料。
     </para>
@@ -503,12 +507,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要從儀表板中移除某個叢集，請按一下該叢集摘要旁邊的 <literal>x</literal> 圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要檢視關於叢集的更多詳細資料，請按一下儀表板上叢集方塊中的某個位置。
     </para>
@@ -516,7 +520,7 @@ Please see LICENSE.txt for this document's license.
      這會開啟一個新的瀏覽器視窗或新的瀏覽器索引標籤。如果您目前未登入叢集，此操作會顯示 Hawk 登入螢幕。登入後，Hawk 會在摘要檢視窗中顯示該叢集的<guimenu>叢集狀態</guimenu>。從此處，您可以如常使用 Hawk 來管理叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      因為<guimenu>叢集儀表板</guimenu>始終是在獨立的瀏覽器視窗或索引標籤中開啟，在 Hawk 中，您可以輕鬆地在儀表板與各叢集管理任務之間切換。
     </para>
@@ -528,15 +532,15 @@ Please see LICENSE.txt for this document's license.
   </para>
 
 
- </sect1>
- <sect1 id="sec-ha-config-hawk-geo">
+ </section>
+ <section xml:id="sec-ha-config-hawk-geo">
   <title>適用於地理叢集的 Hawk</title>
 
   <para>
    如需與地理位置分散叢集 (地理叢集) 相關之 Hawk 功能的詳細資料，請參閱《<citetitle>Quick Start Geo Clustering for <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase></citetitle>》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。
   </para>
- </sect1>
- <sect1 id="sec-ha-config-hawk-trouble">
+ </section>
+ <section xml:id="sec-ha-config-hawk-trouble">
   <title>疑難排解</title>
 
   <variablelist>
@@ -559,7 +563,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-hawk-certificate">
+   <varlistentry xml:id="vle-ha-hawk-certificate">
     <term>取代自行簽署的證書</term>
     <listitem>
      <para>
@@ -605,5 +609,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_drbd.xml
+++ b/zh_TW/xml/ha_drbd.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_drbd.xml" id="cha-ha-drbd">
- <title>DRBD</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_drbd.xml" xml:id="cha-ha-drbd"><title>DRBD</title><info><abstract>
   <para>
    <emphasis>分散式複製區塊裝置</emphasis> (DRBD*) 可讓您跨 IP 網路為位於兩個不同站台的兩個區塊裝置建立鏡像。與 OpenAIS 搭配使用時，DRBD 支援分散式高可用性 Linux 叢集。本章節將介紹如何安裝及設定 DRBD。
   </para>
- </abstract>
- <sect1 id="sec-ha-drbd-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-drbd-overview">
   <title>概念綜覽</title>
 
   <para>
@@ -31,7 +35,7 @@ Please see LICENSE.txt for this document's license.
    DRBD 是 Linux 核心模組，位於下層的 I/O 規劃程式和上層的檔案系統之間，請參閱<xref linkend="fig-ha-drbd-concept"/>。若要與 DRBD 通訊，使用者需使用高階指令 <command>drbdadm</command>。為最大限度地提升靈活性，DRBD 隨附有低階工具 <command>drbdsetup</command>。
   </para>
 
-  <figure id="fig-ha-drbd-concept">
+  <figure xml:id="fig-ha-drbd-concept">
    <title>DRBD 在 Linux 中的位置</title>
    <mediaobject>
     <imageobject role="fo">
@@ -85,8 +89,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    例如，如果原始裝置的大小為 1024 MB，則 DRBD 裝置只能使用 1023 MB 來儲存資料，另有大約 70 KB 隱藏留做儲存中繼資料之用。透過 <filename>/dev/drbd<replaceable>N</replaceable></filename> 存取其餘 KB 的任何嘗試都會失敗，因為這些空間不用於儲存使用者資料。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-install">
+ </section>
+ <section xml:id="sec-ha-drbd-install">
   <title>安裝 DRBD 服務</title>
 
   <para>
@@ -97,7 +101,7 @@ Please see LICENSE.txt for this document's license.
    如果不需要完整的叢集堆疊，而只想使用 DRBD，請參閱<xref linkend="tab-ha-drbd-rpmfiles"/>。它包含了一份適用於 DRBD 的所有 RPM 套件的清單。最近的版本中，<systemitem>drbd</systemitem> 套件已分割為多個獨立套件。
   </para>
 
-  <table id="tab-ha-drbd-rpmfiles">
+  <table xml:id="tab-ha-drbd-rpmfiles">
    <title>DRBD RPM 套件</title>
    <tgroup cols="2">
     <thead>
@@ -248,8 +252,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要將其永久用於 <systemitem class="username">root</systemitem>，請建立或延伸檔案 <filename>/root/.bashrc</filename>，並插入上面的指令行。
   </para>
- </sect1>
- <sect1 id="sec-ha-drbd-configure">
+ </section>
+ <section xml:id="sec-ha-drbd-configure">
   <title>設定 DRBD 服務</title>
 
   <note><title>所需的調整</title>
@@ -268,25 +272,25 @@ Please see LICENSE.txt for this document's license.
    若要手動設定 DRBD，請執行下列步驟：
   </para>
 
-  <procedure id="step-drbd-configure">
+  <procedure xml:id="step-drbd-configure">
    <title>手動設定 DRBD</title>
-   <step performance="required">
+   <step>
      <para>如果叢集已在使用 DRBD，請將叢集置於維護模式：</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=true</screen> 
      <para>如果叢集已在使用 DRBD，而您跳過了此步驟，即時組態中的語法錯誤會導致服務關閉。</para>
      
    </step>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 使用者身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      變更 DRBD 的組態檔案︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        開啟檔案 <filename>/etc/drbd.conf</filename> 並插入以下幾行 (如果它們尚不存在)︰
       </para>
@@ -296,7 +300,7 @@ include "drbd.d/*.res";</screen>
        從 DRBD 8.3 開始，組態檔案已分割為多個獨立檔案，位於 <filename>/etc/drbd.d/</filename> 目錄下。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        開啟檔案 <filename>/etc/drbd.d/global_common.conf</filename>。該檔案中已包含一些預定義的值。轉至 <literal>startup</literal> 區段，並插入以下幾行︰
       </para>
@@ -307,25 +311,25 @@ include "drbd.d/*.res";</screen>
     degr-wfc-timeout 120;
 }</screen>
       <para>
-       這些選項可用於減少開機過程中的逾時，詳細資料請參閱 <ulink url="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>。
+       這些選項可用於減少開機過程中的逾時，詳細資料請參閱 <link xlink:href="http://www.drbd.org/users-guide-emb/re-drbdconf.html"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        建立檔案 <filename>/etc/drbd.d/r0.res</filename>，再根據具體情況變更以下幾行，然後儲存︰
       </para>
-<screen>resource r0 { <co id="co-drbd-config-r0"/>
-  device /dev/drbd0; <co id="co-drbd-config-device"/>
-  disk /dev/sda1; <co id="co-drbd-config-disk"/>
-  meta-disk internal; <co id="co-drbd-config-meta-disk"/>
-  on alice { <co id="co-drbd-config-resname"/>
-    address  192.168.1.10:7788; <co id="co-drbd-config-address"/>
+<screen>resource r0 { <co xml:id="co-drbd-config-r0"/>
+  device /dev/drbd0; <co xml:id="co-drbd-config-device"/>
+  disk /dev/sda1; <co xml:id="co-drbd-config-disk"/>
+  meta-disk internal; <co xml:id="co-drbd-config-meta-disk"/>
+  on alice { <co xml:id="co-drbd-config-resname"/>
+    address  192.168.1.10:7788; <co xml:id="co-drbd-config-address"/>
   }
   on bob { <xref linkend="co-drbd-config-resname" xrefstyle="selec:nopage"/>
     address 192.168.1.11:7788; <xref linkend="co-drbd-config-address" xrefstyle="selec:nopage"/>
   }
   syncer {
-    rate  7M; <co id="co-drbd-config-syncer-rate"/>
+    rate  7M; <co xml:id="co-drbd-config-syncer-rate"/>
   }
 }</screen>
       <calloutlist>
@@ -353,7 +357,7 @@ include "drbd.d/*.res";</screen>
        </callout>
        <callout arearefs="co-drbd-config-meta-disk">
         <para>
-         meta-disk 參數通常包含值 <literal>internal</literal>，但您也可以指定具體的裝置來儲存中繼資料。如需相關資訊，請參閱<ulink url="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>。
+         meta-disk 參數通常包含值 <literal>internal</literal>，但您也可以指定具體的裝置來儲存中繼資料。如需相關資訊，請參閱<link xlink:href="http://www.drbd.org/users-guide-emb/ch-internals.html#s-metadata"/>。
         </para>
        </callout>
        <callout arearefs="co-drbd-config-resname">
@@ -375,13 +379,13 @@ include "drbd.d/*.res";</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查組態檔案的語法。若以下指令傳回錯誤，請檢查您的檔案︰
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> dump all</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您之前已設定 Csync2 (這應該是預設設定)，則 DRBD 組態檔案現已包含在需要同步的檔案清單中。若要同步化這些檔案，請使用：
     </para>
@@ -392,7 +396,7 @@ include "drbd.d/*.res";</screen>
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在每個節點上輸入以下指令以啟始化<emphasis>兩個</emphasis>系統上的中繼資料：
     </para>
@@ -403,7 +407,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
 <screen><prompt role="root">root # </prompt> <command>dd</command> if=/dev/zero of=/dev/sda1 count=16 bs=1M</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在每個節點上輸入以下指令，檢查 DRBD 狀態︰
     </para>
@@ -416,13 +420,13 @@ m:res  cs         ro                   ds                         p  mounted  fs
 0:r0   Connected  Secondary/Secondary  Inconsistent/Inconsistent  C</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      在目標主要節點 (本範例中為 alice) 上啟動重新同步程序︰
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> -- --overwrite-data-of-peer primary r0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>rcdrbd status</command> 再次檢查狀態，您將看到︰
     </para>
@@ -435,19 +439,19 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      兩個節點上 <literal>ds</literal> 列中的狀態 (磁碟狀態) 都必須為 UpToDate。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在您的 DRBD 裝置上建立檔案系統，例如︰
     </para>
 <screen><prompt role="root">root # </prompt><command>mkfs.ext3</command> /dev/drbd/by-res/r0/0</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      掛接檔案系統並投入使用︰
     </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> /dev/drbd /mnt/</screen>
    </step>
-   <step performance="required">
+   <step>
      <para>重設叢集的維護模式旗標：</para>
     <screen><prompt role="root">root # </prompt><command>crm</command> configure property maintenance-mode=false</screen> 
    </step>
@@ -459,20 +463,20 @@ m:res  cs         ro                 ds                 p  mounted  fstype
    或者，若要使用 YaST 設定 DRBD，請執行下列步驟︰
   </para>
 
-  <procedure id="pro-drbd-configure-yast">
+  <procedure xml:id="pro-drbd-configure-yast">
    <title>使用 YaST 設定 DRBD</title>
-   <step performance="required">
+   <step>
     <para>
      啟動 YaST 並選取組態模組<menuchoice><guimenu>高可用性</guimenu> <guimenu>DRBD</guimenu></menuchoice>。如果您已設定了 DRBD 組態，YaST 會向您發出警告。YaST 將會變更您的組態，並將原來的 DRBD 組態檔案另存為 <filename>*.YaSTsave</filename>。
     </para>
      <para>將<menuchoice><guimenu>啟動組態</guimenu><guimenu>開機</guimenu></menuchoice>中的開機旗標保留原樣 (預設為 <literal>off</literal>)；請不要變更該設定，因為 Pacemaker 會管理此服務。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      實際的資源組態在<guimenu>資源組態</guimenu>中設定 (請參閱<xref linkend="fig-ha-drbd-yast-resconfig"/>)。
     </para>
     
-    <figure id="fig-ha-drbd-yast-resconfig">
+    <figure xml:id="fig-ha-drbd-yast-resconfig">
      <title>資源組態</title>
      <mediaobject>
       <imageobject role="fo">
@@ -571,7 +575,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
      上述所有選項在 <filename>/usr/share/doc/packages/drbd-utils/drbd.conf</filename> 檔案與 <command>drbd.conf(5)</command> 的 man 頁面中都以範例做了說明。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果您之前已設定 Csync2 (這應該是預設設定)，則 DRBD 組態檔案現已包含在需要同步的檔案清單中。若要同步化這些檔案，請使用：
     </para>
@@ -582,7 +586,7 @@ m:res  cs         ro                 ds                 p  mounted  fstype
 <screen><prompt role="root">root # </prompt><command>scp</command> /etc/drbd.conf bob:/etc/
 scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在每個節點上輸入以下指令，以在兩個系統上啟始化並啟動 DRBD 服務︰
     </para>
@@ -591,13 +595,13 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> create-md r0
 <prompt role="root">root # </prompt><command>rcdrbrd</command> start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <filename>alice</filename> 上輸入以下指令，將 <filename>alice</filename> 設定為主要節點：
     </para>
 <screen><prompt role="root">root # </prompt><command>drbdsetup</command> /dev/drbd0 primary --overwrite-data-of-peer</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在每個節點上輸入以下指令，檢查 DRBD 服務狀態︰
     </para>
@@ -606,56 +610,56 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      等到兩個節點上的區塊裝置完全同步後再繼續操作。重複 <command>rcdrbd status</command> 指令瞭解同步化進度。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      兩個節點上的區塊裝置完全同步後，以偏好的檔案系統格式化主要節點上的 DRBD 裝置。可以使用任何 Linux 檔案系統。建議使用 <filename>/dev/drbd/by-res/<replaceable>RESOURCE</replaceable></filename> 名稱。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-test">
+ </section>
+ <section xml:id="sec-ha-drbd-test">
   <title>測試 DRBD 服務</title>
 
   <para>
    如果安裝與組態程序按預期執行，您現在就可以執行基本的 DRBD 功能測試。此測試也有助於瞭解軟體的工作原理。
   </para>
 
-  <procedure id="pro-drbd-test">
-   <step performance="required">
+  <procedure xml:id="pro-drbd-test">
+   <step>
     <para>
      測試 alice 上的 DRBD 服務。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        開啟終端機主控台，然後以 <systemitem>root</systemitem> 身分登入。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上建立掛接點，如 <filename>/srv/r0</filename>︰
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        掛接 <command>drbd</command> 裝置︰
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd0 /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        從主要節點建立檔案︰
       </para>
 <screen><prompt role="root">root # </prompt><command>touch</command> /srv/r0/from_alice</screen>
      </step>
-      <step performance="required">
+      <step>
         <para>
           卸載 alice 上的磁碟︰
         </para>
         <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
       </step>
-      <step performance="required">
+      <step>
         <para>
           在 alice 上輸入以下指令，將 alice 上的 DRBD 服務降級︰
         </para>
@@ -663,41 +667,41 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      測試 bob 上的 DRBD 服務。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在 bob 上開啟終端機主控台，然後以 <systemitem>root</systemitem> 身分登入。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上將 DRBD 服務升級為主要服務︰
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上檢查 bob 是否為主要節點︰
       </para>
 <screen><prompt role="root">root # </prompt><command>rcdrbd</command> status</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上建立掛接點，如 <filename>/srv/r0mount</filename>︰
       </para>
 <screen><prompt role="root">root # </prompt><command>mkdir</command> /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上掛接 DRBD 裝置︰
       </para>
 <screen><prompt role="root">root # </prompt><command>mount</command> -o rw /dev/drbd_r0 /srv/r0mount</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        驗證您在 alice 上建立的檔案是否存在︰
       </para>
@@ -708,35 +712,35 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果服務在兩個節點上都可執行，即表示 DRBD 設定已完成。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      再次將 alice 設為主要節點。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在 bob 上輸入以下指令，卸下 bob 上的磁碟︰
       </para>
 <screen><prompt role="root">root # </prompt><command>umount</command> /srv/r0</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 bob 上輸入以下指令，將 bob 上的 DRBD 服務降級︰
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> secondary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上將 DRBD 服務升級為主要服務︰
       </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> primary</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在 alice 上檢查 alice 是否為主要節點︰
       </para>
@@ -744,14 +748,14 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要讓服務在伺服器出現問題時自動啟動並容錯移轉，您可以使用 OpenAIS 將 DRBD 設定為高可用性服務。如需如何安裝和設定 OpenAIS for SUSE Linux Enterprise 11 的相關資訊，請參閱<xref linkend="part-config"/>。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-drbd-tuning">
+ </section>
+ <section xml:id="sec-ha-drbd-tuning">
   <title>調整 DRBD</title>
 
   <para>
@@ -789,18 +793,18 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
    </listitem>
     <listitem>
-      <para>根據工作負載啟用讀取平衡。請參閱 <ulink url="http://blogs.linbit.com/p/256/read-balancing/"/>，以取得詳細資料。</para>
+      <para>根據工作負載啟用讀取平衡。請參閱 <link xlink:href="http://blogs.linbit.com/p/256/read-balancing/"/>，以取得詳細資料。</para>
     </listitem>
   </orderedlist>
- </sect1>
- <sect1 id="sec-ha-drbd-trouble">
+ </section>
+ <section xml:id="sec-ha-drbd-trouble">
   <title>DRBD 疑難排解</title>
 
   <para>
    DRBD 設定涉及眾多不同的元件，因此導致問題發生的原因多種多樣。以下各節將介紹幾種常見的情況並提供了多種解決方案。
   </para>
 
-  <sect2 id="sec-ha-drbd-trouble-config">
+  <section xml:id="sec-ha-drbd-trouble-config">
    <title>組態</title>
    <para>
     如果初始的 DRBD 設定未依預期運作，則可能是由於組態有問題。
@@ -809,12 +813,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     若要獲取有關組態的資訊，請執行下列步驟︰
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       開啟終端機主控台，然後以 <systemitem class="username">root</systemitem> 身分登入。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       執行 <command>drbdadm</command> (含 <command>-d</command> 選項)，測試組態檔案。輸入下列指令︰
      </para>
@@ -823,12 +827,12 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
       在 <command>adjust</command> 選項的試執行 (dry run) 期間，<command>drbdadm</command> 會將 DRBD 資源的實際組態與 DRBD 組態檔案進行比較，但不會執行呼叫。檢閱輸出，以確定您瞭解所有錯誤的來源及原因。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果檔案 <filename>/etc/drbd.d/*</filename> 與 <filename>drbd.conf</filename> 中存在錯誤，請更正後再繼續。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果分割區與設定均正確，請再次執行 <command>drbdadm</command> (不含 <command>-d</command> 選項)。
      </para>
@@ -838,9 +842,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-hostnames">
+  <section xml:id="sec-ha-drbd-hostnames">
    <title>主機名稱</title>
    <para>
     與核心中儲存的主機名稱相比 (請參閱 <command>uname -n</command> 輸出)，DRBD 的主機名稱區分大小寫 (<systemitem>Node0</systemitem> 是不同於 <systemitem>node0</systemitem> 的主機)。
@@ -848,16 +852,16 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    <para>
     如果您擁有多個網路裝置，並希望使用專屬的網路裝置，主機名稱可能不會解析成所使用的 IP 位址。在這種情況下，可以使用參數 <literal>disable-ip-verification</literal>。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-port">
+  <section xml:id="sec-ha-drbd-port">
    <title>TCP 埠 7788</title>
    <para>
     如果您的系統無法連接至對等系統，可能是因為本地防火牆有問題。依預設，DRBD 使用 TCP 埠 <literal>7788</literal> 存取其他節點。請確定在兩個節點上均可存取此連接埠。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-drbd-trouble-broken">
+  <section xml:id="sec-ha-drbd-trouble-broken">
    <title>DRBD 裝置在重新開機後損毀</title>
    <para>
     如果 DRBD 不知道存放最新資料的真實裝置，就會導致電腦分裂狀態。在這種情況下，各個 DRBD 子系統將會做為次要項目出現，並且不會相互連接。在這種情況下，可以在記錄資料中尋找以下訊息：
@@ -873,9 +877,9 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </para>
 <screen><prompt role="root">root # </prompt><command>drbdadm</command> connect r0</screen>
     <para>如此會將一個節點的資料覆寫為對等節點的資料，因此兩個節點上的檢視窗將會保持一致，從而使問題得到解決。</para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-drbd-more">
+  </section>
+ </section>
+ <section xml:id="sec-ha-drbd-more">
   <title>更多資訊</title>
 
   <para>
@@ -885,7 +889,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     專案首頁 <ulink url="http://www.drbd.org"/>。
+     專案首頁 <link xlink:href="http://www.drbd.org"/>。
     </para>
    </listitem>
    <listitem>
@@ -895,7 +899,7 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>，由 Linux Pacemaker Cluster Stack Project 提供。
+     <link xlink:href="http://clusterlabs.org/wiki/DRBD_HowTo_1.0"/>，由 Linux Pacemaker Cluster Stack Project 提供。
     </para>
    </listitem>
    <listitem>
@@ -909,8 +913,8 @@ scp /etc/drbd.d/*  bob:/etc/drbd.d/</screen>
     </para>
    </listitem>
     <listitem>
-      <para>此外，為了更方便地在整個叢集中進行儲存管理，請參閱 <ulink url="http://blogs.linbit.com/p/666/drbd-manager"/> 上關於 <citetitle>DRBD-Manager</citetitle> 的最新宣告。</para>
+      <para>此外，為了更方便地在整個叢集中進行儲存管理，請參閱 <link xlink:href="http://blogs.linbit.com/p/666/drbd-manager"/> 上關於 <citetitle>DRBD-Manager</citetitle> 的最新宣告。</para>
     </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_error_codes.xml
+++ b/zh_TW/xml/ha_error_codes.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_error_codes.xml" id="sec-ha-errorcodes">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_error_codes.xml" xml:id="sec-ha-errorcodes">
  <title>OCF 傳回代碼與失敗復原</title>
 
  <para>
@@ -378,4 +382,4 @@ Please see LICENSE.txt for this document's license.
    </tbody>
   </tgroup>
  </table>
-</sect1>
+</section>

--- a/zh_TW/xml/ha_example.xml
+++ b/zh_TW/xml/ha_example.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_example.xml" id="cha-ha-quickstart">
- <title>設定簡單測試資源的範例</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example.xml" xml:id="cha-ha-quickstart"><title>設定簡單測試資源的範例</title><info/>
+ 
  <para>
   本章提供了設定簡單資源 (IP 位址) 組態的基本範例。該範例說明如何使用 Pacemaker GUI 和 <command>crm</command> 指令行工具這兩種方法來執行此操作。
  </para>
@@ -25,6 +29,6 @@ Please see LICENSE.txt for this document's license.
    </para>
   </listitem>
  </itemizedlist>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_gui_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ha_example_cli_i.xml" parse="xml"/>
+ <xi:include href="ha_example_gui_i.xml" parse="xml"/>
+ <xi:include href="ha_example_cli_i.xml" parse="xml"/>
 </appendix>

--- a/zh_TW/xml/ha_example_cli_i.xml
+++ b/zh_TW/xml/ha_example_cli_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_cli_i.xml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_cli_i.xml">
  <title>手動設定資源</title>
 
  <para>
@@ -18,19 +22,19 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <procedure id="proc-ha-quickstart-man">
+ <procedure xml:id="proc-ha-quickstart-man">
   <title>建立 IP 位址叢集資源</title>
-  <step performance="required">
+  <step>
    <para>
     開啟外圍程序，切換為 <systemitem class="username">root</systemitem> 身分。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     輸入 <command>crm</command> <option>configure</option> 開啟內部外圍程序。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     建立 IP 位址資源：
    </para>
@@ -54,16 +58,16 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>將資源移轉至其他節點</title>
-  <step performance="required">
+  <step>
    <para>
     啟動外圍程序，並切換為 <systemitem class="username">root</systemitem> 使用者。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     將資源 <literal>myip</literal> 移轉至節點 <systemitem>saturn</systemitem>：
    </para>
 <screen><command>crm</command> resource <command>migrate</command> myIP saturn</screen>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/zh_TW/xml/ha_example_gui_i.xml
+++ b/zh_TW/xml/ha_example_gui_i.xml
@@ -1,75 +1,79 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_example_gui_i.xml" id="sec-ha-quickstart-gui">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_example_gui_i.xml" xml:id="sec-ha-quickstart-gui">
  <title>使用 GUI 設定資源</title>
 
  <para>
   建立範例叢集資源並將其移轉至其他伺服器，可協助您進行測試以確保叢集正常運作。設定和移轉的簡易資源為 IP 位址。
  </para>
 
- <procedure id="proc-ha-quickstart-gui">
+ <procedure xml:id="proc-ha-quickstart-gui">
   <title>建立 IP 位址叢集資源</title>
-  <step performance="required">
+  <step>
    <para>
     啟動 Pacemaker GUI，並依照<xref linkend="sec-ha-configuration-gui-intro-connect"/> 所述登入叢集。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在左側窗格中，切換至<guimenu>資源</guimenu>檢視窗，然後在右側窗格中選取要修改的群組，並按一下<guimenu>編輯</guimenu>。下一個視窗會顯示基本的群組參數，以及已為該資源定義的中繼屬性與基本資源。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     按一下<guimenu>基本資源</guimenu>索引標籤，然後按一下<guimenu>新增</guimenu>。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在下一個對話方塊中，設定以下參數以將 IP 位址新增為群組的子資源：
    </para>
    <substeps performance="required">
-    <step performance="required">
+    <step>
      <para>
       輸入唯一的 <literal>ID</literal>。例如，<literal>myIP</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>類別</guimenu>清單中，選取<guimenu>ocf</guimenu>做為資源代辦類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對於 OCF 資源代辦的<guimenu>提供者</guimenu>，選取<guimenu>heartbeat</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>類型</guimenu>清單中，選取<guimenu>IPaddr</guimenu>做為資源代辦。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按<guimenu>下一步</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>例項屬性</guimenu>索引標籤中，選取<guimenu>IP</guimenu>項目並按一下<guimenu>編輯</guimenu>(或在<guimenu>IP</guimenu>項目上連按兩下)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對於<guimenu>值</guimenu>，請輸入所需的 IP 位址 (例如 <literal>10.10.0.1</literal>)，然後按一下<guimenu>確定</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <guimenu>新增</guimenu>一個新的例項屬性，並將 <literal>nic</literal> 指定為<guimenu>名稱</guimenu>，將<literal>eth0</literal> 指定為<guimenu>值</guimenu>，然後按一下<guimenu>確定</guimenu>。
      </para>
@@ -79,7 +83,7 @@ Please see LICENSE.txt for this document's license.
     </step>
    </substeps>
   </step>
-  <step performance="required">
+  <step>
    <para>
     按需要設定了所有參數後，按一下<guimenu>確定</guimenu>以完成該資源的組態設定。組態對話方塊會關閉，同時主視窗會顯示修改的資源。
    </para>
@@ -96,25 +100,25 @@ Please see LICENSE.txt for this document's license.
 
  <procedure>
   <title>將資源移轉至其他節點</title>
-  <step performance="required">
+  <step>
    <para>
     切換至左側窗格中的<guimenu>管理</guimenu>檢視窗，然後在右側窗格中的 IP 位址資源上按一下滑鼠右鍵，並選取<guimenu>移轉資源</guimenu>。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     在新視窗中，從<guimenu>至節點</guimenu>下拉式清單中選取 <literal>saturn</literal>，以將所選資源移至節點 <literal>saturn</literal>。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     若只想暫時移轉資源，請啟用<guimenu>持續時間</guimenu>，並輸入資源移轉至新節點後應保留的時間。
    </para>
   </step>
-  <step performance="required">
+  <step>
    <para>
     按一下<guimenu>確定</guimenu>以確認移轉。
    </para>
   </step>
  </procedure>
-</sect1>
+</section>

--- a/zh_TW/xml/ha_fencing.xml
+++ b/zh_TW/xml/ha_fencing.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_fencing.xml" id="cha-ha-fencing">
- <title>圍籬區隔與 STONITH</title>
-
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_fencing.xml" xml:id="cha-ha-fencing"><title>圍籬區隔與 STONITH</title><info><abstract>
   <para>
    在 HA (High Availability) 的電腦叢集中，圍籬區隔是一個極其重要的概念。叢集有時會偵測到其中一個節點行為異常，需要將其移除。這稱為「<emphasis>圍籬區隔</emphasis>」，通常透過 STONITH 資源來執行。可將圍籬區隔定義為讓 HA 叢集處於已知狀態一種方法。
   </para>
@@ -20,9 +21,12 @@ Please see LICENSE.txt for this document's license.
   <para>
    如果無法確切判斷某個節點或資源的狀態，就會觸發圍籬區隔。即使叢集未注意到指定節點上發生了狀況，圍籬區隔也可以確保該節點不會執行任何重要的資源。
   </para>
- </abstract>
+ </abstract></info>
  
-   <sect1 id="sec-ha-fencing-classes">
+
+ 
+ 
+   <section xml:id="sec-ha-fencing-classes">
   <title>圍籬區隔的類別</title>
 
   <para>
@@ -51,15 +55,15 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-fencing-nodes">
+ </section>
+ <section xml:id="sec-ha-fencing-nodes">
   <title>節點層級圍籬區隔</title>
 
   <para>
    在 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 中，圍籬區隔透過 STONITH (Shoot The Other Node in the Head) 來實現。它提供節點層級的圍籬區隔。High Availability Extension 提供了 <command>stonith</command> 指令行工具，此為一個可擴充介面，用於從遠端關閉叢集中的節點。如需可用選項的綜覽，請執行 <command>stonith --help</command>，如需詳細資訊，請參閱 <command>stonith</command> 的 man 頁面。
   </para>
 
-  <sect2 id="sec-ha-fencing-nodes-devices">
+  <section xml:id="sec-ha-fencing-nodes-devices">
    <title>STONITH 裝置</title>
    <para>
     若要使用節點層級圍籬區隔，首先需要擁有一個圍籬區隔裝置。若要取得 High Availability Extension 支援的 STONITH 裝置清單，請在任何節點上執行下列其中一個指令：
@@ -115,9 +119,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     選擇何種 STONITH 裝置主要取決於您的預算及所使用的硬體類型。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-fencing-nodes-implementation">
+  <section xml:id="sec-ha-fencing-nodes-implementation">
    <title>STONITH 實作</title>
    <para>
     <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 的 STONITH 實作包含兩個元件：
@@ -146,9 +150,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-fencing-config">
+  </section>
+ </section>
+ <section xml:id="sec-ha-fencing-config">
   <title>STONITH 資源和組態</title>
 
   <para>
@@ -194,7 +198,7 @@ Please see LICENSE.txt for this document's license.
 
 <screen>stonith -t <replaceable>stonith-device-type</replaceable> -h</screen>
 
-  <sect2 id="sec-ha-fencing-config-examples">
+  <section xml:id="sec-ha-fencing-config-examples">
    <title>STONITH 資源組態範例</title>
    <para>
     下面提供了使用 <command>crm</command> 指令行工具的語法撰寫的一些範例組態。若要套用它們態，請將範例放入文字檔中 (例如，<filename>sample.txt</filename>)，然後執行以下指令：
@@ -229,7 +233,7 @@ commit</screen>
      UPS 類型圍籬區隔裝置的組態與上述範例相似。此處不做詳述。所有 UPS 裝置都採用相同的機制進行圍籬區隔，而存取裝置的方式卻有所不同。舊式 UPS 裝置只有一個序列埠，通常會使用特殊的序列纜線以 1200 鮑率進行連接。許多新型 UPS 裝置仍然只有一個序列埠，但它們通常還使用 USB 或乙太網路介面。可以使用的連接類型取決於外掛程式所支援的類型。
     </para>
     <para>
-     例如，使用 <command>stonith -t <replaceable>stonith 裝置類型</replaceable> -n</command> 指令比較 <literal>apcmaster</literal> 與 <literal>apcsmart</literal> 裝置：
+     例如，使用 <command>stonith -t</command> <replaceable>stonith 裝置類型</replaceable> -n 指令比較 <literal>apcmaster</literal> 與 <literal>apcsmart</literal> 裝置：
     </para>
 <screen>stonith -t apcmaster -h</screen>
     <para>
@@ -266,12 +270,12 @@ hostlist</screen>
      第一個外掛程式支援具有網路埠和 Telnet 通訊協定的 APC UPS。第二個外掛程式使用 APC SMART 通訊協定 (透過眾多 APC UPS 產品線皆支援的序列線)。
     </para>
    </example>
-   <example id="ex-ha-fencing-kdump">
+   <example xml:id="ex-ha-fencing-kdump">
     <title>Kdump 裝置的組態</title>
     <para> 使用 <literal>stonith:fence_kdump</literal> 資源代辦 (由 <systemitem class="resource">fence-agents</systemitem> 套件提供) 來監控已啟用 kdump 功能的所有節點。下面提供了資源的組態範例：</para>
     <screen>configure
      primitive st-kdump stonith:fence_kdump \
-     params nodename="alice "\ <co id="co-ha-fenc-kdump-nodename"/>
+     params nodename="alice "\ <co xml:id="co-ha-fenc-kdump-nodename"/>
      params pcmk_host_check="dynamic-list" \
      params pcmk_reboot_action="off" \
      params pcmk_monitor_action="metadata" \
@@ -289,11 +293,11 @@ hostlist</screen>
     <screen> /usr/lib64/fence_kdump_send -i <replaceable>INTERVAL</replaceable> -p <replaceable>PORT</replaceable> -c 1 alice bob charly [...]</screen>
     <para> 執行 kdump 的節點將在完成 kdump 後自動重新啟動。請記得在防火牆中為 <literal>fence_kdump</literal> 資源開啟一個連接埠。預設的埠是 <literal>7410</literal>。</para>
    </example>
-  </sect2>
+  </section>
 
   
- </sect1>
- <sect1 id="sec-ha-fencing-monitor">
+ </section>
+ <section xml:id="sec-ha-fencing-monitor">
   <title>監控圍籬區隔裝置</title>
 
   <para>
@@ -320,8 +324,8 @@ hostlist</screen>
   <para>
    如需如何設定監控操作的詳細資訊，請參閱<xref linkend="pro-ha-config-gui-parameters"/> (適用於 GUI 方法)，或參閱<xref linkend="sec-ha-manual-config-monitor"/> (適用於指令行方法)。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-special">
+ </section>
+ <section xml:id="sec-ha-fencing-special">
   <title>特殊圍籬區隔裝置</title>
 
   <para>
@@ -363,7 +367,7 @@ hostlist</screen>
     </term>
     <listitem>
      <para>
-      這是一個自我圍籬區隔裝置。它會對可插入到共享磁碟中的所謂<quote>毒藥丸</quote>做出反應。當共享儲存的連接中斷時，該裝置會讓節點停止運作。若要瞭解如何使用此 STONITH 代辦執行基於儲存區的圍籬區隔，請參閱<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>。也可參閱 <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/> 以取得詳細資料。
+      這是一個自我圍籬區隔裝置。它會對可插入到共享磁碟中的所謂<quote>毒藥丸</quote>做出反應。當共享儲存的連接中斷時，該裝置會讓節點停止運作。若要瞭解如何使用此 STONITH 代辦執行基於儲存區的圍籬區隔，請參閱<xref linkend="cha-ha-storage-protect" xrefstyle="select:nopage"/>、<xref linkend="pro-ha-storage-protect-fencing"/>。也可參閱 <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/> 以取得詳細資料。
      </para>
 
      <important>
@@ -409,8 +413,8 @@ hostlist</screen>
   <para>
    <literal>suicide</literal> 是<quote>I do not shoot my host</quote>(我自己不關閉我的主機) 規則的唯一例外。
   </para>
- </sect1>
- <sect1 id="sec-ha-fencing-recommend">
+ </section>
+ <section xml:id="sec-ha-fencing-recommend">
   <title>基本建議</title>
 
   <para>
@@ -466,8 +470,8 @@ hostlist</screen>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-fencing-more">
+ </section>
+ <section xml:id="sec-ha-fencing-more">
   <title>更多資訊</title>
   <variablelist>
    <varlistentry>
@@ -480,13 +484,13 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-     <term><ulink url="http://www.linux-ha.org/wiki/STONITH"/></term>
+     <term><link xlink:href="http://www.linux-ha.org/wiki/STONITH"/></term>
     <listitem>
      <para> 有關 STONITH 的資訊位於 The High Availability Linux Project 的首頁中。 </para>
     </listitem>
      </varlistentry>
      <varlistentry>
-    <term><ulink url="http://www.clusterlabs.org/doc/"/>
+    <term><link xlink:href="http://www.clusterlabs.org/doc/"/>
     </term>
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
@@ -499,7 +503,7 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
+    <term><link xlink:href="http://techthoughts.typepad.com/managing_computers/2007/10/split-brain-quo.html"/>
     </term>
     <listitem>
      <para>
@@ -508,5 +512,5 @@ hostlist</screen>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_geocluster.xml
+++ b/zh_TW/xml/ha_geocluster.xml
@@ -1,13 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_geocluster.xml" id="cha-ha-geo">
- <title>地理叢集 (多站點叢集)</title>
- <abstract>
-  <para> 除本地叢集和城際叢集外，<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 還支援地理位置分散的叢集 (地理叢集，有時稱為多站點叢集)。這意味著您可以有多個地理位置分散的站台，每個站台都有一個本地叢集。這些叢集之間的容錯移轉由一個更高階的實體來調節控制，即 <literal>booth</literal>。對地理叢集的支援是以 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的一個獨立延伸形式透提供的。如需如何使用和設定地理叢集的詳細資料，請參閱《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。可以從 <ulink url="http://www.suse.com/documentation/"/> 或者所安裝系統的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到該文件。 </para>
- </abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_geocluster.xml" xml:id="cha-ha-geo"><title>地理叢集 (多站點叢集)</title><info><abstract>
+  <para> 除本地叢集和城際叢集外，<phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 還支援地理位置分散的叢集 (地理叢集，有時稱為多站點叢集)。這意味著您可以有多個地理位置分散的站台，每個站台都有一個本地叢集。這些叢集之間的容錯移轉由一個更高階的實體來調節控制，即 <literal>booth</literal>。對地理叢集的支援是以 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的一個獨立延伸形式透提供的。如需如何使用和設定地理叢集的詳細資料，請參閱《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。可以從 <link xlink:href="http://www.suse.com/documentation/"/> 或者所安裝系統的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到該文件。 </para>
+ </abstract></info>
+ 
+ 
 </chapter>

--- a/zh_TW/xml/ha_glossary.xml
+++ b/zh_TW/xml/ha_glossary.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glossary PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE glossary>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<glossary xml:base="ha_glossary.xml" id="gl-heartb">
- <title>術語</title>
+<glossary xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_glossary.xml" xml:id="gl-heartb"><title>術語</title><info/>
+ 
  <glossentry><glossterm>主動/主動、主動/被動</glossterm>
   <glossdef>
    <para>
@@ -29,7 +33,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>bindnetaddr</systemitem> (結合網路位址)</glossterm>
+ <glossentry><glossterm>bindnetaddr (結合網路位址)</glossterm>
   <glossdef>
    <para>
     Corosync 執行檔應該結合的網路位址。 
@@ -43,7 +47,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">boothd</systemitem> (booth 精靈)</glossterm>
+ <glossentry><glossterm>boothd (booth 精靈)</glossterm>
   <glossdef>
    <para>
     地理叢集中每個參與的叢集與仲裁者都會執行服務 <systemitem class="daemon">boothd</systemitem>。該服務會與其他站台上執行的 booth 精靈連接並交換連接詳細資料。
@@ -99,7 +103,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem class="daemon">crmd</systemitem> (叢集資源管理員精靈)</glossterm>
+ <glossentry><glossterm>crmd (叢集資源管理員精靈)</glossterm>
   <glossdef>
    <para>
     CRM 實作為精靈 crmd。它在每個叢集節點上都有一個例項。所有叢集決策都是透過一個被選為主要例項的 crmd 例項集中做出的。如果所選的 crmd 程序 (或它所在的節點) 失敗，系統會建立一個新的 crmd 程序。
@@ -120,7 +124,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-dc"><glossterm>DC (指定協調者)</glossterm>
+ <glossentry xml:id="glos-dc"><glossterm>DC (指定協調者)</glossterm>
   <glossdef>
    <para>
     叢集中的一個 CRM 會被選定為指定協調者 (DC)。DC 是叢集中可以決定是否需要執行全叢集變更 (例如圍籬區隔節點或移動資源) 的唯一實體。DC 也是存放 CIB 主要副本的節點。所有其他節點均從目前 DC 取得其組態和資源配置資訊。成員發生變更後將從叢集的所有節點中選出 DC。
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-failover"><glossterm>容錯移轉</glossterm>
+ <glossentry xml:id="glo-failover"><glossterm>容錯移轉</glossterm>
   <glossdef>
    <para>
     當一台機器上的資源或節點發生故障且受影響的資源將在其他節點上啟動時，會發生此情況。
@@ -203,7 +207,7 @@ Please see LICENSE.txt for this document's license.
 
 
  
-  <glossentry id="glos-lb">
+  <glossentry xml:id="glos-lb">
    <glossterm>載入平衡</glossterm>
    <glossdef>
      <para>使多個伺服器參與同一個服務並執行相同任務的功能。</para>
@@ -224,14 +228,14 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastaddr</systemitem> (多路廣播位址)</glossterm>
+ <glossentry><glossterm>mcastaddr (多路廣播位址)</glossterm>
   <glossdef>
    <para>
       Corosync 可執行檔用於多路廣播的 IP 位址。IP 位址可以是 IPv4 或 IPv6。 
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm><systemitem>mcastport</systemitem> (多路廣播連接埠)</glossterm>
+ <glossentry><glossterm>mcastport (多路廣播連接埠)</glossterm>
   <glossdef>
    <para>
       用於叢集通訊的連接埠。
@@ -252,7 +256,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glos-geo"><glossterm>地理叢集</glossterm>
+ <glossentry xml:id="glos-geo"><glossterm>地理叢集</glossterm>
   <glossdef>
    <para>
     由多個地理位置分散的站台組成，每個站台都有一個本地叢集。這些站台透過 IP 進行通訊。站台間的容錯移轉由一個更高階的實體 (booth) 來調節控制。地理叢集需要克服有限網路頻寬與高延遲的問題。儲存是以非同步模式複製。
@@ -274,7 +278,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="gloss-quorum"><glossterm>最低節點數</glossterm>
+ <glossentry xml:id="gloss-quorum"><glossterm>最低節點數</glossterm>
   <glossdef>
    <para>
     在叢集中，如果叢集分割區擁有絕大多數節點 (或投票)，則其會被定義為具有最低節點數 (即<quote>到達法定數量</quote>)。最低節點數可準確辨識一個分割區。此部分演算法可阻止多個斷線分割區或節點繼續和導致資料與服務毀損 (電腦分裂)。最低節點數是圍籬區隔的先決條件，而圍籬區隔可確保最低節點數是唯一的。
@@ -326,7 +330,7 @@ Please see LICENSE.txt for this document's license.
   </glossdef>
  </glossentry>
 
- <glossentry id="glos-splitbrain"><glossterm>電腦分裂</glossterm>
+ <glossentry xml:id="glos-splitbrain"><glossterm>電腦分裂</glossterm>
   <glossdef>
    <para>
     在該情境下，叢集節點將被分成兩個或多個彼此不知的群組 (透過軟體或硬體故障)。STONITH 可以防止電腦分裂狀況對整個叢集產生不良影響。也稱為<quote>分割的叢集</quote>情境。
@@ -343,7 +347,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </glossdef>
  </glossentry>
- <glossentry id="glo-stonith"><glossterm>STONITH</glossterm>
+ <glossentry xml:id="glo-stonith"><glossterm>STONITH</glossterm>
   <glossdef>
    <para>
     <quote>Shoot the other node in the head</quote>(關閉另一個節點) 的首字母縮略字。它代表一種圍籬區隔機制，會關閉行為異常的節點以防止其在叢集中造成問題。

--- a/zh_TW/xml/ha_hawk_rsc_config_i.xml
+++ b/zh_TW/xml/ha_hawk_rsc_config_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_config_i.xml" id="sec-ha-config-hawk-rsc">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_config_i.xml" xml:id="sec-ha-config-hawk-rsc">
  <title>設定叢集資源</title>
 
  <para>
@@ -47,29 +51,29 @@ Please see LICENSE.txt for this document's license.
 
 
 
- <sect2 id="sec-ha-config-hawk-wizard">
+ <section xml:id="sec-ha-config-hawk-wizard">
   <title>使用設定精靈設定資源</title>
   <para>
-   High Availability Extension 隨附了一組預先定義的樣板，用於一些常用的叢集個案，例如，設定高可用性 NFS 伺服器。<systemitem class="resource">hawk-templates</systemitem> 套件中包含這些預先定義的樣板。您也可以定義自己的精靈樣板。如需詳細資訊，請參閱 <ulink url="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>。
+   High Availability Extension 隨附了一組預先定義的樣板，用於一些常用的叢集個案，例如，設定高可用性 NFS 伺服器。<systemitem class="resource">hawk-templates</systemitem> 套件中包含這些預先定義的樣板。您也可以定義自己的精靈樣板。如需詳細資訊，請參閱 <link xlink:href="https://github.com/ClusterLabs/hawk/blob/master/doc/wizard.txt"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-wizard">
+  <procedure xml:id="pro-ha-config-hawk-wizard">
    <title>使用設定精靈</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>設定精靈</guimenu>。<guimenu>叢集設定精靈</guimenu>會列出可用的資源樣板。如果您按一下某個項目，Hawk 會顯示該樣板的簡要說明文字。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取您要設定的資源集，然後按<guimenu>下一步</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按照螢幕上的指示執行操作。如需關於某個選項的資訊，按一下該選項即可在 Hawk 中顯示簡要說明文字。
     </para>
@@ -86,51 +90,51 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-primitives">
+ <section xml:id="sec-ha-config-hawk-primitives">
   <title>建立簡單叢集資源</title>
   <para>
    若要建立最基本的資源類型，請執行下列步驟：
   </para>
-  <procedure id="pro-ha-config-hawk-primitives">
+  <procedure xml:id="pro-ha-config-hawk-primitives">
    <title>新增基本資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並會列出所有已定義的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<guimenu>基本資源</guimenu>類別並按一下加號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      指定資源︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        輸入唯一的<guimenu>資源 ID</guimenu>。
       </para>
      </step>
-     <step id="step-ha-config-hawk-primitives-start" performance="required">
+     <step xml:id="step-ha-config-hawk-primitives-start">
       <para>
        在<guimenu>類別</guimenu>清單中，選取您要針對該資源使用的資源代辦類別：<guimenu>lsb</guimenu>、<guimenu>ocf</guimenu>、<guimenu>服務</guimenu> 或 <guimenu>stonith</guimenu>。如需詳細資訊，請參閱<xref linkend="sec-ha-config-basics-raclasses"/>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果選取了<guimenu>ocf</guimenu>類別，請指定 OCF 資源代辦的<guimenu>提供者</guimenu>。OCF 規格允許多個廠商提供相同的資源代辦。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在<guimenu>類型</guimenu>清單中，選取要使用的資源代辦 (例如<guimenu>IPaddr</guimenu>或<guimenu>Filesystem</guimenu>)。此資源代辦的簡要描述即會顯示。
       </para>
@@ -140,7 +144,7 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step id="step-ha-config-hawk-parameters" performance="required">
+   <step xml:id="step-ha-config-hawk-parameters">
     <para>
      Hawk 會自動顯示資源所需的所有參數，以及一個空白下拉式清單供您指定其他參數。
     </para>
@@ -148,24 +152,24 @@ Please see LICENSE.txt for this document's license.
      若要定義資源的<guimenu>參數</guimenu>(例項屬性)︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        輸入各所需參數的值。按一下參數旁邊的文字方塊，一段簡要說明文字便會顯示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要完全移除某個參數，請按一下該參數旁邊的減號圖示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要新增其他參數，請按一下空白下拉式清單，然後選取參數並輸入其值。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 會自動顯示最重要的資源<guimenu>操作</guimenu>並提供建議的預設值。如果此時不修改任何設定，Hawk 將會在您確認變更後新增其建議的操作及其預設值。
     </para>
@@ -173,7 +177,7 @@ Please see LICENSE.txt for this document's license.
      如需關於如何修改、新增或移除操作的詳細資料，請參閱<xref linkend="pro-ha-config-hawk-operations"/>。
     </para>
    </step>
-   <step id="step-ha-config-hawk-meta-attr" performance="required">
+   <step xml:id="step-ha-config-hawk-meta-attr">
     <para>
      Hawk 會自動列出資源最重要的中繼屬性，例如 <literal>target-role</literal>。
     </para>
@@ -181,24 +185,24 @@ Please see LICENSE.txt for this document's license.
      若要修改或新增<guimenu>中繼屬性</guimenu>︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        若要為屬性設定一個 (不同的) 值，請從屬性旁邊的下拉式方塊中選取值，或編輯輸入欄位中的值。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要完全移除某個中繼屬性，請按一下該屬性旁邊的減號圖示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要新增其他中繼屬性，請按一下空白下拉式方塊並選取一個屬性。該屬性的預設值即會顯示。如有需要，請依上文所述變更該值。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立資源</guimenu>完成組態。螢幕頂部的訊息會顯示該資源是否已成功建立。
     </para>
@@ -216,9 +220,9 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-stonith">
+ <section xml:id="sec-ha-config-hawk-stonith">
   <title>建立 STONITH 資源</title>
   <important>
    <title>沒有 STONITH 則不提供支援</title>
@@ -229,61 +233,61 @@ Please see LICENSE.txt for this document's license.
   <para>
    依預設，全域叢集選項 <literal>stonith-enabled</literal> 設定為 <literal>true</literal>：如果未定義 STONITH 資源，叢集將拒絕啟動任何資源。設定一或多個 STONITH 資源以完成 STONITH 設定。儘管 STONITH 的設定與其他資源相似，但它們的行為在某些方面有所不同。如需詳細資料，請參閱<xref linkend="sec-ha-fencing-config"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-stonith">
+  <procedure xml:id="pro-ha-config-hawk-stonith">
    <title>新增 STONITH 資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並列出所有定義的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<guimenu>基本資源</guimenu>類別並按一下加號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      指定資源︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        輸入唯一的<guimenu>資源 ID</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在<guimenu>類別</guimenu>清單中，選取資源代辦類別<guimenu>stonith</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        從<guimenu>類型</guimenu>清單中，選取用於控制 STONITH 裝置的 STONITH 外掛程式。此外掛程式的簡要描述即會顯示。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 會自動顯示資源的必要<guimenu>參數</guimenu>。請輸入每個參數的值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      Hawk 會顯示最重要的資源<guimenu>操作</guimenu>並提供建議的預設值。如果此時不修改任何設定，Hawk 將會在您確認後新增其建議的操作及其預設值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如無特定原因，請採用預設的<guimenu>中繼屬性</guimenu>設定。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      確認變更以建立 STONITH 資源。
     </para>
@@ -292,41 +296,41 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要完成圍籬區隔組態，請新增條件約束或使用複製品，或同時使用這兩種方式。如需詳細資訊，請參閱<xref linkend="cha-ha-fencing"/>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-templates">
+ <section xml:id="sec-ha-config-hawk-templates">
   <title>使用資源樣板</title>
   <para>
    如果您要建立大量具有相似組態的資源，定義資源樣板是最輕鬆的方法。定義資源樣板後，您可以在基本資源或某些類型的條件約束中參考該樣板。如需有關資源樣板功能和用法的詳細資訊，請參閱<xref linkend="sec-ha-config-basics-constraints-templates"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-templates-create">
+  <procedure xml:id="pro-ha-config-hawk-templates-create">
    <title>建立資源樣板</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，以及<guimenu>樣板</guimenu>類別。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<guimenu>樣板</guimenu>類別並按一下加號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入<guimenu>樣板 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      像指定基本資源一樣指定資源樣板。請依照<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/> 中的說明從<xref linkend="step-ha-config-hawk-primitives-start" xrefstyle="select:label"/> 開始。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立資源</guimenu>完成組態。螢幕頂部的訊息會顯示該資源樣板是否已成功建立。
     </para>
@@ -343,54 +347,54 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-templates-use">
+  <procedure xml:id="pro-ha-config-hawk-templates-use">
    <title>參考資源樣板</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要在基本資源中參考新建的資源樣板，請執行以下步驟：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並會列出所有定義的資源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選取<guimenu>基本資源</guimenu>類別並按一下加號圖示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        輸入唯一的<guimenu>資源 ID</guimenu>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        啟用<guimenu>使用樣板</guimenu>，然後從下拉式選單中選取要參考的樣板。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果需要，請依照<xref linkend="pro-ha-config-hawk-primitives"/> 所述指定更多<guimenu>參數</guimenu>、<guimenu>操作</guimenu>或<guimenu>中繼屬性</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要在並存或順序條件約束中參考新建的資源樣板，請執行<xref linkend="pro-ha-config-hawk-constraints-collocation-order"/> 所述的步驟。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-constraints">
+ <section xml:id="sec-ha-config-hawk-constraints">
   <title>設定資源條件約束</title>
   <para>
    設定所有資源後，需要指定叢集應如何正確處理這些資源。資源條件約束可讓您指定資源可在哪些叢集節點上執行，載入資源的順序以及特定資源所依賴的其他資源。
@@ -405,23 +409,23 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-constraints-location">
+  <procedure xml:id="pro-ha-config-hawk-constraints-location">
    <title>新增或修改位置條件約束</title>
    <para>
     對於位置條件約束，需要指定條件約束 ID、資源、分數和節點：
    </para>
 
-   <step id="step-ha-config-hawk-constraints-start" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-start">
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>條件約束</guimenu>。<guimenu>條件約束</guimenu>螢幕會顯示所有條件約束類型的類別，並會列出所有定義的條件約束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要新增新的<guimenu>位置</guimenu>條件約束，請按一下相應類別中的加號圖示。
     </para>
@@ -429,27 +433,27 @@ Please see LICENSE.txt for this document's license.
      若要修改某個現有條件約束，請按一下該條件約束旁邊的扳手圖示，然後選取<guimenu>編輯條件約束</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入唯一的<guimenu>條件約束 ID</guimenu>。若您目前在修改現有條件約束，那麼其 ID 已經定義。
     </para>
    </step>
-   <step id="step-ha-config-hawk-constraints-stop" performance="required">
+   <step xml:id="step-ha-config-hawk-constraints-stop">
     <para>
      選取要對其定義條件約束的<guimenu>資源</guimenu>。清單會顯示已為叢集設定之所有資源的 ID。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      為條件約束設定<guimenu>分數</guimenu>。正值表示資源可以在您下一步中指定的<guimenu>節點</guimenu>上執行。負值表示資源不應在該節點上執行。將分數設定為 <literal>INFINITY</literal> 會強制資源在該節點上執行。分數設定為 <literal>-INFINITY</literal> 表示資源不得在該節點上執行。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      為條件約束選取<guimenu>節點</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立條件約束</guimenu>完成組態。螢幕頂部的訊息會顯示該條件約束是否已成功建立。
     </para>
@@ -466,22 +470,22 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
-  <procedure id="pro-ha-config-hawk-constraints-collocation-order">
+  <procedure xml:id="pro-ha-config-hawk-constraints-collocation-order">
    <title>新增或修改並存或順序條件約束</title>
    <para>
     對這兩種類型的條件約束需要指定條件約束 ID 和分數，然後將資源新增至相依性鏈結：
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>條件約束</guimenu>。<guimenu>條件約束</guimenu>螢幕會顯示所有條件約束類型的類別，並列出所有定義的條件約束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要新增新的<guimenu>並存</guimenu>或<guimenu>順序</guimenu>條件約束，請按一下相應類別中的加號圖示。
     </para>
@@ -489,12 +493,12 @@ Please see LICENSE.txt for this document's license.
      若要修改某個現有條件約束，請按一下該條件約束旁邊的扳手圖示，然後選取<guimenu>編輯條件約束</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入唯一的<guimenu>條件約束 ID</guimenu>。若您目前在修改現有條件約束，那麼其 ID 已經定義。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      定義<guimenu>分數</guimenu>。
     </para>
@@ -505,27 +509,27 @@ Please see LICENSE.txt for this document's license.
      對於順序條件約束，如果分數大於零，則必須滿足條件約束，否則，條件約束只是一項建議。預設值為 <literal>INFINITY</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      對於順序條件約束通常可以啟用<guimenu>對稱</guimenu>選項。這會指定資源停止時使用相反順序。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要為條件約束定義資源，請執行以下步驟：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        從<guimenu>向條件約束新增資源</guimenu>清單中選取一個資源。清單會顯示為叢集設定之所有資源和資源樣板的 ID。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要新增選定的資源，請按一下清單旁邊的加號圖示。下方即會出現一個新清單。從該清單中選取下一個資源。由於並存和順序條件約束都是定義資源之間的相依性，因此您至少需要兩個資源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        從<guimenu>向條件約束新增資源</guimenu>清單中選取另一個資源。按一下加號圖示以新增該資源。
       </para>
@@ -539,24 +543,24 @@ Please see LICENSE.txt for this document's license.
        但是，如果您定義的是並存條件約束，則資源之間的箭頭圖示反映的是它們之間的相依性，而<emphasis>不是</emphasis>其啟動順序。由於最頂端的資源依賴於下一個資源 (下面的資源依此類推)，叢集首先會決定向哪個位置放置最後一個資源，然後根據該決定放置依賴資源。若無法符合條件約束要求，叢集可能會決定不允許執行相依資源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        為並存或順序條件約束新增所需數量的資源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果您要交換兩個資源的順序，按一下資源右側的雙箭頭即可在相依性鏈結中交換資源順序。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，請為每個資源指定更多參數，例如角色 (「<literal>主要</literal>」、「<literal>從屬</literal>」、「<literal>已啟動</literal>」或「<literal>已停止</literal>」)。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立條件約束</guimenu>完成組態。螢幕頂部的訊息會顯示該條件約束是否已成功建立。
     </para>
@@ -576,29 +580,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    您可以使用另一種格式來定義並存或順序條件約束︰資源集。資源集的順序語意與群組相同。
   </para>
-  <procedure id="pro-ha-config-hawk-constraints-sets">
+  <procedure xml:id="pro-ha-config-hawk-constraints-sets">
    <title>在並存或順序條件約束中使用資源集</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依照<xref linkend="pro-ha-config-hawk-constraints-collocation-order"/> 所述定義並存或順序條件約束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將資源新增至相依性鏈結後，按一下右側的鏈結圖示即可將這些資源放入資源集。屬於資源集的資源四周以框架圍起，以此標示資源集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      您也可以將多個資源新增至某個資源集，或建立多個資源集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要從資源集中去除某個資源，請按一下相應資源上方的剪刀圖示。
     </para>
@@ -616,14 +620,14 @@ Please see LICENSE.txt for this document's license.
      該資源即會從集中移除，並放回到它在相依性鏈結中的原始位置。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      確認變更以完成條件約束組態。
     </para>
    </step>
   </procedure>
   <para>
-   如需設定條件約束的詳細資訊，以及關於順序與並存基本概念的詳細背景資訊，請參閱 <ulink url="http://www.clusterlabs.org/doc/"/> 上提供的文件：
+   如需設定條件約束的詳細資訊，以及關於順序與並存基本概念的詳細背景資訊，請參閱 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上提供的文件：
   </para>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
@@ -642,27 +646,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
-  <procedure id="pro-ha-config-hawk-constraints-remove">
+  <procedure xml:id="pro-ha-config-hawk-constraints-remove">
    <title>移除條件約束</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>條件約束</guimenu>。<guimenu>條件約束</guimenu>螢幕會顯示所有條件約束類型的類別，並列出所有定義的條件約束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下條件約束旁邊的扳手圖示，然後選取<guimenu>移除條件約束</guimenu>。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failover">
+ <section xml:id="sec-ha-config-hawk-failover">
   <title>指定資源容錯移轉節點</title>
   <para>
    若資源失敗，系統會自動將其重新啟動。若在目前節點上無法將其重新啟動，或資源已在目前節點上失敗 N 次，則資源會嘗試容錯移轉至其他節點。您可以定義一個數值，讓資源在失敗該次數 (<literal>migration-threshold</literal>) 之後移轉至新節點。如果叢集中有兩個以上的節點，則某個資源應容錯移轉至哪個節點由 High Availability 軟體來選擇。
@@ -670,29 +674,29 @@ Please see LICENSE.txt for this document's license.
   <para>
    您可以執行以下步驟指定資源容錯移轉至某個特定節點：
   </para>
-  <procedure id="pro-ha-config-hawk-failover">
-   <step performance="required">
+  <procedure xml:id="pro-ha-config-hawk-failover">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依<xref linkend="pro-ha-config-hawk-constraints-location"/> 所述為該資源設定位置條件約束。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/> 中的<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 所述將 <literal>migration-threshold</literal> 中繼屬性新增至該資源，並為該 migration-threshold 輸入一個<guimenu>值</guimenu>。該值應該為小於 INFINITY 的正數。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要讓資源的 failcount 自動過期，請依<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/> 中的<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 所述將 <literal>failure-timeout</literal> 中繼屬性新增至該資源，並為該 failure-timeout 輸入一個<guimenu>值</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要指定具有資源優先設定的其他容錯移轉節點，請建立其他位置條件約束。
     </para>
@@ -704,9 +708,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    您也可以隨時手動清理資源的 failcount，而不是等待資源的 failcount 自動過期。如需詳細資訊，請參閱<xref linkend="sec-ha-config-hawk-cleanup"/>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-failback">
+ <section xml:id="sec-ha-config-hawk-failback">
   <title>指定資源錯誤回復節點 (資源粘性)</title>
   <para>
    當原始節點重新回到線上和叢集中時，資源可能會回復至該節點。若要防止此狀況，或要為資源指定不同的錯誤回復節點，請變更資源的粘性值。您可以在建立資源時指定資源粘性，也可以在以後指定。
@@ -717,28 +721,28 @@ Please see LICENSE.txt for this document's license.
 <?dbfo-need height="20em"?>
 
 
-  <procedure id="pro-ha-config-hawk-stickiness">
+  <procedure xml:id="pro-ha-config-hawk-stickiness">
    <title>指定資源粘性</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/> 中的<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 所述將 <literal>resource-stickiness</literal> 中繼屬性新增至資源。
     </para>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      為 resource-stickiness 指定介於 <literal>-INFINITY</literal> 和 <literal>INFINITY</literal> 之間的值。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-utilization">
+ <section xml:id="sec-ha-config-hawk-utilization">
   <title>根據負載影響設定資源的配置</title>
   <para>
    並非所有資源都相同。有些資源 (例如 Xen 客體作業系統) 要求代管它們的節點滿足其容量要求。如果投放資源後，所需的容量總和超出了提供的容量，則資源效能將會下降，或者資源將會失敗。
@@ -784,74 +788,74 @@ Please see LICENSE.txt for this document's license.
   <para>
    設定好節點提供的容量和資源需要的容量後，需在全域叢集選項中設定放置策略，否則容量組態將不會生效。可以使用幾個策略來排程負載：例如，您可將負載集中於最少的節點上，或在所有可用的節點上平均分攤。若需更多資訊，請參閱<xref linkend="sec-ha-config-basics-utilization"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-placement">
+  <procedure xml:id="pro-ha-config-hawk-placement">
    <title>設定配置策略</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>叢集內容</guimenu>以檢視全域叢集選項及目前值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      從<guimenu>新增新的內容</guimenu>下拉式清單中，選擇 <literal>placement-strategy</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根據要求將<guimenu>配置策略</guimenu>設定為適當的值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下加號圖示以新增新的叢集內容 (包括其值)。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      確認您的變更。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-monitor">
+ <section xml:id="sec-ha-config-hawk-monitor">
   <title>設定資源監控</title>
   <para>
    High Availability Extension 不僅能夠偵測節點故障，還能偵測到節點上個別資源發生的故障。若要確定某個資源是否正在執行，請對其設定資源監控。設定資源監控需指定逾時和/或啟動延遲值以及間隔。該間隔會告知 CRM 應檢查資源狀態的頻率。您還可以設定特定參數，例如為 <literal>start</literal> 或 <literal>stop</literal> 操作設定 <literal>Timeout</literal>。
   </para>
-  <procedure id="pro-ha-config-hawk-operations">
+  <procedure xml:id="pro-ha-config-hawk-operations">
    <title>新增或修改監控操作</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並列出所有定義的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取要修改的資源，按一下該資源旁邊的扳手圖示，然後選取<guimenu>編輯資源</guimenu>。資源定義即會顯示。Hawk 會自動顯示最重要的資源操作 (<literal>monitor</literal>、<literal>start</literal>、<literal>stop</literal>) 並提供建議的預設值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要變更某個操作的值：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        按一下該操作旁邊的筆型圖示。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        在開啟的對話方塊中指定以下值：
       </para>
@@ -881,24 +885,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        確認變更以關閉此對話方塊，並返回<guimenu>編輯資源</guimenu>螢幕。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要完全移除某個操作，請按一下該操作旁邊的減號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要新增其他操作，請按一下空白下拉式方塊並選取一個操作。該操作的預設值即會顯示。必要時可按一下鋼筆圖示來變更預設值。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>套用變更</guimenu>完成組態。螢幕頂部的訊息會顯示該資源是否已成功更新。
     </para>
@@ -910,9 +914,9 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要檢視發生的資源故障，請在 Hawk 中切換至<guimenu>叢集狀態</guimenu>螢幕，然後選取要查看的資源。按一下該資源旁邊的扳手圖示，然後選取<guimenu>顯示詳細資料</guimenu>。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-group">
+ <section xml:id="sec-ha-config-hawk-group">
   <title>設定叢集資源群組</title>
   <para>
    某些叢集資源依賴於其他元件或資源，且要求每個元件或資源以特定順序啟動並在同一個伺服器上執行。若要簡化此組態，您可以使用群組。
@@ -927,39 +931,39 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ha-config-hawk-group">
+  <procedure xml:id="pro-ha-config-hawk-group">
    <title>新增資源群組</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並列出所有定義的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<guimenu>群組</guimenu>類別並按一下加號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入唯一的<guimenu>群組 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要定義群組成員，請在<guimenu>可用的基本資源</guimenu>清單中選取一或多個項目，然後按一下 &lt; 圖示將其新增至<guimenu>群組子項</guimenu>清單中。所有新的群組成員都會新增至清單底部。若要定義群組成員的順序，目前您需要依所需順序逐個新增和移除這些群組成員。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，請依照<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select: lable title nopage"/>中的<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 所述修改或新增<guimenu>中繼屬性</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立群組</guimenu>完成組態。螢幕頂部的訊息會顯示該群組是否已成功建立。
     </para>
@@ -976,9 +980,9 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-confighawk-clone">
+ <section xml:id="sec-ha-confighawk-clone">
   <title>設定複製品資源</title>
   <para>
    如果希望某些資源同時在叢集中的多個節點上執行，請將這些資源設定為複製品。例如，您可以對 STONITH 這樣的資源以及 OCFS2 這樣的叢集檔案系統使用複製功能。您可以複製所提供的任何資源。資源的資源代辦支援複製。根據複製品資源執行時所在的節點，您可以對這些資源進行不同的設定。
@@ -992,39 +996,39 @@ Please see LICENSE.txt for this document's license.
     複製品可以將基本資源或群組做為子資源。在 Hawk 中，建立複製品時無法建立或修改子資源。請在新增複製品之前建立子資源並視需要對其進行設定。如需詳細資訊，請參閱<xref linkend="pro-ha-config-hawk-primitives"/> 或<xref linkend="pro-ha-config-hawk-group"/>。
    </para>
   </note>
-  <procedure id="pro-ha-config-hawk-clone">
+  <procedure xml:id="pro-ha-config-hawk-clone">
    <title>新增或修改複製品</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。<guimenu>資源</guimenu>螢幕會顯示所有資源類型的類別，並列出所有定義的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取<guimenu>複製品</guimenu>類別並按一下加號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入唯一的<guimenu>複製品 ID</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      從<guimenu>子資源</guimenu>清單中，選取要做為複製品子資源的基本資源或群組。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果需要，請依照<xref linkend="pro-ha-config-hawk-primitives" xrefstyle="select:label title nopage"/>中的<xref linkend="step-ha-config-hawk-meta-attr" xrefstyle="select:label"/> 所述修改或新增<guimenu>中繼屬性</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>建立複製品</guimenu>完成組態。螢幕頂部的訊息會顯示該複製品是否已成功建立。
     </para>
@@ -1041,5 +1045,5 @@ Please see LICENSE.txt for this document's license.
     </imageobject>
    </mediaobject>
   </figure>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_hawk_rsc_manage_i.xml
+++ b/zh_TW/xml/ha_hawk_rsc_manage_i.xml
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<sect1 xml:base="ha_hawk_rsc_manage_i.xml" id="sec-ha-config-hawk-manage">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_hawk_rsc_manage_i.xml" xml:id="sec-ha-config-hawk-manage">
  <title>管理叢集資源</title>
 
  <para>
@@ -46,7 +50,7 @@ Please see LICENSE.txt for this document's license.
   </mediaobject>
  </figure>
 
- <sect2 id="sec-ha-config-hawk-start">
+ <section xml:id="sec-ha-config-hawk-start">
   <title>啟動資源</title>
   <para>
    啟動叢集資源之前，請先確定該資源已正確設定。例如，如果想要使用 Apache 伺服器做為叢集資源，請先設定 Apache 伺服器。完成 Apache 組態設定後，再在叢集中啟動相應的資源。
@@ -66,27 +70,27 @@ Please see LICENSE.txt for this document's license.
   <para>
    透過 Hawk 建立資源時，您可以使用 <literal>target-role</literal> 中繼屬性設定該資源的初始狀態。如果將其值設定為 <literal>stopped</literal>，則資源建立後不會自動啟動。
   </para>
-  <procedure id="pro-ha-config-hawk-start">
+  <procedure xml:id="pro-ha-config-hawk-start">
    <title>啟動新資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個資源檢視中，按一下資源旁邊的扳手圖示，然後選取<guimenu>啟動</guimenu>。若要繼續，請確認顯示的訊息。資源啟動後，Hawk 會將該資源的色彩變為綠色，並顯示目前執行該資源的節點。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-cleanup">
+ <section xml:id="sec-ha-config-hawk-cleanup">
   <title>清理資源</title>
   <para>
    如果資源失敗，系統會自動將其重新啟動，但每次失敗都會增加該資源的 failcount。
@@ -97,95 +101,95 @@ Please see LICENSE.txt for this document's license.
   <para>
    資源的 failcount 可自動重設 (若為資源設定 <literal>failure-timeout</literal> 選項)，也可按如下方式手動重設。
   </para>
-  <procedure id="pro-ha-config-hawk-clean">
+  <procedure xml:id="pro-ha-config-hawk-clean">
    <title>清理資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個資源檢視中，按一下失敗資源旁邊的扳手圖示，然後選取<guimenu>清理</guimenu>。若要繼續，請確認顯示的訊息。
     </para>
 
     <para>
-     如此會對指定節點上的指定資源執行指令 <command>crm_resource <option>-C</option></command> 與 <command>crm_failcount <option>-D</option></command>。
+     如此會對指定節點上的指定資源執行指令 <command>crm_resource </command> <option>-C</option> 與 <command>crm_failcount </command> <option>-D</option>。
     </para>
    </step>
   </procedure>
   <para>
    如需詳細資訊，請參閱 <command>crm_resource</command> 與 <command>crm_failcount</command> 的 man 頁面。
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-remove">
+ <section xml:id="sec-ha-config-hawk-remove">
   <title>移除叢集資源</title>
   <para>
    如果需要從叢集移除資源，請按照下面的程序操作，以免出現組態錯誤：
   </para>
 
 
-  <procedure id="pro-ha-config-hawk-rm">
+  <procedure xml:id="pro-ha-config-hawk-rm">
    <title>移除叢集資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依照<xref linkend="pro-ha-config-hawk-clean"/> 中的說明在所有節點上清理該資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個資源檢視中，按一下資源旁邊的扳手圖示，然後選取<guimenu>停止</guimenu>。若要繼續，請確認顯示的訊息。
     </para>
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      如果資源已停止，請按一下資源旁邊的扳手圖示，然後選取<guimenu>刪除資源</guimenu>。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-migrate">
+ <section xml:id="sec-ha-config-hawk-migrate">
   <title>移轉叢集資源</title>
   <para>
    如<xref linkend="sec-ha-config-hawk-failover"/> 所述，當軟體或硬體發生故障時，叢集會自動對資源進行容錯移轉 (移轉)，具體情況視您可以定義的特定參數 (例如移轉限定值或資源粘性) 而定。除此之外，您也可以手動將資源移轉至叢集中的其他節點。或者，您可以選擇將資源移出目前節點，並讓叢集決定要將它放在哪個位置。
   </para>
-  <procedure id="pro-ha-config-hawk-migrate">
+  <procedure xml:id="pro-ha-config-hawk-migrate">
    <title>手動移轉資源</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個資源檢視中，按一下資源旁邊的扳手圖示，然後選取<guimenu>移動</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在新視窗中選取要將資源移至其中的節點。
     </para>
@@ -193,7 +197,7 @@ Please see LICENSE.txt for this document's license.
      如此會建立一個位置條件約束，其目的節點的分數為 <literal>INFINITY</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      或者，選擇將資源<guimenu>從目前節點移開</guimenu>。
     </para>
@@ -213,7 +217,7 @@ Please see LICENSE.txt for this document's license.
 
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>確定</guimenu>以確認移轉。
     </para>
@@ -222,33 +226,33 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要讓資源回到原來的狀態，請執行下列步驟：
   </para>
-  <procedure id="pro-ha-config-hawk-migrate-back">
+  <procedure xml:id="pro-ha-config-hawk-migrate-back">
    <title>清除移轉條件約束</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個資源檢視中，按一下資源旁邊的扳手圖示，然後選取<guimenu>放棄重新配置規則</guimenu>。若要繼續，請確認顯示的訊息。
     </para>
     <para>
-     此過程會使用 <command>crm_resource <option>-U</option></command> 指令。資源<emphasis>可以</emphasis>移回其原始位置，也可以保留在目前的位置 (具體取決於資源粘性)。
+     此過程會使用 <command>crm_resource </command> <option>-U</option> 指令。資源<emphasis>可以</emphasis>移回其原始位置，也可以保留在目前的位置 (具體取決於資源粘性)。
     </para>
    </step>
   </procedure>
   <para>
-   如需詳細資訊，請參閱 <command>crm_resource</command> 的 man 頁面或 <ulink url="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。可參閱其中的「Resource Migration」(資源移轉) 一節。<citetitle/>
+   如需詳細資訊，請參閱 <command>crm_resource</command> 的 man 頁面或 <link xlink:href="http://www.clusterlabs.org/doc/"/> 上的《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明)。可參閱其中的「Resource Migration」(資源移轉) 一節。<citetitle/>
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-maint-mode">
+ <section xml:id="sec-ha-config-hawk-maint-mode">
   <title>使用維護模式</title>
     <para>您可能不時地需要對個別叢集元件或整個叢集執行測試或維護任務 — 變更叢集組態、更新個別節點的軟體套件，或者將叢集升級到更高的產品版本。 </para>
     <para>
@@ -291,39 +295,39 @@ Please see LICENSE.txt for this document's license.
    <para>
    如需處於維護模式的資源和叢集會發生之情況的詳細資料，請參閱<xref linkend="sec-ha-config-basics-maint-mode"/>。
   </para>
-  <procedure id="pro-ha-config-hawk-maint-mode-rsc">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-rsc">
    <title>向資源套用維護模式</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中，選取<guimenu>資源</guimenu>。選取要將其置於維護模式或不受管理模式的資源，然後按一下資源旁邊的扳手圖示並選取<guimenu>編輯資源</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      開啟<guimenu>中繼屬性</guimenu>類別。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      從空白下拉式清單中，選取 <guimenu>maintenance</guimenu> 屬性並按一下加號圖示新增該屬性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      啟用 <literal>maintenance</literal> 旁邊的核取方塊，將 maintenance 屬性設定為 <literal>yes</literal>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      確認您的變更。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      完成針對該資源的維護任務後，停用該資源 <literal>maintenance</literal> 屬性旁邊的核取方塊。
     </para>
@@ -333,23 +337,23 @@ Please see LICENSE.txt for this document's license.
    </step>
   </procedure>
 
-  <procedure id="pro-ha-config-hawk-maint-mode-nodes">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-nodes">
    <title>向節點套用維護模式</title>
    <para>
     有時，需要將個別節點置於維護模式。
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在其中一個節點檢視窗中，按一下節點旁邊的扳手圖示，然後選取<guimenu>維護</guimenu>。
     </para>
@@ -357,38 +361,38 @@ Please see LICENSE.txt for this document's license.
      如此會將以下例項屬性新增至該節點：<literal>maintenance="true"</literal>。先前在這個維護模式節點上執行的資源將會變成<literal>未受管理</literal>模式。在該節點脫離維護模式之前，系統將不會為其配置任何新的資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要停用維護模式，請按一下節點旁邊的扳手圖示，然後選取<guimenu>就緒</guimenu>。
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-maint-mode-cluster">
+  <procedure xml:id="pro-ha-config-hawk-maint-mode-cluster">
    <title>向叢集套用維護模式</title>
    <para>
     若要為整個叢集設定或取消設定維護模式，請執行下列步驟：
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集組態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <guimenu>CRM 組態</guimenu>群組中，從空白下拉式方塊中選取 <guimenu>maintenance-mode</guimenu> 屬性，然後按一下加號圖示新增該屬性。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要設定 <literal>maintenance-mode=true</literal>，請啟用 <literal>maintenance-mode</literal> 旁邊的核取方塊，並確認您所做的變更。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      完成針對整個叢集的維護任務後，停用 <literal>maintenance-mode</literal> 屬性旁邊的核取方塊。
     </para>
@@ -397,27 +401,27 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-history">
+ <section xml:id="sec-ha-config-hawk-history">
   <title>檢視叢集歷程</title>
 
   <para>
    Hawk 提供了以下用於檢視叢集過往事件 (按不同的層級和不同的詳細程度) 的功能。
   </para>
-  <procedure id="pro-ha-config-hawk-recent">
+  <procedure xml:id="pro-ha-config-hawk-recent">
    <title>檢視節點或資源的最近事件</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>叢集狀態</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>樹狀檢視</guimenu>或<guimenu>表格檢視</guimenu>中，按一下目標資源或節點旁邊的扳手圖示，然後選取<guimenu>檢視最近的事件</guimenu>。
     </para>
@@ -426,28 +430,28 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
-  <procedure id="pro-ha-config-hawk-history-explorer">
+  <procedure xml:id="pro-ha-config-hawk-history-explorer">
    <title>使用歷程總管檢視轉換</title>
    <para>
     <guimenu>歷程總管</guimenu>提供某個時間範圍內 (您可以定義此時間範圍) 的轉換資訊。它還會列出其先前執行的歷程，並可讓您<guimenu>刪除</guimenu>不再需要的報告。<guimenu>歷程總管</guimenu>使用 <literal>hb_report</literal> 提供的資訊。 
 
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在左側導覽列中選取<guimenu>歷程總管</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      瀏覽時段預設設為過去的 24 小時。若要修改此值，請設定其他<guimenu>開始時間</guimenu>和<guimenu>結束時間</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>顯示</guimenu>開始收集轉換資料。
     </para>
@@ -467,7 +471,7 @@ Please see LICENSE.txt for this document's license.
   <para>
    下列資訊就會顯示：
   </para>
-  <variablelist id="vl-hawk-history-results">
+  <variablelist xml:id="vl-hawk-history-results">
    <title>歷程總管結果</title>
    <varlistentry>
     <term><guimenu>時間</guimenu>
@@ -493,7 +497,7 @@ Please see LICENSE.txt for this document's license.
 
     <listitem>
      <para>
-      開啟一個快顯視窗，其中會顯示屬於該特定轉換之記錄資料的片段。視窗可以顯示不同程度的詳細資料：按一下<guimenu>詳細資料</guimenu>會顯示 <command>crm history transition <replaceable>peinput</replaceable></command> 的輸出 (包括資源代辦的記錄訊息)。按一下<guimenu>完整記錄</guimenu>還會顯示來自 <systemitem>pengine</systemitem>、<systemitem>crmd</systemitem> 與 <systemitem>lrmd</systemitem> 的詳細資料，該按鈕的作用相當於 <command>crm history transition log <replaceable>peinput</replaceable></command> 指令。
+      開啟一個快顯視窗，其中會顯示屬於該特定轉換之記錄資料的片段。視窗可以顯示不同程度的詳細資料：按一下<guimenu>詳細資料</guimenu>會顯示 <command>crm history transition</command> <replaceable>peinput</replaceable> 的輸出 (包括資源代辦的記錄訊息)。按一下<guimenu>完整記錄</guimenu>還會顯示來自 <systemitem>pengine</systemitem>、<systemitem>crmd</systemitem> 與 <systemitem>lrmd</systemitem> 的詳細資料，該按鈕的作用相當於 <command>crm history transition log</command> <replaceable>peinput</replaceable> 指令。
      </para>
     </listitem>
    </varlistentry>
@@ -529,22 +533,22 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-simulator">
+ <section xml:id="sec-ha-config-hawk-simulator">
   <title>瞭解可能發生的失敗個案</title>
 
   <para>
    Hawk 提供了一個<guimenu>模擬器</guimenu>，可讓您瞭解會發生的故障情境，以防患於未然。切換至模擬器模式後，可以變更節點狀態，新增或編輯資源與條件約束，變更叢集組態，或執行多個資源操作，以瞭解這些事件發生時叢集的行為。只要啟動模擬器模式，<guimenu>叢集狀態</guimenu>螢幕右下角就會顯示一個控制對話方塊。模擬器會收集所有螢幕中發生的變更並將它們新增至其內部事件佇列中。除非在控制對話方塊中手動觸發，否則使用排入佇列的事件來執行模擬將不會成功。執行模擬後，您可以檢視並分析可能會發生的情況的詳細資料 (記錄片段、轉換圖形和 CIB 狀態)。
   </para>
-  <procedure id="pro-ha-config-hawk-simulator">
+  <procedure xml:id="pro-ha-config-hawk-simulator">
    <title>切換至模擬器模式</title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要啟用模擬器模式，請按一下頂層列中的扳手圖示 (使用者名稱旁邊)，然後選取<guimenu>模擬器</guimenu>。
     </para>
@@ -552,24 +556,24 @@ Please see LICENSE.txt for this document's license.
      Hawk 的背景色彩即會變更，指出模擬器正在使用中。模擬器控制對話方塊顯示在<guimenu>叢集狀態</guimenu>螢幕右下角。其標題<guimenu>模擬器 (初始狀態)</guimenu>指示尚未執行過模擬器。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      填入模擬器的事件佇列：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        若要模擬某個節點的狀態變更：在模擬器控制對話方塊中按一下<guimenu>+節點</guimenu>。選取您要操作的<guimenu>節點</guimenu>，並選取其目標<guimenu>狀態</guimenu>。確認變更，以將其新增至控制器對話方塊中列出的事件佇列中。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要模擬資源操作：在模擬器控制對話方塊中按一下<guimenu>+操作</guimenu>。選取要操作的<guimenu>資源</guimenu>，以及要模擬的<guimenu>操作</guimenu>。如有必要，請定義一個<guimenu>間隔</guimenu>。選取要在其上執行該操作的<guimenu>節點</guimenu>以及預期的<guimenu>結果</guimenu>。確認變更，以將其新增至控制器對話方塊中列出的事件佇列中。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      對要模擬的任何其他節點狀態或資源操作重複上述步驟。
     </para>
@@ -585,12 +589,12 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要插入其他要模擬的變更：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        切換至下列一或多個 Hawk 螢幕：<guimenu>叢集狀態</guimenu>、<guimenu>設定精靈</guimenu>、<guimenu>叢集組態</guimenu>、<guimenu>資源</guimenu>或<guimenu>條件約束</guimenu>。
       </para>
@@ -601,7 +605,7 @@ Please see LICENSE.txt for this document's license.
        </para>
       </note>
      </step>
-     <step performance="required">
+     <step>
       <para>
        視需要在螢幕上新增或修改參數。
       </para>
@@ -610,19 +614,19 @@ Please see LICENSE.txt for this document's license.
        
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        若要回到模擬器控制對話方塊，請切換至<guimenu>叢集狀態</guimenu>螢幕，或按一下頂層列中的扳手圖示，然後再次按一下<guimenu>模擬器</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要移除<guimenu>已插入狀態</guimenu>中列出的事件，請選取相應的項目，然後按一下清單下方的減號圖示。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在模擬器控制對話方塊中按一下<guimenu>執行</guimenu>，啟動該輪模擬。<guimenu>叢集狀態</guimenu>螢幕即會顯示模擬的事件。例如，如果將某個節點標示為未清理，該節點現在將顯示為離線，並且它的所有資源都將停止。模擬器控制對話方塊將變更為<guimenu>模擬器 (最終狀態)</guimenu>。
     </para>
@@ -638,70 +642,70 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </figure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要檢視關於模擬執行的更多詳細資訊：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        在模擬器對話方塊中按一下<guimenu>詳細資料</guimenu>連結，以查看所發生之情況的記錄片段。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        按一下<guimenu>圖形</guimenu>連結，以顯示轉換圖形。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        按一下<guimenu>CIB (入)</guimenu>，以顯示初始 CIB 狀態。若要查看轉換後 CIB 的內容，請按一下<guimenu>CIB (出)</guimenu>。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要從頭開始進行一次新模擬，請使用<guimenu>重設</guimenu>按鈕。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要離開模擬模式，請關閉模擬器控制對話方塊。<guimenu>叢集狀態</guimenu>螢幕將切換回其正常色彩，並顯示目前叢集狀態。
     </para>
    </step>
   </procedure>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-config-hawk-crm-report">
+ <section xml:id="sec-ha-config-hawk-crm-report">
   <title>產生叢集報告</title>
 
   <para>
    為了分析和診斷叢集發生的問題，Hawk 可以產生叢集報告，用於從叢集中的所有節點收集資訊。
   </para>
-  <procedure id="pro-ha-config-hawk-crm-report">
+  <procedure xml:id="pro-ha-config-hawk-crm-report">
    <title>產生 <literal>hb_report</literal></title>
-   <step performance="required">
+   <step>
     <para>
      啟動網頁瀏覽器並依<xref linkend="sec-ha-config-hawk-intro-connect"/> 所述登入叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下頂層列中使用者名稱旁邊的扳手圖示，然後選取<guimenu>產生 hb_report</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查時段預設為過去 1 小時。若要修改此值，請設定其他<guimenu>開始時間</guimenu>和<guimenu>結束時間</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>產生</guimenu>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      建立報告後，按一下相應的連結以下載 <filename>*.tar.bz2</filename> 檔案。
     </para>
@@ -710,5 +714,5 @@ Please see LICENSE.txt for this document's license.
   <para>
    如需 <literal>hb_report</literal> 和 <literal>crm_report</literal> 等工具涉及之記錄檔案的詳細資訊，請參閱<xref linkend="vle-ha-crm-report"/>。
   </para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_installation.xml
+++ b/zh_TW/xml/ha_installation.xml
@@ -1,20 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_installation.xml" id="cha-ha-installation">
- <title>安裝與基本設定</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_installation.xml" xml:id="cha-ha-installation"><?dbfo-need height="20em"?><title>安裝與基本設定</title><info><abstract>
   <para> 本章說明如何重頭開始安裝和設定 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase>。選擇自動設定或手動設定。自動設定可讓您在數分鐘之內便擁有一個運作中的叢集 (您可以選擇在稍後調整任何選項)，而手動設定則可讓您一開始就設定好個別選項。 </para>
 
   <para>
    若要移轉執行舊版 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 的叢集，或是更新屬於執行中叢集之節點上的軟體套件，請參閱<xref linkend="app-ha-migration"/>一章。
   </para>
- </abstract>
- <sect1 id="sec-ha-installation-terms">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-installation-terms">
   <title>術語定義</title>
   <para>本章使用了一些術語，其定義如下。</para>
   <variablelist>
@@ -40,7 +44,7 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-mcastaddr">
+   <varlistentry xml:id="vle-ha-mcastaddr">
     <term>多路廣播位址 (<systemitem>mcastaddr</systemitem>)
    </term>
     <listitem>
@@ -80,11 +84,11 @@ Please see LICENSE.txt for this document's license.
      </note>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-rrp">
+   <varlistentry xml:id="vle-ha-rrp">
     <term>備援環狀通訊協定 (RRP)</term>
     <listitem>
      <para>
-       允許使用多重備援區域網路，以針對部分或全部網路錯誤提供恢復功能。如此一來，只要有一個網路正常運作，便仍可進行叢集通訊。Corosync 支援 Totem 備援環狀通訊協定。系統會對所有參與節點施加一個邏輯記號傳遞環，以安全穩妥地傳遞訊息。只有持有記號的節點才允許廣播訊息。若需更多資訊，請參閱<ulink url="http://www.rcsc.de/pdf/icdcs02.pdf"/>。
+       允許使用多重備援區域網路，以針對部分或全部網路錯誤提供恢復功能。如此一來，只要有一個網路正常運作，便仍可進行叢集通訊。Corosync 支援 Totem 備援環狀通訊協定。系統會對所有參與節點施加一個邏輯記號傳遞環，以安全穩妥地傳遞訊息。只有持有記號的節點才允許廣播訊息。若需更多資訊，請參閱<link xlink:href="http://www.rcsc.de/pdf/icdcs02.pdf"/>。
      </para>
      <para>
       如果 Corosync 中已定義備援通訊通道，請使用 RRP 告知叢集如何使用這些介面。RRP 有三種模式 (<literal>rrp_mode</literal>)：
@@ -119,7 +123,7 @@ Please see LICENSE.txt for this document's license.
       Csync2 使用 IP 位址和預先共用金鑰在同步群組內進行驗證。您需要為每個同步化群組產生一個金鑰檔案，並將其複製到群組中的所有成員。
      </para>
      <para>
-      如需有關 Csync2 的詳細資訊，請參閱 <ulink url="http://oss.linbit.com/csync2/paper.pdf"/>。
+      如需有關 Csync2 的詳細資訊，請參閱 <link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -127,7 +131,7 @@ Please see LICENSE.txt for this document's license.
     <term><systemitem class="resource">conntrack 工具</systemitem></term>
     <listitem>
      <para>
-      使用這些工具可與內核連接追蹤系統互動，以對 iptables 啟用<emphasis>陳述</emphasis>封包檢查。High Availability Extension 使用它來在叢集節點之間同步連接狀態。如需詳細資訊，請參閱 <ulink url="http://conntrack-tools.netfilter.org/"/>。
+      使用這些工具可與內核連接追蹤系統互動，以對 iptables 啟用<emphasis>陳述</emphasis>封包檢查。High Availability Extension 使用它來在叢集節點之間同步連接狀態。如需詳細資訊，請參閱 <link xlink:href="http://conntrack-tools.netfilter.org/"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -138,16 +142,16 @@ Please see LICENSE.txt for this document's license.
       AutoYaST 這套系統可在不需使用者互動的情況下自動安裝一或多個 SUSE Linux Enterprise 系統。在 SUSE Linux Enterprise 上，您可以建立包含安裝與組態資料的 AutoYaST 設定檔。此設定檔會告訴 AutoYaST 要安裝什麼，及如何設定安裝的系統，以便最終部署一個即用系統。之後，可以採用多種方式使用此設定檔進行大規模部署 (例如，複製現存叢集節點)。
      </para>
      <para>
-      如需如何在不同情況下使用 AutoYaST 的詳細指示，請參閱 <ulink url="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。詳情位於「<citetitle>自動安裝</citetitle>」一章。
+      如需如何在不同情況下使用 AutoYaST 的詳細指示，請參閱 <link xlink:href="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。詳情位於「<citetitle>自動安裝</citetitle>」一章。
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
-<?dbfo-need height="20em"?>
+ </section>
 
 
- <sect1 id="sec-ha-installation-overview">
+
+ <section xml:id="sec-ha-installation-overview">
   <title>綜覽</title>
 
   <para>
@@ -156,7 +160,7 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="sec-ha-installation-add-on" xrefstyle="select:title"/>︰
     </para>
@@ -166,7 +170,7 @@ Please see LICENSE.txt for this document's license.
 <screen><prompt role="root">root # </prompt><command>zypper</command> in -t pattern ha_sles</screen>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      初始設定叢集︰
     </para>
@@ -174,32 +178,32 @@ Please see LICENSE.txt for this document's license.
      在將會成為叢集成員的所有節點上安裝軟體後，需要執行以下步驟以初始設定叢集。
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-channels" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選擇性︰<xref linkend="sec-ha-installation-setup-security" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-csync2" xrefstyle="select:title"/>。由於 Csync2 的組態只是在一個節點上設定，因此所有節點上都需要啟動 Csync2 及 <systemitem class="daemon">xinetd</systemitem> 服務。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選擇性︰<xref linkend="sec-ha-installation-setup-conntrackd" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-setup-services" xrefstyle="select:title"/>
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        <xref linkend="sec-ha-installation-start" xrefstyle="select:title"/>。所有節點上都需要啟動 OpenAIS/Corosync 服務。
       </para>
@@ -232,19 +236,19 @@ Please see LICENSE.txt for this document's license.
   <para>
    若要進行大規模部署，也可以透過 AutoYaST 複製現存節點。複製的節點將安裝相同的套件並具有相同的系統組態。如需詳細資料，請參閱<xref linkend="sec-ha-installation-autoyast"/>。
   </para>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-add-on">
+ <section xml:id="sec-ha-installation-add-on">
   <title>安裝為附加產品</title>
 
   <para>
-   <literal>高可用性</literal>安裝模式中包含了使用 High Availability Extension 設定與管理叢集所需的套件。此模式只在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 已做為 SUSE® Linux Enterprise Server 的附加產品安裝後才能使用。如需如何安裝附加產品的資訊，請參閱 <ulink url="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。詳情位於「<citetitle>安裝附加產品</citetitle>」一章。
+   <literal>高可用性</literal>安裝模式中包含了使用 High Availability Extension 設定與管理叢集所需的套件。此模式只在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 已做為 SUSE® Linux Enterprise Server 的附加產品安裝後才能使用。如需如何安裝附加產品的資訊，請參閱 <link xlink:href="http://www.suse.com/doc"/> 上的《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》。詳情位於「<citetitle>安裝附加產品</citetitle>」一章。
 
   </para>
 
-  <procedure id="pro-ha-install-pattern">
+  <procedure xml:id="pro-ha-install-pattern">
    <title>安裝高可用性模式</title>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 使用者身分啟動 YaST，然後選取<menuchoice><guimenu>軟體</guimenu> <guimenu>軟體管理</guimenu></menuchoice>。
     </para>
@@ -252,12 +256,12 @@ Please see LICENSE.txt for this document's license.
      或者在指令行上以 <systemitem class="username">root</systemitem> 身分使用 <command>yast2 sw_single</command> 啟動 YaST 模組。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      從<guimenu>過濾器</guimenu>清單中選取<guimenu>模式</guimenu>，然後啟用模式清單中的<guimenu>高可用性</guimenu>模式。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>接受</guimenu>開始安裝套件。
     </para>
@@ -267,7 +271,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </note>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<emphasis>所有</emphasis>將成為叢集成員的機器上安裝高可用性模式。
     </para>
@@ -276,9 +280,9 @@ Please see LICENSE.txt for this document's license.
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-installation-setup-auto">
+ <section xml:id="sec-ha-installation-setup-auto">
   <title>自動設定叢集 (sleha-bootstrap)</title>
 
   <para> <systemitem class="resource">sleha-bootstrap</systemitem> 套件中提供了設定正常執行的單節點叢集、將更多節點加入叢集以及從現存叢集中移除節點所需要的一切功能︰ </para>
@@ -331,40 +335,40 @@ Please see LICENSE.txt for this document's license.
    </listitem>
   </itemizedlist>
 
-  <procedure id="pro-ha-installation-setup-sleha-init">
+  <procedure xml:id="pro-ha-installation-setup-sleha-init">
    <title>自動設定第一個節點</title>
    <para> <command>sleha-init</command> 指令會檢查 NTP 的組態，並引導您完成設定叢集通訊層 (Corosync) 組態以及 (選擇性) SBD 組態的步驟，以保護您的共享儲存區。請執行下列步驟。如需詳細資料，請參閱 <command>sleha-init</command> man 頁面。 </para>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 身分登入要做為叢集節點的實體或虛擬機器。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 執行如下指令啟動開機程序檔 </para>
     <screen><prompt role="root">root # </prompt>sleha-init</screen>
     <para> 如果 NTP 未設定為在開機時啟動，則會出現一則訊息。 </para>
     <para> 如果您決定仍要繼續，該程序檔將會自動產生用於 SSH 存取及 Csync2 同步工具的密鑰，並啟動這兩項任務所需的服務。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 若要設定叢集通訊層 (Corosync)︰ </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para> 輸入要繫結到的網路位址。程序檔預設將建議 <systemitem>eth0</systemitem> 網路位址。您也可以輸入不同的網路位址，如 <literal>bond0</literal> 位址。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> 輸入多路廣播位址。程序檔會建議一個隨機位址，您可將其做為預設值。 </para>
      </step>
-     <step performance="required">
+     <step>
       <para> 輸入多路廣播連接埠。程序檔會建議預設值 <literal>5405</literal>。 </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para> 若要設定 SBD (選擇性)，請輸入要用於 SBD 的區塊裝置之分割區的永久路徑。該路徑必須在叢集的所有節點間保持一致。 </para>
     <para>
      
     </para>
     <para> 最後，程序檔將啟動 OpenAIS 服務以使單節點叢集上線，並啟用 Web 管理介面 Hawk。Hawk 將要使用的 URL 會顯示在螢幕上。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如需該設定程序的所有詳細資料，請查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -386,7 +390,7 @@ Please see LICENSE.txt for this document's license.
    <screen><prompt role="root">root # </prompt><command>passwd</command> hacluster</screen>
   </important>
 
-  <procedure id="pro-ha-installation-setup-sleha-join">
+  <procedure xml:id="pro-ha-installation-setup-sleha-join">
    <title>將節點新增至現存叢集</title>
    <para> 如果您的叢集處於正常執行狀態 (包含一或多個節點)，請使用 <command>sleha-join</command> 開機程序檔新增更多叢集節點。該程序檔只需要存取一個現存叢集節點，然後便會自動在目前機器上完成基本設定。請執行下列步驟。如需詳細資料，請參閱 <command>sleha-join</command> man 頁面。 </para>
    <para> 如果您已使用 YaST 叢集模組設定現存叢集節點，請在執行 <command>sleha-join</command> 之前確定符合以下必要條件︰ </para>
@@ -399,26 +403,26 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
    <para> 如果您目前是透過 Hawk 登入第一個節點，便可以追蹤叢集狀態的變更並檢視 Web 介面中啟動的資源。 </para>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 身分登入要加入叢集的實體或虛擬機器。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 執行如下指令啟動開機程序檔︰ </para>
     <screen><prompt role="root">root # </prompt>sleha-join</screen>
     <para> 如果 NTP 未設定為在開機時啟動，則會出現一則訊息。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如果您決定仍要繼續，系統將提示您輸入現存節點的 IP 位址。請輸入 IP 位址。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如果之前未在這兩台機器之間設定無密碼 SSH 存取，此時系統還會提示您輸入現存節點的 <systemitem class="username">root</systemitem> 密碼。 </para>
     <para> 登入指定節點後，程序檔將會複製 Corosync 組態，設定 SSH 與 Csync2，並使目前機器以新叢集節點的身分上線。除此之外，它還會啟動 Hawk 所需的服務。如果您已設定包含 OCFS2 的共享儲存區，程序檔還將自動為 OCFS2 檔案系統建立掛接點目錄。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 對要新增至叢集的所有機器重複上述步驟。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如需該程序的詳細資料，請查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -439,24 +443,24 @@ Please see LICENSE.txt for this document's license.
 
   
 
-  <procedure id="pro-ha-installation-setup-sleha-remove">
+  <procedure xml:id="pro-ha-installation-setup-sleha-remove">
    <title>從現存叢集中移除節點</title>
    <para> 如果您的叢集處於正常執行狀態 (至少包含兩個節點)，請使用 <command>sleha-remove</command> 開機程序檔從叢集中移除各別節點。您需要知道要從叢集中移除之節點的 IP 位址或主機名稱。請執行下列步驟。如需詳細資料，請參閱 <command>sleha-remove</command> man 頁面。 </para>
    
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 身分登入其中一個叢集節點。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 執行如下指令啟動開機程序檔︰ </para>
     <screen><prompt role="root">root # </prompt>sleha-remove -c <replaceable>IP_ADDR_OR_HOSTNAME</replaceable></screen>
     <para> 該程序檔會啟用 <systemitem class="daemon">sshd</systemitem>，在指定的節點上停止 OpenAIS 服務並傳播檔案以在其餘節點之間同步 Csync2。 </para>
     
     <para> 如果您指定了主機名稱，但是無法聯繫上要移除的節點 (或該主機名稱無法解析)，程序檔將告知您這一情況，並詢問您是否無論如何都要移除該節點。如果您指定了 IP 位址，但是無法聯繫上該節點，程序檔將要求您輸入主機名稱並確認是否無論如何都要移除該節點。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 若要移除更多節點，請重複上述步驟。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 如需該程序的詳細資料，請查看 <filename>/var/log/sleha-bootstrap.log</filename>。 </para>
    </step>
   </procedure>
@@ -466,25 +470,25 @@ Please see LICENSE.txt for this document's license.
   <procedure>
    <title>從機器中移除 High Availability Extension 軟體</title>
    <para>若要從您不再需要用做叢集節點的機器中移除 High Availability Extension 軟體，請執行以下步驟。</para>
-   <step performance="required">
+   <step>
     <para>停止叢集服務：</para>
     <screen><prompt role="root">root # </prompt>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>移除 High Availability Extension 附加產品：</para>
     <screen><prompt role="root">root # </prompt><command>zypper</command> rm -t products sle-hae</screen>
    </step>
   </procedure>
 
- </sect1>
- <sect1 id="sec-ha-installation-setup-manual">
+ </section>
+ <section xml:id="sec-ha-installation-setup-manual">
   <title>手動設定叢集 (YaST)</title>
 
   <para>
    如需進行初始設定需要執行的所有步驟的綜覽，請參閱<xref linkend="sec-ha-installation-overview"/>。
   </para>
 
-   <sect2 id="sec-ha-installation-setup-yast2cluster">
+   <section xml:id="sec-ha-installation-setup-yast2cluster">
    <title>YaST 叢集模組</title>
    <para>
     以下各節將引導您透過 YaST 叢集模組完成每個設定步驟。若要存取該模組，請以 <systemitem class="username">root</systemitem> 身分啟動 YaST，然後選取<menuchoice><guimenu>高可用性</guimenu> <guimenu>叢集</guimenu></menuchoice>。或者在指令行上使用 <command>yast2 cluster</command> 啟動模組。
@@ -506,9 +510,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     請注意，YaST 叢集模組中的部分選項僅適用於目前節點，其餘選項可能會自動傳送到所有節點。如需詳細資訊，請參閱以下各節。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-channels">
+  <section xml:id="sec-ha-installation-setup-channels">
    <title>定義通訊通道</title>
    <para>
     若要讓叢集節點之間順利通訊，至少需定義一個通訊通道。
@@ -534,37 +538,37 @@ Please see LICENSE.txt for this document's license.
      如果情況允許，請選擇網路裝置 Bonding。
     </para>
    </important>
-   <procedure id="pro-ha-installation-setup-channel1">
+   <procedure xml:id="pro-ha-installation-setup-channel1">
     <title>定義第一個通訊通道</title>
     <para>
      在叢集節點間進行通訊需要使用多路廣播 (UDP) 或單點傳播 (UDPU)。
     </para>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>通訊通道</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要使用多路廣播︰
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         將<guimenu>傳輸</guimenu>通訊協定設定為 <literal>UDP</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定義<guimenu>結合網路位址</guimenu>。將此值設定為要用於叢集多路廣播的子網路。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定義<guimenu>多路廣播位址</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定義<guimenu>多路廣播埠</guimenu>。
        </para>
@@ -586,27 +590,27 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要使用單點傳播︰
      </para>
      <substeps performance="required">
-      <step performance="required">
+      <step>
        <para>
         將<guimenu>傳輸</guimenu>通訊協定設定為 <literal>UDPU</literal>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定義<guimenu>結合網路位址</guimenu>。將此值設定為要用於叢集單點傳播的子網路。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para>
         定義<guimenu>多路廣播埠</guimenu>。
        </para>
       </step>
-      <step performance="required">
+      <step>
        <para> 若要進行單點傳播通訊，Corosync 需要知道叢集中所有節點的 IP 位址。請對將成為叢集成員的每個節點按一下<guimenu>新增</guimenu>，然後輸入以下詳細資料：</para>
        <itemizedlist mark="bullet" spacing="normal">
         <listitem>
@@ -638,22 +642,22 @@ Please see LICENSE.txt for this document's license.
       </step>
      </substeps>
     </step>
-    <step performance="required">
+    <step>
      <para> <guimenu>自動產生節點 ID</guimenu> 選項預設已啟用。如果您使用的是 IPv4 位址，則節點 ID 是選填資料；但如果使用的是 IPv6 位址，則節點 ID 是必填資料。若要為每個叢集節點自動產生唯一的 ID (與手動為每個節點指定 ID 相比，這種做法較不容易出錯)，請將此選項保留為啟用狀態。</para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集的任何選項，請確認您的變更並關閉叢集模組。YaST 會將此組態寫入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如有需要，依照下文所述定義另一個通訊通道。或者，按<guimenu>下一步</guimenu>，然後繼續<xref linkend="pro-ha-installation-setup-security"/>。
      </para>
     </step>
    </procedure>
 
-   <procedure id="pro-ha-installation-setup-channel2">
+   <procedure xml:id="pro-ha-installation-setup-channel2">
     <title>定義備援通訊通道</title>
     <para>
      如果網路裝置 Bonding 因某種原因而無法使用，次佳選擇就是在 Corosync 中定義備援通訊通道 (另一個環)。如此便可使用實體位置相互分隔的兩個網路進行通訊。如果一個網路發生故障，叢集節點仍然可以透過另一個網路進行通訊。
@@ -664,17 +668,17 @@ Please see LICENSE.txt for this document's license.
       如果設定多個環狀網路，每個節點都可以擁有多個 IP 位址。這需要反映在所有節點的 <filename>/etc/hosts</filename> 檔案中。
      </para>
     </important>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>通訊通道</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       啟用<guimenu>備援通道</guimenu>。備援通道必須使用您定義的第一個通訊通道所使用的相同通訊協定。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用多路廣播，請為備援通道定義<guimenu>結合網路位址</guimenu>、<guimenu>多路廣播位址</guimenu>及<guimenu>多路廣播埠</guimenu>。
      </para>
@@ -685,7 +689,7 @@ Please see LICENSE.txt for this document's license.
       現在，您便已在 Corosync 中定義了另一個通訊通道，這將構成又一個記號傳遞環。在 <filename>/etc/corosync/corosync.conf</filename> 中，主要環狀網路 (即您設定的第一個通道) 的環狀網路編號為 <literal>0</literal>，第二個環狀網路 (備援通道) 的環狀網路編號為 <literal>1</literal>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要指示 Corosync 如何及何時使用這兩個不同的通道，請選取要使用的<guimenu>rrp_mode</guimenu>(<literal>active</literal> 或 <literal>passive</literal>)。如需這些模式的詳細資訊，請參閱<xref linkend="vle-ha-rrp"/> 或按一下<guimenu>說明</guimenu>。一旦使用 RRP，便會使用串流控制傳輸協定 (SCTP) 替代 TCP 進行節點間的通訊。High Availability Extension 會監控目前各環的狀態，並在發生故障後自動重新啟用備援環。或者，您也可以使用 <command>corosync-cfgtool</command> 手動檢查環狀網路狀態。請使用 <option>-h</option> 檢視可用選項。
      </para>
@@ -693,12 +697,12 @@ Please see LICENSE.txt for this document's license.
       如果只定義了一個通訊通道，則會自動停用<guimenu>rrp_mode</guimenu>(設為 <literal>none</literal> 值)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集的任何選項，請確認您的變更並關閉叢集模組。YaST 會將此組態寫入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要進一步設定叢集組態，請按<guimenu>下一步</guimenu>並繼續<xref linkend="sec-ha-installation-setup-security"/>。
      </para>
@@ -707,26 +711,26 @@ Please see LICENSE.txt for this document's license.
    <para>
     <filename>/etc/corosync/corosync.conf.example</filename> 中提供了 UDP 設定的範例檔案。<filename>/etc/corosync/corosync.conf.example.udpu</filename> 中則提供了 UDPU 設定的範例。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-security">
+  <section xml:id="sec-ha-installation-setup-security">
    <title>定義驗證設定</title>
    <para>
     下一步是定義叢集的驗證設定。您可以使用 HMAC/SHA1 驗證，這種驗證方式需要使用共享密碼來保護和驗證訊息。您指定的驗證金鑰 (密碼) 將用於叢集中的所有節點。
    </para>
-   <procedure id="pro-ha-installation-setup-security">
+   <procedure xml:id="pro-ha-installation-setup-security">
     <title>啟用安全驗證</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>安全性</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       啟動<guimenu>啟用安全性驗證</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       針對新建立的叢集按一下<guimenu>產生驗證金鑰檔案</guimenu>。系統即會建立一個驗證金鑰並將其寫入 <filename>/etc/corosync/authkey</filename>。
      </para>
@@ -745,22 +749,22 @@ Please see LICENSE.txt for this document's license.
       如果要讓目前機器加入現存叢集，請不要產生新的金鑰檔案，而是將現存叢集某個節點中的 <filename>/etc/corosync/authkey</filename> 複製到目前機器 (以手動方式或使用 Csync2)。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集的任何選項，請確認您的變更並關閉叢集模組。YaST 會將此組態寫入 <filename>/etc/corosync/corosync.conf</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要進一步設定叢集組態，請按<guimenu>下一步</guimenu>並繼續<xref linkend="sec-ha-installation-setup-csync2"/>。
      </para>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-installation-setup-csync2">
+  <section xml:id="sec-ha-installation-setup-csync2">
    <title>將組態傳輸至所有節點</title>
    <para>
     您應當使用 <command>csync2</command> 工具在叢集中的所有節點間複製產生的組態檔案，而不是手動將其複製到所有節點。
@@ -769,12 +773,12 @@ Please see LICENSE.txt for this document's license.
     若要如此，您需要執行下列基本步驟︰
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-yast" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-csync2-start" xrefstyle="select:title"/>。
      </para>
@@ -796,25 +800,25 @@ Please see LICENSE.txt for this document's license.
      </para>
     </listitem>
    </itemizedlist>
-   <para><ulink url="http://oss.linbit.com/csync2/"/> 和 <ulink url="http://oss.linbit.com/csync2/paper.pdf"/> 上提供了關於 Csync2 的詳細資訊。</para>
-   <procedure id="pro-ha-installation-setup-csync2-yast">
+   <para><link xlink:href="http://oss.linbit.com/csync2/"/> 和 <link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/> 上提供了關於 Csync2 的詳細資訊。</para>
+   <procedure xml:id="pro-ha-installation-setup-csync2-yast">
     <title>使用 YaST 設定 Csync2</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>Csync2</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要指定同步群組，請在<guimenu>同步主機</guimenu>群組中按一下<guimenu>新增</guimenu>，然後輸入叢集中所有節點的本地主機名稱。對於每個節點，都必須使用 <command>hostname</command> 指令傳回的字串。
      </para>
     </step>
-    <step id="step-csync2-generate-key" performance="required">
+    <step xml:id="step-csync2-generate-key">
      <para>
       按一下<guimenu>產生預先共用金鑰</guimenu>建立同步化群組的金鑰檔案。建立的金鑰檔案會寫入 <filename>/etc/csync2/key_hagroup</filename>。建立之後，必須手動將其複製到叢集的所有成員。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要在<guimenu>同步化檔案</guimenu>清單中填入所有節點間執行同步化通常所需的檔案，請按一下<guimenu>新增建議的檔案</guimenu>。
      </para>
@@ -830,28 +834,28 @@ Please see LICENSE.txt for this document's license.
       </mediaobject>
      </figure>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要在待同步檔案的清單中<guimenu>編輯</guimenu>、<guimenu>新增</guimenu>或<guimenu>移除</guimenu>檔案，則使用相應的按鈕。您必須輸入各個檔案的絕對路徑名稱。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>開啟 Csync2</guimenu>以啟動 Csync2。如此會執行 <command>chkconfig csync2</command>，以在開機時自動啟動 Csync2。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集的任何選項，請確認您的變更並關閉叢集模組。隨後，YaST 會將 Csync2 組態寫入 <filename>/etc/csync2/csync2.cfg</filename>。若現在要啟動同步程序，請繼續<xref linkend="pro-ha-installation-setup-csync2-start"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要進一步設定叢集組態，請按<guimenu>下一步</guimenu>並繼續<xref linkend="sec-ha-installation-setup-conntrackd"/>。
      </para>
     </step>
    </procedure>
-   <procedure id="pro-ha-installation-setup-csync2-start">
+   <procedure xml:id="pro-ha-installation-setup-csync2-start">
     <title>使用 Csync2 同步組態檔案</title>
     <para>
      若要使用 Csync2 成功同步檔案，請確定符合以下必要條件︰
@@ -882,7 +886,7 @@ rcxinetd start</screen>
       </note>
      </listitem>
     </itemizedlist>
-    <step performance="required">
+    <step>
      <para>
       在要<emphasis>從中</emphasis>複製組態的節點上，執行如下指令︰
      </para>
@@ -897,7 +901,7 @@ rcxinetd start</screen>
 ERROR from peer hex-14: File is also marked dirty here!
 Finished with 1 errors.</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您確定目前節點上的是檔案的<quote>最佳</quote>版本，可以透過強制使用此檔案並重新同步來解決衝突︰
      </para>
@@ -906,7 +910,7 @@ csync2 -x</screen>
     </step>
    </procedure>
    <para>
-    如需有關 Csync2 選項的詳細資訊，請執行 <command>csync2 <option>-help</option></command>。
+    如需有關 Csync2 選項的詳細資訊，請執行 <command>csync2 </command> <option>-help</option>。
    </para>
    <note>
     <title>發生任何變更後推送同步</title>
@@ -914,23 +918,23 @@ csync2 -x</screen>
      Csync2 僅會推送變更，而<emphasis>不會</emphasis>持續在節點間同步檔案。
     </para>
     <para>
-     每次對需要同步的檔案進行更新時，都需要將變更推入至其於節點︰在您進行了變更的節點上執行 <command>csync2 <option>-xv</option></command>。如果在未變更檔案的任何其他節點上執行該指令，系統不會執行任何操作。
+     每次對需要同步的檔案進行更新時，都需要將變更推入至其於節點︰在您進行了變更的節點上執行 <command>csync2 </command> <option>-xv</option>。如果在未變更檔案的任何其他節點上執行該指令，系統不會執行任何操作。
     </para>
    </note>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-conntrackd">
+  <section xml:id="sec-ha-installation-setup-conntrackd">
    <title>同步叢集節點間的連接狀態</title>
    <para>
     若要對 iptables 啟用<emphasis>可設定狀態的</emphasis>封包檢查，請設定並使用 conntrack 工具。 
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-installation-setup-conntrackd" xrefstyle="select:title"/>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       為 <systemitem class="daemon">conntrackd</systemitem> 設定資源 (類別︰<literal>ocf</literal>，提供者︰<literal>heartbeat</literal>)。如果使用 Hawk 新增資源，請使用 Hawk 建議的預設值。
      </para>
@@ -940,44 +944,44 @@ csync2 -x</screen>
     設定 conntrack 工具之後，您便可以使用它們來<xref linkend="cha-ha-lvs" xrefstyle="select:title"/>。
    </para>
 
-   <procedure id="pro-ha-installation-setup-conntrackd">
+   <procedure xml:id="pro-ha-installation-setup-conntrackd">
     <title>使用 YaST 設定 <systemitem class="resource">conntrackd</systemitem></title>
     <para>
      使用 YaST 叢集模組設定使用者空間 <systemitem class="daemon">conntrackd</systemitem>。該工具需要一個不會用於其他通訊通道的專屬網路介面。之後，可透過資源代辦啟動該精靈。
     </para>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>設定 conntrackd</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       選取一個用於同步連接狀態的<guimenu>專屬介面</guimenu>。系統會自動偵測到所選介面的 IPv4 位址並在 YaST 中顯示。該介面必須已設定並支援多路廣播。
 
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       定義用於同步連接狀態的<guimenu>多路廣播位址</guimenu>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在<guimenu>群組編號</guimenu>中，定義要與之同步連接狀態的群組數字 ID。
       
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按一下<guimenu>產生 /etc/conntrackd/conntrackd.conf</guimenu>以建立 <systemitem class="daemon">conntrackd</systemitem> 的組態檔案。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集的任何選項，請確認您的變更並關閉叢集模組。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要進一步設定叢集組態，請按<guimenu>下一步</guimenu>並繼續<xref linkend="sec-ha-installation-setup-services"/>。
      </para>
@@ -994,21 +998,21 @@ csync2 -x</screen>
      </imageobject>
     </mediaobject>
    </figure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-setup-services">
+  <section xml:id="sec-ha-installation-setup-services">
    <title>設定服務</title>
    <para>
     在 YaST 叢集模組中定義是否要在節點開機時啟動某些服務。您還可以使用該模組手動啟動和停止服務。若要使叢集節點上線並啟動叢集資源管理員，必須執行 OpenAIS 這項服務。
    </para>
-   <procedure id="pro-ha-installation-setup-services">
+   <procedure xml:id="pro-ha-installation-setup-services">
     <title>啟用叢集服務</title>
-    <step performance="required">
+    <step>
      <para>
       在 YaST 叢集模組中，切換至<guimenu>服務</guimenu>類別。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要在此叢集節點每次開機時都啟動 OpenAIS，請在<guimenu>開機</guimenu>群組中選取相應的選項。如果在<guimenu>開機</guimenu>群組中選取<guimenu>關閉</guimenu>，則每次此節點開機後，您都必須手動啟動 OpenAIS。若要手動啟動 OpenAIS，請使用 <command>rcopenais start</command> 指令。
      </para>
@@ -1022,21 +1026,21 @@ csync2 -x</screen>
       </para>
      </note>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果要使用 Pacemaker GUI 設定、管理和監控叢集資源，請啟動<guimenu>啟用 mgmtd</guimenu>。GUI 需要使用此精靈。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要立即啟動或停止 OpenAIS，請按一下相應的按鈕。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>若要在防火牆中開啟所需的連接埠，以便叢集能夠在目前機器上通訊，請啟用<guimenu>在防火牆中開啟埠</guimenu>。該組態會寫入 <filename>/etc/sysconfig/SuSEfirewall2.d/services/cluster</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果修改了現存叢集節點的任何選項，請確認您的變更並關閉叢集模組。請注意，該組態僅適用於目前機器，而非所有叢集節點。
      </para>
@@ -1056,21 +1060,21 @@ csync2 -x</screen>
      </figure>
     </step>
    </procedure>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-installation-start">
+  <section xml:id="sec-ha-installation-start">
    <title>連接叢集</title>
    <para>
     完成初始叢集組態設定之後，請在<emphasis>每個</emphasis>叢集節點上啟動 OpenAIS/Corosync 服務，以使堆疊上線︰
    </para>
    <procedure>
     <title>啟動 OpenAIS/Corosync 並檢查狀態</title>
-    <step performance="required">
+    <step>
      <para>
       登入現存節點。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       檢查該服務是否已在執行︰
      </para>
@@ -1080,12 +1084,12 @@ csync2 -x</screen>
      </para>
 <screen><prompt role="root">root # </prompt>rcopenais start</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對每個叢集節點重複上述步驟。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在其中一個節點上，使用 <command>crm status</command> 指令檢查叢集狀態。如果所有節點都已上線，則輸出應如下所示︰
      </para>
@@ -1105,9 +1109,9 @@ csync2 -x</screen>
    <para>
     設定好基本組態並且節點上線後，您可以使用 crm 外圍程序、Pacemaker GUI 或 HA Web Konsole 等叢集管理工具開始設定叢集資源。如需詳細資訊，請參閱以下各章節。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-installation-autoyast">
+  </section>
+ </section>
+ <section xml:id="sec-ha-installation-autoyast">
   <title>使用 AutoYaST 進行大規模部署</title>
 
   <para>
@@ -1116,7 +1120,7 @@ csync2 -x</screen>
 
 
 
-  <procedure id="pro-ha-installation-clone-node">
+  <procedure xml:id="pro-ha-installation-clone-node">
    <title>使用 AutoYaST 複製叢集節點</title>
    <important>
     <title>完全一樣的硬體</title>
@@ -1124,43 +1128,43 @@ csync2 -x</screen>
      本案例假設您要將 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署到硬體組態完全一樣的一組機器上。
     </para>
    </important>
-   <para>如果要在不相同的硬體上部署叢集節點，請參閱《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》的「<citetitle>自動安裝</citetitle>」一章中「<citetitle>以規則為基礎的自動安裝</citetitle>」一節，該文件的網址為 <ulink url="http://www.suse.com/doc"/>。 </para>
-   <step performance="required">
+   <para>如果要在不相同的硬體上部署叢集節點，請參閱《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》的「<citetitle>自動安裝</citetitle>」一章中「<citetitle>以規則為基礎的自動安裝</citetitle>」一節，該文件的網址為 <link xlink:href="http://www.suse.com/doc"/>。 </para>
+   <step>
     <para>
      確定已正確安裝並設定要複製的節點。如需詳細資料，請分別參閱<xref linkend="sec-ha-installation-add-on"/>、<xref linkend="sec-ha-installation-setup-auto"/> 或<xref linkend="sec-ha-installation-setup-manual"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依照《<citetitle>SUSE Linux Enterprise <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 部署指南</citetitle>》中的概要描述，進行簡單的大規模部署。基本步驟包括以下幾項︰
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        建立 AutoYaST 設定檔。請使用 AutoYaST GUI 在現存系統組態的基礎上建立一個設定檔並加以修改。在 AutoYaST 中，選擇<guimenu>High Availability</guimenu>模組，然後按一下<guimenu>複製</guimenu>按鈕。如有需要，調整其他模組中的組態，並將產生的控制檔案儲存為 XML 檔案。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        指定 AutoYaST 設定檔的來源，以及要傳遞給其他節點的安裝常式的參數。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        指定 SUSE Linux Enterprise Server 與 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 安裝資料的來源。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        指定及設定自動安裝的開機程序。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        透過手動新增參數或建立 <filename>info</filename> 檔案的方式，將指令行傳遞給安裝常式。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        啟動和監控自動安裝程序。
       </para>
@@ -1173,14 +1177,14 @@ csync2 -x</screen>
    成功安裝副本後，請執行以下步驟將複製的節點加入叢集︰
   </para>
 
-  <procedure id="pro-ha-installation-clone-start">
+  <procedure xml:id="pro-ha-installation-clone-start">
    <title>連接複製的節點</title>
-   <step performance="required">
+   <step>
     <para>
      依照<xref linkend="sec-ha-installation-setup-csync2"/> 所述使用 Csync2 將金鑰組態檔案從設定的節點傳輸到複製的節點。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要使節點上線，請依照<xref linkend="sec-ha-installation-start"/> 所述在複製的節點上啟動 OpenAIS 服務。
     </para>
@@ -1190,5 +1194,5 @@ csync2 -x</screen>
   <para>
    複製的節點現在將加入叢集，因為 <filename>/etc/corosync/corosync.conf</filename> 檔案已透過 Csync2 套用至複製的節點。CIB 會自動在叢集節點間同步。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_intro.xml
+++ b/zh_TW/xml/ha_intro.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE preface PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE preface>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<preface xml:base="ha_intro.xml" id="pre-ha">
- <title>關於本指南</title>
+<preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_intro.xml" xml:id="pre-ha"><title>關於本指南</title><info/>
+ 
  <para>
   <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 是一套採用了開放原始碼叢集技術的整合式套裝軟體，可用於實作高可用性的實體與虛擬 Linux 叢集。為進行快速有效的組態設定和管理，High Availability Extension 中提供了圖形使用者介面 (GUI) 和指令行介面 (CLI)。此外還隨附了 HA Web Konsole (Hawk)，這樣您還可以透過 Web 介面管理 Linux 叢集。
  </para>
@@ -58,12 +62,12 @@ Please see LICENSE.txt for this document's license.
   本手冊的許多章節包含連到其他文件資源的連結。包括系統和網際網路上所提供的其他文件。
  </para>
  <para>
-  如需適用於產品的文件與最新文件更新的綜覽，請參閱 <ulink url="http://www.suse.com/doc/"/>。
+  如需適用於產品的文件與最新文件更新的綜覽，請參閱 <link xlink:href="http://www.suse.com/doc/"/>。
  </para>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_feedback_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_typografie_i.xml" parse="xml"/>
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common_intro_making_i.xml" parse="xml"/>
+ <xi:include href="common_intro_feedback_i.xml" parse="xml"/>
+ <xi:include href="common_intro_typografie_i.xml" parse="xml"/>
+ <xi:include href="common_intro_making_i.xml" parse="xml"/>
  
  
 </preface>

--- a/zh_TW/xml/ha_lvs.xml
+++ b/zh_TW/xml/ha_lvs.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_lvs.xml" id="cha-ha-lvs">
- <title>藉由 Linux Virtual Server 實現負載平衡</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_lvs.xml" xml:id="cha-ha-lvs"><title>藉由 Linux Virtual Server 實現負載平衡</title><info/>
+ 
 
  <para>
   Linux Virtual Server (LVS) 的目標是提供一個基本架構，將各網路連接導向至多部可分攤其工作負載的伺服器。Linux Virtual Server 是一組伺服器叢集 (一或多個負載平衡器與幾部執行服務的實際伺服器)，對外部用戶端而言則是一個大型的高速伺服器。這種表面上的單個伺服器稱為<emphasis>虛擬伺服器</emphasis>。Linux Virtual Server 可用於構建擴充性強、可用性高的網路服務，例如 Web、快取、郵件、FTP、媒體和 VoIP 服務。
@@ -14,14 +18,14 @@ Please see LICENSE.txt for this document's license.
  <para>
   實際的伺服器與負載平衡器之間可透過高速 LAN 或地理位置分散的 WAN 來連接。負載平衡器可將請求發送到不同的伺服器。它們可以讓叢集的多個平行服務顯示為單一 IP 位址 (虛擬 IP 位址或 VIP) 上的一個虛擬服務。發送請求可以使用 IP 負載平衡技術或應用程式層級的負載平衡技術。以透明方式在叢集中新增或移除節點可以實現系統的延展性。透過偵測節點或精靈故障，然後重新正確地設定系統可以提供高可用性。
  </para>
- <sect1 id="sec-ha-lvs-overview">
+ <section xml:id="sec-ha-lvs-overview">
   <title>概念綜覽</title>
 
   <para>
    以下幾節概要介紹了主要的 LVS 元件和概念。
   </para>
 
-  <sect2 id="sec-ha-lvs-overview-director">
+  <section xml:id="sec-ha-lvs-overview-director">
    <title>導向器</title>
    <para>
     LVS 的主要元件是 ip_vs (或 IPVS) 核心代碼。它會在 Linux 核心 (第 4 層交換) 內執行輸送層負載平衡。執行包含 IPVS 代碼的 Linux 核心的節點稱為<emphasis>導向器</emphasis>。在導向器上執行的 IPVS 代碼是 LVS 的必要特性。
@@ -32,9 +36,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     依預設，此核心不需要安裝 IPVS 模組。IPVS 核心模組包含在 <systemitem class="resource">cluster-network-kmp-default</systemitem> 套件內。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-userspace">
+  <section xml:id="sec-ha-lvs-overview-userspace">
    <title>使用者空間控制器和精靈</title>
    <para>
     <systemitem class="daemon">ldirectord</systemitem> 是一個使用者空間精靈，可在 LVS 負載平衡虛擬伺服器叢集中管理 Linux Virtual Server 和監控實際的伺服器。組態檔案 <filename>/etc/ha.d/ldirectord.cf</filename> 指定虛擬服務及其關聯的實際伺服器，並告知 <systemitem class="daemon">ldirectord</systemitem> 如何將伺服器設定為 LVS 重新導向器。啟始化精靈時，會為叢集建立虛擬服務。
@@ -45,9 +49,9 @@ Please see LICENSE.txt for this document's license.
    <para>
     <systemitem class="daemon">ldirectord</systemitem> 使用 <systemitem>ipvsadm</systemitem> 工具 (<systemitem class="resource">ipvsadm</systemitem> 套件) 來處理 Linux 核心中的虛擬伺服器表格。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-forwarding">
+  <section xml:id="sec-ha-lvs-overview-forwarding">
    <title>封包轉遞</title>
    <para>
     導向器將用戶端封包傳送至實際伺服器的方式有三種︰
@@ -78,16 +82,16 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-lvs-overview-schedulers">
+  <section xml:id="sec-ha-lvs-overview-schedulers">
    <title>排程演算法</title>
    <para>
     使用哪一部實際伺服器來處理用戶端請求的新連接，是由不同的演算法決定的。這些演算法以模組的形式提供，可根據特定需求進行調整。如需可用模組的綜覽，請參閱 <command>ipvsadm(8)</command> man 頁面。從用戶端接收到連接請求後，導向器會依據<emphasis>排程</emphasis>為該用戶端指定實際的伺服器。排程器是 IPVS 核心代碼的一部分，用於決定哪一部實際伺服器將獲取下一個新連接。
    </para>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-lvs-ldirectord">
+  </section>
+ </section>
+ <section xml:id="sec-ha-lvs-ldirectord">
   <title>使用 YaST 設定 IP 負載平衡</title>
 
   <para>
@@ -113,69 +117,69 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="sec-ha-lvs-ldirectord-global">
+  <procedure xml:id="sec-ha-lvs-ldirectord-global">
    <title>設定全域參數</title>
    <para>
     以下程序介紹如何設定最重要的全域參數。如需個別參數和此處未涉及之參數的詳細資料，請按一下<guimenu>說明</guimenu>或參閱 <systemitem class="daemon">ldirectord</systemitem> man 頁面。
    </para>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>檢查間隔時間</guimenu>定義 <systemitem class="daemon">ldirectord</systemitem> 連接各個實際伺服器以檢查它們是否連接的時間間隔。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>檢查逾時</guimenu>設定實際伺服器應在上次檢查後的多少時間內給於回應。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>失敗計數</guimenu>可以定義當 <systemitem class="daemon">ldirectord</systemitem> 嘗試向實際伺服器發出多少次要求後即判定檢查失敗。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>協議逾時</guimenu>可以定義協議檢查的逾時時間 (秒)。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>錯誤回復</guimenu>中，輸入當所有實際伺服器都當機時，Web 服務重新導向到之 Web 伺服器的主機名稱或 IP 位址。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果希望系統在與實際伺服器的連接狀態發生變更時傳送警示，請在<guimenu>電子郵件警示</guimenu>中輸入有效的電子郵件地址。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>電子郵件警示頻率</guimenu>可以定義當實際伺服器長時間無法存取時，重新傳送電子郵件警示的間隔時間 (秒)。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>電子郵件警示狀態</guimenu>中指定出現哪種伺服器狀態時傳送電子郵件警示。如果要定義多種狀態，可以逗號分隔。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>自動重新載入</guimenu>定義 <systemitem class="daemon">ldirectord</systemitem> 是否應持續監控組態檔案的修改情況。如果設定為<literal>是</literal>，便會在變更後自動重新載入組態。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用<guimenu>Quiescent</guimenu>參數定義是否要從核心的 LVS 表格中移除發生故障的實際伺服器。如果設定為<guimenu>是</guimenu>，則不會移除出現故障的伺服器。而是將其權值設為 <literal>0</literal>，表示不接受任何新的連接。已建立的連接將保持，直到逾時。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要讓記錄使用不同的路徑，則在<guimenu>記錄檔案</guimenu>中指定記錄的路徑。依預設，<systemitem class="daemon">ldirectord</systemitem> 會將其記錄寫入 <filename>/var/log/ldirectord.log</filename>。
     </para>
    </step>
   </procedure>
 
-  <figure id="fig-ha-lvs-yast-global">
+  <figure xml:id="fig-ha-lvs-yast-global">
    <title>YaST IP 負載平衡 — 全域參數</title>
    <mediaobject>
     <imageobject role="fo">
@@ -187,27 +191,27 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <procedure id="sec-ha-lvs-ldirectord-virtual">
+  <procedure xml:id="sec-ha-lvs-ldirectord-virtual">
    <title>設定虛擬服務</title>
    <para>
     您可以透過為各項虛擬服務定義一對參數的方式設定一或多個虛擬服務。以下程序介紹如何為虛擬服務設定最重要的全域參數。如需個別參數和此處未涉及之參數的詳細資料，請按一下<guimenu>說明</guimenu>或參閱 <systemitem class="daemon">ldirectord</systemitem> man 頁面。
    </para>
-   <step performance="required">
+   <step>
     <para>
      在 YaST IP 負載平衡模組中，切換至<guimenu>虛擬伺服器組態</guimenu>索引標籤。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <guimenu>新增</guimenu>新的虛擬伺服器，或<guimenu>編輯</guimenu>現有的虛擬伺服器。此時會出現一個新的對話方塊並顯示可用的選項。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>虛擬伺服器</guimenu>中輸入以 LVS 形式存取負載平衡器和實際伺服器時所使用的共享虛擬 IP 位址 (IPv4 或 IPv6) 及連接埠。也可以指定主機名稱和服務來代替 IP 位址和連接埠號。或者，也可以使用防火牆標記。防火牆標記是將任意一組 <literal>VIP:連接埠</literal>服務集結到一個虛擬服務的一種方式。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要指定<guimenu>實際伺服器</guimenu>，需要輸入伺服器的 IP 位址 (IPv4、IPv6 或主機名稱)、連接埠 (或服務名稱) 及轉遞方式。轉遞方式必須是 <literal>gate</literal>、<literal>ipip</literal> 或 <literal>masq</literal>，詳情請參閱<xref linkend="sec-ha-lvs-overview-forwarding"/>。
     </para>
@@ -215,47 +219,47 @@ Please see LICENSE.txt for this document's license.
      按一下<guimenu>新增</guimenu>按鈕並輸入各個實際伺服器所需的引數。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>檢查類型</guimenu>中，選取測試實際伺服器是否仍在工作時執行的檢查類型。例如，若要傳送請求並檢查回應中是否包含預期字串，請選取「<literal>協議</literal>」。
     </para>
    </step>
-   <step id="step-ha-lvs-ldirectord-service" performance="required">
+   <step xml:id="step-ha-lvs-ldirectord-service">
     <para>
      如果<guimenu>檢查類型</guimenu>已設定為「<literal>協議</literal>」，則還需要定義要監控之服務的類型。從<guimenu>服務</guimenu>下拉式清單中選取所需的服務類型。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>請求</guimenu>中輸入檢查間隔期間向每部實際伺服器所請求之物件的 URI。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果要檢查實際伺服器的回應中是否包含某個字串 (<quote>I'm alive</quote>訊息)，請定義要比對的正規表示式。在<guimenu>接收</guimenu>中輸入正規表示式。如果實際伺服器的回應中包含此表示式，說明此實際伺服器正在運行。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根據您在<xref linkend="step-ha-lvs-ldirectord-service"/> 中選取的<guimenu>服務</guimenu>類型，您還需要指定其他參數以進行驗證。切換至<guimenu>驗證類型</guimenu>索引標籤，然後輸入<guimenu>登入名稱</guimenu>、<guimenu>密碼</guimenu>、<guimenu>資料庫</guimenu>或<guimenu>秘密</guimenu>等詳細資料。如需詳細資訊，請參閱 YaST 說明文字或 <systemitem class="daemon">ldirectord</systemitem> man 頁面。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      切換至<guimenu>其他</guimenu>索引標籤。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取用於負載平衡的<guimenu>規劃程式</guimenu>。如需可用之規劃程式的相關資訊，請參閱 <command>ipvsadm(8)</command> man 頁面。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      選取要使用的<guimenu>協定</guimenu>。如果虛擬服務指定為 IP 位址和連接埠，則必須是 <literal>tcp</literal> 或 <literal>udp</literal> 協定。如果虛擬服務指定為防火牆標記，則必須是 <literal>fwm</literal> 協定。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      根據需要定義其他參數。按一下<guimenu>確定</guimenu>確認您的組態。YaST 會將此組態寫入 <filename>/etc/ha.d/ldirectord.cf</filename>。
     </para>
@@ -264,7 +268,7 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <figure id="fig-ha-lvs-yast-virtual">
+  <figure xml:id="fig-ha-lvs-yast-virtual">
    <title>YaST IP 負載平衡 — 虛擬服務</title>
    <mediaobject>
     <imageobject role="fo">
@@ -276,25 +280,25 @@ Please see LICENSE.txt for this document's license.
    </mediaobject>
   </figure>
 
-  <example id="ex-ha-lvs-ldirectord">
+  <example xml:id="ex-ha-lvs-ldirectord">
    <title>簡單的 ldirectord 組態</title>
    <para>
     <xref linkend="fig-ha-lvs-yast-global"/> 和<xref linkend="fig-ha-lvs-yast-virtual"/> 中的顯示的值會產生以下組態 (定義於 <filename>/etc/ha.d/ldirectord.cf</filename>)︰
    </para>
-<screen>autoreload = yes <co id="co-ha-ldirectord-autoreload"/>
-checkinterval = 5 <co id="co-ha-ldirectord-checkintervall"/>
-checktimeout = 3 <co id="co-ha-ldirectord-checktimeout"/>
-quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
-    virtual = 192.168.0.200:80 <co id="co-ha-ldirectord-virtual"/>
-    checktype = negotiate <co id="co-ha-ldirectord-checktype"/>
-    fallback = 127.0.0.1:80 <co id="co-ha-ldirectord-fallback"/>
-    protocol = tcp <co id="co-ha-ldirectord-protocol"/>
-    real = 192.168.0.110:80 gate <co id="co-ha-ldirectord-real"/>
+<screen>autoreload = yes <co xml:id="co-ha-ldirectord-autoreload"/>
+checkinterval = 5 <co xml:id="co-ha-ldirectord-checkintervall"/>
+checktimeout = 3 <co xml:id="co-ha-ldirectord-checktimeout"/>
+quiescent = yes <co xml:id="co-ha-ldirectord-quiescent"/>
+    virtual = 192.168.0.200:80 <co xml:id="co-ha-ldirectord-virtual"/>
+    checktype = negotiate <co xml:id="co-ha-ldirectord-checktype"/>
+    fallback = 127.0.0.1:80 <co xml:id="co-ha-ldirectord-fallback"/>
+    protocol = tcp <co xml:id="co-ha-ldirectord-protocol"/>
+    real = 192.168.0.110:80 gate <co xml:id="co-ha-ldirectord-real"/>
     real = 192.168.0.120:80 gate <xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/>
-    receive = "still alive" <co id="co-ha-ldirectord-receive"/>
-    request = "test.html" <co id="co-ha-ldirectord-request"/>
-    scheduler = wlc <co id="co-ha-ldirectord-scheduler"/>
-    service = http <co id="co-ha-ldirectord-service"/></screen>
+    receive = "still alive" <co xml:id="co-ha-ldirectord-receive"/>
+    request = "test.html" <co xml:id="co-ha-ldirectord-request"/>
+    scheduler = wlc <co xml:id="co-ha-ldirectord-scheduler"/>
+    service = http <co xml:id="co-ha-ldirectord-service"/></screen>
    <calloutlist>
     <callout arearefs="co-ha-ldirectord-autoreload">
      <para>
@@ -367,8 +371,8 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     此組態會產生以下程序流︰<systemitem class="daemon">ldirectord</systemitem> 將每隔 5 秒 (<xref linkend="co-ha-ldirectord-checkintervall" xrefstyle="select:label nopage"/>) 連接一次各個實際伺服器，並請求<xref linkend="co-ha-ldirectord-real" xrefstyle="select:label nopage"/> 和<xref linkend="co-ha-ldirectord-request" xrefstyle="select:label nopage"/> 中指定的 <literal>192.168.0.110:80/test.html</literal> 或 <literal>192.168.0.120:80/test.html</literal>。如果最後一次檢查時，3 秒內 (<xref linkend="co-ha-ldirectord-checktimeout" xrefstyle="select:label nopage"/>) 未從某部實際伺服器收到預期的 <literal>still alive</literal> 字串 (<xref linkend="co-ha-ldirectord-receive" xrefstyle="select:label nopage"/>)，則會將該實際伺服器從可用池中移除。但是，由於設定了 <literal>quiescent=yes</literal> (<xref linkend="co-ha-ldirectord-quiescent" xrefstyle="select:label nopage"/>)，因此該部實際伺服器不會從 LVS 表格移除，但其權值會設為 <literal>0</literal>，這樣便不會接受與此實際伺服器的新連接。已建立的連接將保持，直到逾時。
    </para>
   </example>
- </sect1>
- <sect1 id="sec-ha-lvs-further">
+ </section>
+ <section xml:id="sec-ha-lvs-further">
   <title>更多設定</title>
 
   <para>
@@ -397,16 +401,16 @@ quiescent = yes <co id="co-ha-ldirectord-quiescent"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-lvs-more">
+ </section>
+ <section xml:id="sec-ha-lvs-more">
   <title>更多資訊</title>
 
   <para>
-   如需有關 Linux Virtual Server 的詳細資訊，請參閱專案首頁 <ulink url="http://www.linuxvirtualserver.org/"/>。
+   如需有關 Linux Virtual Server 的詳細資訊，請參閱專案首頁 <link xlink:href="http://www.linuxvirtualserver.org/"/>。
   </para>
 
   <para>
    如需有關 <systemitem class="daemon">ldirectord</systemitem> 的資訊，請參閱完整的 man 頁面。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_management.xml
+++ b/zh_TW/xml/ha_management.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_management.xml" id="app-ha-management">
- <title>叢集管理工具</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_management.xml" xml:id="app-ha-management"><title>叢集管理工具</title><info/>
+ 
  <para>
   High Availability Extension 隨附了一組功能全面的工具，可協助您利用指令行來管理叢集。本章介紹管理 CIB 中的叢集組態與叢集資源所需的工具。<xref linkend="app-ha-troubleshooting"/> 中介紹了管理資源代辦的其他指令行工具和用於對設定進行除錯和疑難排解的工具。
  </para>

--- a/zh_TW/xml/ha_migration.xml
+++ b/zh_TW/xml/ha_migration.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_migration.xml" id="app-ha-migration">
- <title>升級叢集和更新軟體套件</title>
- <abstract>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_migration.xml" xml:id="app-ha-migration"><title>升級叢集和更新軟體套件</title><info><abstract>
   <para>
    本章介紹兩種不同的方案：將叢集升級到另一個版本的 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> (主要版本或 Service Pack)，以及更新叢集節點上的個別套件。
   </para>
- </abstract>
+ </abstract></info>
  
- <sect1 id="sec-ha-migration-terminology">
+ 
+ 
+ <section xml:id="sec-ha-migration-terminology">
   <title>術語</title>
   
   <para>
@@ -57,13 +61,13 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-upgrade">
+ <section xml:id="sec-ha-migration-upgrade">
   <title>將叢集升級到產品的最新版本</title>
   
   <para>
-   支援哪種升級路徑以及如何執行升級，視執行叢集的目前產品版本以及您要移轉到的目標版本而定。如需與此相關的一般資訊，請參閱《<citetitle>SUSE Linux Enterprise Server 11 部署指南</citetitle>》中的「<citetitle>更新 SUSE Linux Enterprise</citetitle>」一章。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。
+   支援哪種升級路徑以及如何執行升級，視執行叢集的目前產品版本以及您要移轉到的目標版本而定。如需與此相關的一般資訊，請參閱《<citetitle>SUSE Linux Enterprise Server 11 部署指南</citetitle>》中的「<citetitle>更新 SUSE Linux Enterprise</citetitle>」一章。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。
   </para>
   
   <important>
@@ -84,7 +88,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </itemizedlist>
   </important>
- <sect2 id="sec-ha-migration-sle11">
+ <section xml:id="sec-ha-migration-sle11">
   <title>從 SLES 10 升級到 SLE HA 11</title>
 
    <important>
@@ -134,34 +138,34 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <sect3 id="sec-ha-migration-sle11-prep">
+  <section xml:id="sec-ha-migration-sle11-prep">
    <title>準備與備份</title>
    <para>
     在將叢集升級到產品的下一版本並相應地轉換資料之前，需要對目前的叢集做一些準備工作。
    </para>
-   <procedure id="pro-ha-migration-sle11-prep">
+   <procedure xml:id="pro-ha-migration-sle11-prep">
     <title>準備 SUSE Linux Enterprise Server 10 SP4 叢集</title>
-    <step performance="required">
+    <step>
      <para>
       登入叢集。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       檢閱 Heartbeat 組態檔案 <filename>/etc/ha.d/ha.cf</filename>，並檢查所有通訊媒體是否支援多路廣播。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       確認以下檔案在所有節點上都相同︰<filename>/etc/ha.d/ha.cf</filename> 和 <filename>/var/lib/heartbeat/crm/cib.xml</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       對每個節點執行 <command>rcheartbeat stop</command>，使它們離線。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在更新至最新版本之前，除了需要依建議執行一般性系統備份之外，還需備份以下檔案，因為在升級到 SUSE Linux Enterprise Server 11 後需要使用它們來執行轉換程序檔︰
      </para>
@@ -188,36 +192,36 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </itemizedlist>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果您擁有 EVMS2 資源，請將非 LVM EVMS2 磁碟區轉換為 SUSE Linux Enterprise Server 10 上相容的磁碟區。在轉換過程中 (請參閱<xref linkend="sec-ha-migration-sle11-convert"/>)，這些磁碟區將轉變並歸入 LVM2 磁碟區群組。轉換之後，請務必使用 <command>vgchange -c y</command> 將各個磁碟區群組標示為高可用性叢集的成員。
 
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-install">
+  <section xml:id="sec-ha-migration-sle11-install">
    <title>升級/安裝</title>
    <para>
     準備好叢集並備份好檔案之後，便可以在叢集節點上執行 SUSE Linux Enterprise 11 的全新安裝。
    </para>
-   <procedure id="pro-ha-migration-sle11-install">
+   <procedure xml:id="pro-ha-migration-sle11-install">
     <title>升級到 SUSE Linux Enterprise 11</title>
-    <step performance="required">
+    <step>
      <para>
       在所有叢集節點上執行 SUSE Linux Enterprise 11 的全新安裝。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       在所有叢集節點上，將 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 做為 SUSE Linux Enterprise Server 的附加產品進行安裝。如需詳細資訊，請參閱<xref linkend="sec-ha-installation-add-on"/>。
      </para>
     </step>
    </procedure>
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-convert">
+  <section xml:id="sec-ha-migration-sle11-convert">
    <title>資料轉換</title>
    <para>
     安裝 SUSE Linux Enterprise Server 11 和 High Availability Extension 之後，便可開始轉換資料。High Availability Extension 隨附的轉換程序檔已經過周密設定，但它並不能在完全自動的模式下完成所有設定。它會警告您它所進行的變更，但仍需要您的互動和決定。您需要瞭解叢集的詳細情況，因為最終是由您來確認這些變更是否有意義。轉換程序檔位於 <filename>/usr/lib/heartbeat</filename> 中 (若您使用的是 64 位元系統，則位於 <filename>/usr/lib64/heartbeat</filename> 中)。
@@ -228,9 +232,9 @@ Please see LICENSE.txt for this document's license.
      為了讓您熟悉轉換程序，我們強烈建議您先進行轉換測試 (不做任何變更)。您可以使用相同的測試目錄來執行重複的測試回合，但只需複製一次檔案。
     </para>
    </note>
-   <procedure id="pro-ha-migration-sle11-test">
+   <procedure xml:id="pro-ha-migration-sle11-test">
     <title>測試轉換</title>
-    <step performance="required">
+    <step>
      <para>
       在其中一個節點上，建立測試目錄並將備份檔案複製到測試目錄中︰
      </para>
@@ -240,7 +244,7 @@ $ cp /var/lib/heartbeat/hostcache /tmp/hb2openais-testdir
 $ cp /etc/logd.cf /tmp/hb2openais-testdir
 $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用以下指令開始進行測試回合
      </para>
@@ -250,7 +254,7 @@ $ sudo cp /var/lib/heartbeat/crm/cib.xml /tmp/hb2openais-testdir</screen>
      </para>
 <screen>$ /usr/lib64/heartbeat/hb2openais.sh -T /tmp/hb2openais-testdir -U</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       讀取並驗證產生的 <filename>openais.conf</filename> 和 <filename>cib-out.xml</filename> 檔案︰
      </para>
@@ -262,27 +266,27 @@ $ crm_verify -V -x cib-out.xml</screen>
    <para>
     如需轉換階段的詳細資訊，請參閱所安裝之 High Availability Extension 中的 <filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>。
    </para>
-   <procedure id="pro-ha-migration-sle11-convert">
+   <procedure xml:id="pro-ha-migration-sle11-convert">
     <title>轉換資料</title>
     <para>
      執行測試回合並檢查輸出之後，便可以開始轉換資料。您只需在<emphasis>一個</emphasis>節點上執行轉換。主叢集組態 (CIB) 會自動複寫到其他節點中。轉換程序檔會自動複製需要複寫的所有其他檔案。
     </para>
-    <step performance="required">
+    <step>
      <para>
       確定所有節點上都在執行 <systemitem class="daemon">sshd</systemitem>，並且 <systemitem class="username">root</systemitem> 可以存取該服務，以便轉換程序檔能成功將檔案複製到其他叢集節點。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       確定所有 ocfs2 檔案系統都已卸載。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       High Availability Extension 隨附了預設的 OpenAIS 組態檔案。若在執行以下步驟時，不希望預設的組態被覆寫，請複製一份 <filename>/etc/ais/openais.conf</filename> 組態檔案。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       以 <systemitem class="username">root</systemitem> 身分啟動轉換程序檔。若正在使用 sudo，請使用 <option>-u</option> 選項指定有特權的使用者︰
      </para>
@@ -291,7 +295,7 @@ $ crm_verify -V -x cib-out.xml</screen>
       程序檔會依據 <filename>/etc/ha.d/ha.cf</filename> 中儲存的組態，產生適用於 OpenAIS 叢集堆疊的新組態檔案 <filename>/etc/ais/openais.conf</filename>。程序檔還會分析 CIB 組態，並讓您知道您的叢集組態是否需要因環境從 Heartbeat 變為 OpenAIS 而變更。所有檔案處理都是在執行轉換的節點上完成，然後再複寫到其他節點。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       按照螢幕上的指示執行操作。
      </para>
@@ -304,16 +308,16 @@ $ crm_verify -V -x cib-out.xml</screen>
     完成升級後，就不能重新回復到 SUSE Linux Enterprise Server 10。
    </para>
 
-  </sect3>
+  </section>
 
-  <sect3 id="sec-ha-migration-sle11-more">
+  <section xml:id="sec-ha-migration-sle11-more">
    <title>更多資訊</title>
    <para>
     如需轉換程序檔和轉換階段的更多詳細資料，請參閱所安裝之 High Availability Extension 中的 <filename>/usr/share/doc/packages/pacemaker/README.hb2openais</filename>。
    </para>
-  </sect3>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp1">
   <title>從 SLE HA 11 升級到 SLE HA 11 SP1</title>
 
    <note>
@@ -325,7 +329,7 @@ $ crm_verify -V -x cib-out.xml</screen>
 
 
 
-  <procedure id="pro-ha-migration-rolling-upgrade">
+  <procedure xml:id="pro-ha-migration-rolling-upgrade">
    <title>執行滾存升級</title>
 
     <warning>
@@ -335,36 +339,36 @@ $ crm_verify -V -x cib-out.xml</screen>
       如果某個節點上的叢集資源管理員在軟體更新期間處於使用中狀態，可能會導致出現不可預知的結果，例如圍籬區隔使用中的節點。
      </para>
     </warning>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身分登入要升級和停止 OpenAIS 的節點︰
     </para>
 <screen>rcopenais stop</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查您的系統備份是否最新、能否還原。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-tolatest" performance="required">
+   <step xml:id="step-ha-migration-upgrade-tolatest">
     <para>
      執行從 SUSE Linux Enterprise Server 11 到 SUSE Linux Enterprise Server 11 SP1 的升級程序，以及從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 到 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP1 的升級程序。如需如何升級產品的相關資訊，請參閱《SUSE Linux Enterprise Server 11 SP1 部署指南》中的「<citetitle>更新 SUSE Linux Enterprise</citetitle>」一章。
     </para>
    </step>
-   <step id="step-ha-migration-upgrade-ais" performance="required">
+   <step xml:id="step-ha-migration-upgrade-ais">
     <para>
      在已升級的節點上重新啟動 OpenAIS/Corosync，讓節點重新加入叢集︰
     </para>
 <screen>rcopenais start</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      讓下一個節點離線，並對其重複執行此程序。
     </para>
    </step>
   </procedure>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp2">
   <title>從 SLE HA 11 SP1 升級到 SLE HA 11 SP2</title>
 
   <para>
@@ -398,8 +402,8 @@ $ crm_verify -V -x cib-out.xml</screen>
     只有將<emphasis>所有</emphasis>叢集節點都升級到最新的產品版本後，才可以使用 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP2 隨附的新功能。在滾存升級期間，只有一段較短的時間支援 SP1/SP2 混合叢集。請在一週內完成滾存升級。
    </para>
   </important>
- </sect2>
- <sect2 id="sec-ha-migration-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-migration-sle11-sp3">
   <title>從 SLE HA 11 SP2 升級到 SLE HA 11 SP3</title>
 
   <para>
@@ -416,9 +420,9 @@ $ crm_verify -V -x cib-out.xml</screen>
     只有將<phrase role="productname">所有<phrase os="sles">叢集節點都升級到最新的產品版本後，才可以使用 </phrase></phrase>SUSE Linux Enterprise High Availability Extension<emphasis/> 11 SP3 隨附的新功能。在滾存升級期間，只有一段較短的時間支援 SP2/SP3 混合叢集。請在一週內完成滾存升級。
    </para>
   </important>
- </sect2>
+ </section>
   
-  <sect2 id="sec-ha-migration-sle11-sp4">
+  <section xml:id="sec-ha-migration-sle11-sp4">
    <title>從 SLE HA 11 SP3 升級到 SLE HA 11 SP4</title>
    
    <para>
@@ -429,7 +433,7 @@ $ crm_verify -V -x cib-out.xml</screen>
     依照<xref linkend="pro-ha-migration-rolling-upgrade"/> 所述繼續，並注意以下差異：在<xref linkend="step-ha-migration-upgrade-tolatest" xrefstyle="select:name"/> 中，從 SUSE Linux Enterprise Server 11  SP3 升級到 SUSE Linux Enterprise Server 11 SP4，以及從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級到 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4。
    </para>
    
-   <note id="note-ha-cib-upgrade">
+   <note xml:id="note-ha-cib-upgrade">
     <title>升級 CIB 語法版本</title>
     <para>標記 (用於對資源分組) 和某些 ACL 功能僅適用於 <literal>pacemaker-2.0</literal> 或更高的 CIB 語法版本。(若要檢查版本，請執行 <command>cibadmin -Q |grep validate-with</command>)。如果您已從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級，則 CIB 版本預設<emphasis>不會</emphasis>升級。若要手動升級到最新的 CIB 版本，請使用下列其中一個指令：</para>
     <screen><prompt role="root">root # </prompt>cibadmin --upgrade --force</screen>
@@ -443,10 +447,10 @@ $ crm_verify -V -x cib-out.xml</screen>
      只有將<phrase role="productname">所有<phrase os="sles">叢集節點都升級到最新的產品版本後，才可以使用 </phrase></phrase>SUSE Linux Enterprise High Availability Extension<emphasis/> 11 SP4 隨附的新功能。在滾存升級期間，只有一段較短的時間支援 SP3/SP4 混合叢集。請在一週內完成滾存升級。
     </para>
    </important>
-  </sect2>
+  </section>
   
- </sect1>
- <sect1 id="sec-ha-update">
+ </section>
+ <section xml:id="sec-ha-update">
   <title>更新叢集節點上的軟體套件</title>
   
   <warning>
@@ -461,7 +465,7 @@ $ crm_verify -V -x cib-out.xml</screen>
    在節點上安裝任何套件更新之前，請檢查以下幾點：
   </para>
   
-  <itemizedlist id="il-ha-update-cond" mark="bullet" spacing="normal">
+  <itemizedlist xml:id="il-ha-update-cond" mark="bullet" spacing="normal">
    <title>停止叢集堆疊的條件</title>
    <listitem>
     <para>
@@ -499,13 +503,13 @@ $ crm_verify -V -x cib-out.xml</screen>
   </para>
   
   <screen><prompt role="root">root # </prompt>rcopenais start</screen>
- </sect1>
+ </section>
  
- <sect1 id="sec-ha-migration-more">
+ <section xml:id="sec-ha-migration-more">
   <title>更多資訊</title>
 
   <para>
-   如需所升級產品目標版本的任何變更及新功能的詳細資訊，請參閱其版本說明，這些文件可從 <ulink url="https://www.suse.com/releasenotes/"/> 取得。
+   如需所升級產品目標版本的任何變更及新功能的詳細資訊，請參閱其版本說明，這些文件可從 <link xlink:href="https://www.suse.com/releasenotes/"/> 取得。
   </para>
- </sect1>
+ </section>
 </appendix>

--- a/zh_TW/xml/ha_naming.xml
+++ b/zh_TW/xml/ha_naming.xml
@@ -1,16 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_naming.xml" id="app-naming">
-  <title>命名慣例</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_naming.xml" xml:id="app-naming"><title>命名慣例</title><info/>
+  
   <para>本指南對叢集節點和名稱、叢集資源與條件約束使用以下命名慣例。
   </para>
   
-  <variablelist id="vl-naming-cluster-names-nodes">
+  <variablelist xml:id="vl-naming-cluster-names-nodes">
     
     <varlistentry>
       <term>叢集節點</term>

--- a/zh_TW/xml/ha_netbonding.xml
+++ b/zh_TW/xml/ha_netbonding.xml
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_netbonding.xml" id="cha-ha-netbonding">
- <title>網路裝置 Bonding</title>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_netbonding.xml" xml:id="cha-ha-netbonding"><title>網路裝置 Bonding</title><info/>
+ 
  <para>
   對於許多系統而言，實作的網路連接除了需要符合一般乙太網路裝置的標準資料安全性或可用性要求之外，還需要符合其他要求。在這些情況下，數個乙太網路裝置可以結集成單個 Bonding 裝置。
  </para>
@@ -17,7 +21,7 @@ Please see LICENSE.txt for this document's license.
   使用 OpenAIS 時，bonding 裝置無法透過叢集軟體管理。因此，必須在可能需要存取 bonding 裝置的每個叢集節點上設定該裝置。
  </para>
 
- <sect1 id="sec-ha-netbond-yast">
+ <section xml:id="sec-ha-netbond-yast">
   <title>使用 YaST 設定 Bonding 裝置</title>
 
   <para>
@@ -25,27 +29,27 @@ Please see LICENSE.txt for this document's license.
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身分啟動 YaST，然後選取<menuchoice><guimenu>網路裝置</guimenu> <guimenu>網路設定</guimenu></menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>網路設定</guimenu>中，切換至<guimenu>綜覽</guimenu>索引標籤，其中會顯示可用的裝置。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查要結集至 bonding 裝置的乙太網路裝置是否已經指定了 IP 位址。如果已指定，請加以變更：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選取要變更的裝置，然後按一下<guimenu>編輯</guimenu>。
       </para>
      </step>
-     <step id="step-bond-slave" performance="required">
+     <step xml:id="step-bond-slave">
       <para>
        在開啟的<guimenu>網路卡設定</guimenu>對話方塊的<guimenu>位址</guimenu>索引標籤中，選中<guimenu>沒有連結和 IP 設定 (Bonding 從屬)</guimenu>選項。
       </para>
@@ -60,24 +64,24 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        按<guimenu>下一步</guimenu>回到<guimenu>網路設定</guimenu>對話方塊中的<guimenu>綜覽</guimenu>索引標籤。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      若要新增新的 Bonding 裝置：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        按一下<guimenu>新增</guimenu>，然後將<guimenu>裝置類型</guimenu>設為<guimenu>Bond</guimenu>。按<guimenu>下一步</guimenu>繼續。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        選取為 bonding 裝置指定 IP 位址的方法。有三種方法可供您選擇︰
       </para>
@@ -102,12 +106,12 @@ Please see LICENSE.txt for this document's license.
        請使用適合您環境的方法。如果是由 OpenAIS 管理虛擬 IP 位址，請選取<guimenu>靜態指定的 IP 位址</guimenu>，然後為介面指定一個 IP 位址。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切換到<guimenu>Bond 從屬</guimenu>索引標籤。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        它會顯示已在<xref linkend="step-bond-slave" xrefstyle="select:label       nopage"/> 中設定為 Bonding 從屬的所有乙太網路裝置。若要選取要加入 Bond 的乙太網路裝置，請選取相應<guimenu>Bond 從屬</guimenu>前面的核取方塊。
       </para>
@@ -122,7 +126,7 @@ Please see LICENSE.txt for this document's license.
        </mediaobject>
       </informalfigure>
      </step>
-     <step performance="required">
+     <step>
       <para>
        編輯<guimenu>Bond 驅動程式選項</guimenu>。可用模式如下︰
       </para>
@@ -192,22 +196,22 @@ Please see LICENSE.txt for this document's license.
        </varlistentry>
       </variablelist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        請務必將參數 <literal>miimon=100</literal> 新增至<guimenu>Bond 驅動程式選項</guimenu>。如果不指定此參數，則不會定期檢查連結，因此，結合驅動程式可能會持續在有故障的連結上遺失封包。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按<guimenu>下一步</guimenu>，然後按<guimenu>確定</guimenu>離開 YaST，以完成 Bonding 裝置設定。YaST 會將組態寫入 <filename>/etc/sysconfig/network/ifcfg-bond<replaceable>裝置編號</replaceable></filename>。
     </para>
    </step>
   </procedure>
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-netbond-hotpug-yast">
+ <section xml:id="sec-ha-netbond-hotpug-yast">
   <title>Bonding 從屬的熱插拔</title>
 
   <para>
@@ -220,12 +224,12 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果您偏好手動設定，請參閱《SUSE Linux Enterprise Server 11 管理指南》「<citetitle>基本網路</citetitle>」一章中的「<citetitle>Bonding 從屬的熱插拔</citetitle>」一節。
    </para>
-   <step performance="required">
+   <step>
     <para>
      以 <systemitem class="username">root</systemitem> 身分啟動 YaST，然後選取<menuchoice><guimenu>網路裝置</guimenu> <guimenu>網路設定</guimenu></menuchoice>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在<guimenu>網路設定</guimenu>中，切換至<guimenu>綜覽</guimenu>索引標籤，其中會顯示已設定的裝置。如果 bonding 從屬已設定，<guimenu>備註</guimenu>欄中會指出該情況。
     </para>
@@ -240,39 +244,39 @@ Please see LICENSE.txt for this document's license.
      </mediaobject>
     </informalfigure>
    </step>
-   <step performance="required">
+   <step>
     <para>
      針對已結集到 bonding 從屬的每個乙太網路裝置，執行以下步驟：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        選取要變更的裝置，然後按一下<guimenu>編輯</guimenu>。<guimenu>網路卡設定</guimenu>對話方塊即會開啟。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切換至<guimenu>一般</guimenu>索引標籤，並確定<guimenu>啟動裝置</guimenu>設為<literal>熱插拔時</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        切換至<guimenu>硬體</guimenu>索引標籤。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        針對<guimenu>Udev 規則</guimenu>按一下<guimenu>變更</guimenu>，然後選取<guimenu>匯流排 ID</guimenu>選項。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        按一下<guimenu>確定</guimenu>和<guimenu>下一步</guimenu>，回到<guimenu>網路設定</guimenu>對話方塊中的<guimenu>綜覽</guimenu>索引標籤。如果您現在按一下乙太網路裝置項目，下方窗格將會顯示裝置的詳細資料，其中包括匯流排 ID。
       </para>
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      按一下<guimenu>確定</guimenu>確認您的變更並離開網路設定。
     </para>
@@ -282,8 +286,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    開機時，<filename>/etc/init.d/network</filename> 不會等待熱插拔從屬裝置，但會等待 Bond 就緒，而後者至少需要一個可用的從屬裝置。當從系統中移除其中一個從屬介面 (從 NIC 驅動程式解除結合、<command>rmmod</command> NIC 驅動程式或實際移除 PCI 熱插拔) 時，核心會自動將它從 Bond 中移除。當將新卡新增至系統 (更換插槽中的硬體) 時，<systemitem>udev</systemitem> 會套用基於匯流排的永久命名規則將其重新命名，然後為它呼叫 <command>ifup</command>。<command>ifup</command> 呼叫會自動將它加入 Bond。
   </para>
- </sect1>
- <sect1 id="sec-ha-netbonding-more">
+ </section>
+ <section xml:id="sec-ha-netbonding-more">
   <title>更多資訊</title>
 
   <para>
@@ -292,5 +296,5 @@ Please see LICENSE.txt for this document's license.
   <para>對於高可用性設定，本指南所述的以下選項特別重要：<option>miimon</option> 和 <option>use_carrier</option>。</para>
 
 
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_news.xml
+++ b/zh_TW/xml/ha_news.xml
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE appendix>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<appendix xml:base="ha_news.xml" id="cha-ha-changes">
- <title>最新功能</title>
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_news.xml" xml:id="cha-ha-changes"><title>最新功能</title><info/>
+ 
  <para>
   下面幾節將概要介紹各版軟體之間最重要的修改。文中彙總了基本設定是否已完全重新設定、組態檔案是否已移至他處，或者是否做了其他大幅變更等資訊。
  </para>
  <para>
-  如需詳細資料和最新資訊，請參閱相應產品版本的版本說明。您可以從所安裝系統的 <filename>/usr/share/doc/release-notes</filename> 中取得相應的版本說明，也可以從 <ulink url="https://www.suse.com/releasenotes/"/> 線上取得。
+  如需詳細資料和最新資訊，請參閱相應產品版本的版本說明。您可以從所安裝系統的 <filename>/usr/share/doc/release-notes</filename> 中取得相應的版本說明，也可以從 <link xlink:href="https://www.suse.com/releasenotes/"/> 線上取得。
  </para>
- <sect1 id="sec-ha-changes-sle11">
+ <section xml:id="sec-ha-changes-sle11">
   <title>版本 10 SP3 至版本 11</title>
 
   <para>
@@ -24,10 +28,10 @@ Please see LICENSE.txt for this document's license.
    如需從 SUSE® Linux Enterprise Server 10 SP3 升級到 SUSE Linux Enterprise Server 11 後 High Availability 各元件發生之變更的詳細資料，請參閱下面幾節。
   </para>
 
-  <sect2 id="sec-ha-changes-sle11-new">
+  <section xml:id="sec-ha-changes-sle11-new">
    <title>新特性和新功能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-fail">
+    <varlistentry xml:id="vle-ha-news-fail">
      <term>移轉限定值與故障逾時</term>
      <listitem>
       <para>
@@ -35,7 +39,7 @@ Please see LICENSE.txt for this document's license.
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry id="vle-ha-news-defaults">
+    <varlistentry xml:id="vle-ha-news-defaults">
      <term>資源和操作預設值</term>
      <listitem>
       <para>
@@ -92,12 +96,12 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-changed">
+  <section xml:id="sec-ha-changes-sle11-changed">
    <title>變更的特性與功能</title>
    <variablelist>
-    <varlistentry id="vle-ha-news-options">
+    <varlistentry xml:id="vle-ha-news-options">
      <term>資源和叢集選項的命名慣例</term>
      <listitem>
       <para>
@@ -203,9 +207,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-changes-sle11-removed">
+  <section xml:id="sec-ha-changes-sle11-removed">
    <title>已移除的特性與功能</title>
    <variablelist>
     <varlistentry>
@@ -225,9 +229,9 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp1">
+  </section>
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp1">
   <title>版本 11 至版本 11 SP1</title>
 
   <variablelist>
@@ -337,8 +341,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp2">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp2">
   <title>版本 11 SP1 至版本 11 SP2</title>
 
   <variablelist>
@@ -459,8 +463,8 @@ Please see LICENSE.txt for this document's license.
 
 
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp3">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp3">
   <title>版本 11 SP2 至版本 11 SP3</title>
 
   <variablelist>
@@ -579,8 +583,8 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
   
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-changes-sle11-sp4">
+ </section>
+ <section xml:id="sec-ha-changes-sle11-sp4">
   <title>版本 11 SP3 至版本 11 SP4</title>
   <variablelist>
    <varlistentry>
@@ -597,7 +601,7 @@ Please see LICENSE.txt for this document's license.
        <para>移除了包含代辦清單的「<citetitle>HA OCF 代辦</citetitle>」一章。因此，也移除了「<citetitle>疑難排解與參考</citetitle>」部分，並且將<xref linkend="app-ha-troubleshooting" xrefstyle="select:title"/>一章移到了附錄中。</para>
       </listitem>
       <listitem>
-       <para>已將 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的文件轉移到一份獨立文件 (Fate#316120)。如需如何使用和設定地理位置分散叢集的詳細資料，請參閱《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。可以從 <ulink url="http://www.suse.com/documentation/"/> 或者所安裝系統的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到該文件。</para>
+       <para>已將 Geo Clustering for SUSE Linux Enterprise High Availability Extension 的文件轉移到一份獨立文件 (Fate#316120)。如需如何使用和設定地理位置分散叢集的詳細資料，請參閱《Quick Start Geo Clustering for SUSE Linux Enterprise High Availability Extension》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。可以從 <link xlink:href="http://www.suse.com/documentation/"/> 或者所安裝系統的 <filename>/usr/share/doc/manual/sle-ha-geo-manuals_en/</filename> 下找到該文件。</para>
       </listitem>
       <listitem>
        <para>變更了<literal>主要-從屬</literal>資源的術語，在上游文件中，此類資源現在稱為<literal>多狀態</literal>資源。</para>
@@ -688,7 +692,7 @@ Please see LICENSE.txt for this document's license.
        <para>更新了該章，以反映<xref linkend="cha-ha-config-basics"/>中所述的新功能。</para>
       </listitem>
       <listitem>
-       <para>與地理叢集相關之所有 Hawk 功能的介紹內容已移至單獨的文件中。請參閱 <ulink url="http://www.suse.com/documentation/"/> 上的新文件《<citetitle>Geo Clustering for SUSE Linux Enterprise High Availability Extension Quick Start</citetitle>》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。</para>
+       <para>與地理叢集相關之所有 Hawk 功能的介紹內容已移至單獨的文件中。請參閱 <link xlink:href="http://www.suse.com/documentation/"/> 上的新文件《<citetitle>Geo Clustering for SUSE Linux Enterprise High Availability Extension Quick Start</citetitle>》(Geo Clustering for SUSE Linux Enterprise High Availability Extension 快速入門)。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -737,7 +741,7 @@ Please see LICENSE.txt for this document's license.
       </listitem>
       <listitem>
        <para>依據升級 CIB 驗證版本後提供的新 ACL 功能更新了章節。如需詳細資料，請參閱<xref linkend="note-ha-cib-upgrade"/>。</para>
-       <para>如果您已從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級並保留了以前的 CIB 版本，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的「<citetitle>存取控制清單</citetitle>」一章。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。</para>
+       <para>如果您已從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 升級並保留了以前的 CIB 版本，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》中的「<citetitle>存取控制清單</citetitle>」一章。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。</para>
       </listitem>
      </itemizedlist>
     </listitem>
@@ -748,16 +752,16 @@ Please see LICENSE.txt for this document's license.
     <listitem>
      <itemizedlist mark="bullet" spacing="normal">
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：新增了關於監視程式以及會存取監視程式計時器的其他軟體說明 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：新增了關於監視程式以及會存取監視程式計時器的其他軟體說明 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891340"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：新增了關於如何在開機時載入監視程式驅動程式的資訊 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
+       <para><xref linkend="pro-ha-storage-protect-watchdog"/>：新增了關於如何在開機時載入監視程式驅動程式的資訊 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=892344"/>)。</para>
       </listitem>
       <listitem>
-       <para><xref linkend="pro-ha-storage-protect-fencing"/>：新增了與 <literal>msgwait</literal> 逾時相關的 <literal>stonith-timeout</literal> 時長建議 (<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)。 </para>
+       <para><xref linkend="pro-ha-storage-protect-fencing"/>：新增了與 <literal>msgwait</literal> 逾時相關的 <literal>stonith-timeout</literal> 時長建議 (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891346"/>)。 </para>
       </listitem>
       <listitem>
-       <para>調整了<xref linkend="pro-ha-storage-protect-sbd-daemon"/>(<ulink url="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
+       <para>調整了<xref linkend="pro-ha-storage-protect-sbd-daemon"/>(<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=891499"/>)。</para>
       </listitem>
       <listitem>
        <para>介紹如何透過對 STONITH 資源組態使用 <literal>pcmk_delay_max</literal> 參數，來避免採用 <literal>no-quorum-policy=ignore</literal> 設定的叢集發生雙重圍籬區隔 (Fate#31713)。</para>
@@ -770,7 +774,7 @@ Please see LICENSE.txt for this document's license.
     <term><xref linkend="cha-ha-rear"/></term>
     <listitem>
      <para>該章內容已徹底修訂，並已更新為 Rear 版本 <literal>1.16</literal>。</para>
-     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 隨附了兩個 Rear 版本：版本 <literal>1.10.0</literal> (包含在 RPM 套件 <systemitem class="resource">rear</systemitem> 中) 和版本 <literal>1.16</literal> (包含在 RPM 套件 <systemitem class="resource">rear116</systemitem> 中)。如需 Rear 版本 <literal>1.10.0</literal> 的文件，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。</para>
+     <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 隨附了兩個 Rear 版本：版本 <literal>1.10.0</literal> (包含在 RPM 套件 <systemitem class="resource">rear</systemitem> 中) 和版本 <literal>1.16</literal> (包含在 RPM 套件 <systemitem class="resource">rear116</systemitem> 中)。如需 Rear 版本 <literal>1.10.0</literal> 的文件，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。</para>
     </listitem>
    </varlistentry>
    
@@ -831,5 +835,5 @@ Please see LICENSE.txt for this document's license.
    
    
 
- </sect1>
+ </section>
 </appendix>

--- a/zh_TW/xml/ha_nfs_quick_config_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_config_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_config_i.xml" id="sec-ha-quick-nfs-initial">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_config_i.xml" xml:id="sec-ha-quick-nfs-initial">
  <title>Initial Configuration</title>
 
  <para>
@@ -18,7 +19,7 @@ Please see LICENSE.txt for this document's license.
   3 or 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-initial-drbd-resource">
+ <section xml:id="sec-ha-quick-nfs-initial-drbd-resource">
   <title>Configuring a DRBD Resource</title>
   <para>
    First, it is necessary to configure a DRBD resource to hold your data.
@@ -56,9 +57,9 @@ Please see LICENSE.txt for this document's license.
    Csync2, refer to <xref linkend="sec-ha-installation-setup-csync2"/>.
   </para>
   
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-initial-lvm-config">
+ <section xml:id="sec-ha-quick-nfs-initial-lvm-config">
   <title>Configuring LVM</title>
   <para>
    To use LVM with DRBD, it is necessary to change some options in the LVM
@@ -162,9 +163,9 @@ mkfs -t ext3 /dev/nfs/sales
 mkfs -t ext3 /dev/nfs/engineering</screen>
    </listitem>
   </orderedlist>
- </sect2>
+ </section>
 
- <sect2 os="sles" id="sec-ha-quick-nfs-initial-setup">
+ <section os="sles" xml:id="sec-ha-quick-nfs-initial-setup">
   <title>Initial Cluster Setup</title>
   <para>
    Use the YaST cluster module for the initial cluster setup. The process
@@ -192,11 +193,11 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
    Then start the OpenAIS/Corosync service as described in
    <xref linkend="sec-ha-installation-start"/>.
   </para>
- </sect2>
+ </section>
 
  
 
- <sect2 id="sec-ha-quick-nfs-initial-pacemaker">
+ <section xml:id="sec-ha-quick-nfs-initial-pacemaker">
   <title>Creating a Basic Pacemaker Configuration</title>
   <para>
    Configure a STONITH device as described in
@@ -236,5 +237,5 @@ mkfs -t ext3 /dev/nfs/engineering</screen>
 crm(live)configure# property no-quorum-policy="ignore"
 crm(live)configure# rsc_defaults resource-stickiness="200"
 crm(live)configure# commit</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_nfs_quick_failover_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_failover_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_failover_i.xml" id="sec-ha-quick-nfs-failover">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_failover_i.xml" xml:id="sec-ha-quick-nfs-failover">
  <title>Ensuring Smooth Cluster Failover</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   failover.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time">
   <title>NFSv4 Lease Time</title>
   <para>
    For exports used by NFSv4 clients, the NFS server hands out
@@ -43,9 +44,9 @@ Please see LICENSE.txt for this document's license.
    may cause a prolonged period of NFS lock-up that clients experience
    during an NFS service transition on the cluster.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-failover-lease-time-change">
+ <section xml:id="sec-ha-quick-nfs-failover-lease-time-change">
   <title>Modifying NFSv4 Lease Time</title>
   <para>
    To allow for faster failover, you may decrease the grace period.
@@ -65,5 +66,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>NFSD_V4_GRACE=10</screen>
   <para>Restart the NFS services.</para>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_nfs_quick_install_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_install_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_install_i.xml" id="sec-ha-quick-nfs-prereq">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_install_i.xml" xml:id="sec-ha-quick-nfs-prereq">
  <title>Prerequisites and Installation</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   sure that the following prerequisites are fulfilled.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-prereq-pkg">
+ <section xml:id="sec-ha-quick-nfs-prereq-pkg">
   <title>Software Requirements</title>
   <itemizedlist os="sles" mark="bullet" spacing="normal">
    <listitem>
@@ -112,9 +113,9 @@ Please see LICENSE.txt for this document's license.
    </para>
    
   </note>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-prereq-services">
+ <section xml:id="sec-ha-quick-nfs-prereq-services">
   <title>Services at Boot Time</title>
   <para os="sles">
    After you have installed the required packages, take care of a few
@@ -142,5 +143,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_nfs_quick_intro_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_intro_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_intro_i.xml" id="sec-ha-quick-nfs-intro">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_intro_i.xml" xml:id="sec-ha-quick-nfs-intro">
  <title>Introduction</title>
 
  <para>
@@ -18,4 +19,4 @@ Please see LICENSE.txt for this document's license.
   enterprise: NFSv3 and NFSv4. The solution described in this document is
   applicable to NFS clients using either version.
  </para>
-</sect1>
+</section>

--- a/zh_TW/xml/ha_nfs_quick_rsc_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_rsc_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_rsc_i.xml" id="sec-ha-quick-nfs-resources">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_rsc_i.xml" xml:id="sec-ha-quick-nfs-resources">
  <title>Cluster Resources for a A Highly Available NFS Service</title>
 
  <para>
@@ -110,7 +111,7 @@ Please see LICENSE.txt for this document's license.
   </para>
  </example>
 
- <sect2 id="sec-ha-quick-nfs-resources-drbd">
+ <section xml:id="sec-ha-quick-nfs-resources-drbd">
   <title>DRBD Master/Slave Resource</title>
   <para>
    To configure this resource, issue the following commands from the
@@ -136,9 +137,9 @@ crm(live)configure# commit</screen>
    Check this with the <command>crm_mon</command> command, or by looking at
    the contents of <filename>/proc/drbd</filename>.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsserver">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsserver">
   <title>NFS Kernel Server Resource</title>
   <para>
    In the <literal>crm</literal> shell, the resource for the NFS server
@@ -166,9 +167,9 @@ crm(live)configure# commit</screen>
    After you have committed this configuration, Pacemaker should start the
    NFS Kernel server processes on both nodes.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-lvm">
+ <section xml:id="sec-ha-quick-nfs-resources-lvm">
   <title>LVM and File System Resources</title>
   <orderedlist spacing="normal">
    <listitem>
@@ -241,9 +242,9 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
     </para>
    </listitem>
   </itemizedlist>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-nfsexport">
+ <section xml:id="sec-ha-quick-nfs-resources-nfsexport">
   <title>NFS Export Resources</title>
   <para>
    Once your DRBD, LVM, and file system resources are working properly,
@@ -251,7 +252,7 @@ crm(live)configure# colocation c_nfs_on_drbd inf: \
    available NFS export resources, use the <literal>exportfs</literal>
    resource type.
   </para>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
    <title>NFSv4 Virtual File System Root</title>
    <para>
     If clients exclusively use NFSv3 to connect to the server, you do not
@@ -305,8 +306,8 @@ crm(live)configure# commit</screen>
      </para>
     </listitem>
    </orderedlist>
-  </sect3>
-  <sect3 id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
+  </section>
+  <section xml:id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
    <title>Non-root NFS Exports</title>
    <para>
     All NFS exports that do <emphasis>not</emphasis> represent an NFSv4
@@ -368,10 +369,10 @@ crm(live)configure# primitive p_exportfs_engineering \
      <screen>exportfs -v</screen>
     </listitem>
    </orderedlist>
-  </sect3>
- </sect2>
+  </section>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-resources-ipaddr">
+ <section xml:id="sec-ha-quick-nfs-resources-ipaddr">
   <title>Resource for Floating IP Address</title>
   <para>
    To enable smooth and seamless failover, your NFS clients will be
@@ -435,5 +436,5 @@ crm(live)configure# primitive p_exportfs_engineering \
     will suffer service interruptions on cluster failover.
    </para>
   </note>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_nfs_quick_use_i.xml
+++ b/zh_TW/xml/ha_nfs_quick_use_i.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1 PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE sect1>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<?xml-stylesheet href="urn:x-suse:xslt:profiling:novdoc-profile.xsl"
-  type="text/xml" 
-  title="Profiling step"?>
-<sect1 xml:base="ha_nfs_quick_use_i.xml" id="sec-ha-quick-nfs-use">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_nfs_quick_use_i.xml" xml:id="sec-ha-quick-nfs-use">
  <title>Using the NFS Service</title>
 
  <para>
@@ -16,7 +17,7 @@ Please see LICENSE.txt for this document's license.
   NFS client. It covers NFS clients using NFS versions 3 and 4.
  </para>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv3">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv3">
   <title>Connecting with NFS Version 3</title>
   <para>
    To connect to the highly available NFS service with an NFS version 3
@@ -42,9 +43,9 @@ Please see LICENSE.txt for this document's license.
    For further NFSv3 mount options, consult the <command>nfs</command> man
    page.
   </para>
- </sect2>
+ </section>
 
- <sect2 id="sec-ha-quick-nfs-use-nfsv4">
+ <section xml:id="sec-ha-quick-nfs-use-nfsv4">
   <title>Connecting with NFS Version 4</title>
   <important>
    <para>
@@ -72,5 +73,5 @@ Please see LICENSE.txt for this document's license.
   </para>
   <screen>mount -t nfs4 -o rsize=32768,wsize=32768 \
   10.9.9.180:/engineering /home/engineering</screen>
- </sect2>
-</sect1>
+ </section>
+</section>

--- a/zh_TW/xml/ha_ocfs2.xml
+++ b/zh_TW/xml/ha_ocfs2.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_ocfs2.xml" id="cha-ha-ocfs2">
- <title>OCFS2</title><indexterm class="startofrange" id="idx-filesystems-ocfs2"> <primary>檔案系統</primary> <secondary>OCFS2</secondary> </indexterm>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_ocfs2.xml" xml:id="cha-ha-ocfs2"><title>OCFS2</title><info><abstract>
   <para>
    Oracle Cluster File System 2 (OCFS2) 是一般性用途的日誌檔案系統，自 Linux 2.6 版起便已完全整合到該核心中。OCFS2 可讓您將應用程式二進位檔案、資料檔案和資料庫儲存於裝置上的共享儲存中。叢集中所有節點均同時具有檔案系統的讀取與寫入權限。透過複製品資源管理的使用者空間控制精靈可提供與 HA 堆疊的整合，特別是與 OpenAIS/Corosync 和分散式鎖定管理員 (DLM) 的整合。
   </para>
- </abstract>
- <sect1 id="sec-ha-ocfs2-features">
+ </abstract></info>
+ <indexterm class="startofrange" xml:id="idx-filesystems-ocfs2"> <primary>檔案系統</primary> <secondary>OCFS2</secondary> </indexterm>
+ 
+ <section xml:id="sec-ha-ocfs2-features">
   <title>特點及優勢</title>
 
   <para>
@@ -104,8 +108,8 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-ocfs2-utils">
+ </section>
+ <section xml:id="sec-ha-ocfs2-utils">
   <title>OCFS2 套件與管理公用程式</title>
 
   <para>
@@ -197,8 +201,8 @@ Please see LICENSE.txt for this document's license.
     </tbody>
    </tgroup>
   </table>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create-service">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create-service">
   <title>設定 OCFS2 服務與 STONITH 資源</title>
 
 
@@ -218,7 +222,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <procedure id="pro-ocfs2-resources">
+  <procedure xml:id="pro-ocfs2-resources">
    <title>設定 DLM 與 O2CB 資源</title>
    <para>
     該組態由一個包含數個基本資源的基礎群組與一個基礎複製品構成。之後，基礎群組與基礎複製品便可用於各種情況 (例如，用於 OCFS2 與 cLVM)。您只需根據需要新增相應的基本資源來擴充基礎群組。由於基礎群組有內部並存與順序條件約束，因此您不必指定多個個別群組、複製品及其相依項，這使總體設定程序更為簡便。
@@ -226,17 +230,17 @@ Please see LICENSE.txt for this document's license.
    <para>
     對叢集中的某個節點執行下列步驟︰
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動外圍程序，並以 <systemitem class="username">root</systemitem> 或同等身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     執行 <command>crm <option>configure</option></command>。
+     執行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入以下內容以建立 DLM 與 O2CB 的基本資源：
     </para>
@@ -250,7 +254,7 @@ Please see LICENSE.txt for this document's license.
      <literal>dlm</literal> 複製品資源控制分散式鎖定管理員服務，並用於確定此服務在叢集中的所有節點上啟動。鑒於基礎群組的內部並存與順序，<literal>o2cb</literal> 服務只會在已執行 <literal>dlm</literal> 服務副本的節點上啟動。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入以下內容以建立一個基礎群組與一個基礎複製品：
 
@@ -259,19 +263,19 @@ Please see LICENSE.txt for this document's license.
 <command>clone</command> base-clone base-group \
       meta interleave="true"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 檢閱所做的變更。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果所有設定都正確，請使用 <command>commit</command> 提交變更，然後使用 <command>exit</command> 離開 crm 即時組態。
     </para>
    </step>
   </procedure>
 
-  <procedure id="pro-ocfs2-stonith">
+  <procedure xml:id="pro-ocfs2-stonith">
    <title>設定 STONITH 資源</title>
    <note>
     <title>需要 STONITH 裝置</title>
@@ -279,22 +283,22 @@ Please see LICENSE.txt for this document's license.
      您需要設定一部圍籬區隔裝置。如果沒有設定合適的 STONITH 機制 (如 <literal>external/sbd</literal>)，組態將失敗。
     </para>
    </note>
-   <step performance="required">
+   <step>
     <para>
      啟動外圍程序，並以 <systemitem class="username">root</systemitem> 或同等身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依<xref linkend="pro-ha-storage-protect-sbd-create"/> 所述建立一個 SBD 分隔區。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     執行 <command>crm <option>configure</option></command>。
+     執行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將 <literal>external/sdb</literal> 設定為圍籬區隔裝置 (其 <literal>/dev/sdb2</literal> 做為共享儲存區上的專用分割區)，執行活動訊號與圍籬區隔︰
     </para>
@@ -302,19 +306,19 @@ Please see LICENSE.txt for this document's license.
       params pcmk_delay_max="15" \
       op monitor interval="15" timeout="15"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 檢閱所做的變更。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果所有設定都正確，請使用 <command>commit</command> 提交變更，然後使用 <command>exit</command> 離開 crm 即時組態。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-create">
+ </section>
+ <section xml:id="sec-ha-ocfs2-create">
   <title>建立 OCFS2 磁碟區</title>
 
   <para>
@@ -336,7 +340,7 @@ Please see LICENSE.txt for this document's license.
    然後按<xref linkend="pro-ocfs2-volume"/> 中所述，使用 <command>mkfs.ocfs2</command> 建立並格式化 OCFS2 磁碟區。此指令最重要的參數列於<xref linkend="tab-ha-ofcs2-mkfs-ocfs2-params"/>。如需詳細資訊及指令語法，請參閱 <command>mkfs.ocfs2</command> man 頁面。
   </para>
 
-  <table id="tab-ha-ofcs2-mkfs-ocfs2-params">
+  <table xml:id="tab-ha-ofcs2-mkfs-ocfs2-params">
    <title>OCFS2 的重要參數</title>
    <tgroup cols="2">
     <thead>
@@ -449,22 +453,22 @@ Please see LICENSE.txt for this document's license.
 
 
 
-  <procedure id="pro-ocfs2-volume">
+  <procedure xml:id="pro-ocfs2-volume">
    <title>建立並格式化 OCFS2 磁碟區</title>
    <para>
     在其中<emphasis>一</emphasis>個叢集節點上執行下列步驟。
    </para>
-   <step performance="required">
+   <step>
     <para>
      開啟終端機視窗，並以 <systemitem class="username">root</systemitem> 身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用指令 <command>crm status</command> 檢查叢集是否上線。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>mkfs.ocfs2</command> 公用程式建立並格式化磁碟區。如需此指令的語法資訊，請參閱 <command>mkfs.ocfs2</command> man 頁面。
     </para>
@@ -475,27 +479,27 @@ Please see LICENSE.txt for this document's license.
 
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-mount">
+ </section>
+ <section xml:id="sec-ha-ocfs2-mount">
   <title>掛接 OCFS2 磁碟區</title>
 
   <para>
    您可以按<xref linkend="pro-ocfs2-mount-cluster"/> 中所述，手動或使用叢集管理員掛接 OCFS2 磁碟區。
   </para>
 
-  <procedure id="pro-ocfs2-mount-manual">
+  <procedure xml:id="pro-ocfs2-mount-manual">
    <title>手動掛接 OCFS2 磁碟區</title>
-   <step performance="required">
+   <step>
     <para>
      開啟終端機視窗，並以 <systemitem class="username">root</systemitem> 身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用指令 <command>crm status</command> 檢查叢集是否上線。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      從指令行掛接磁碟區，請使用 <command>mount</command> 指令。
     </para>
@@ -509,22 +513,22 @@ Please see LICENSE.txt for this document's license.
    </para>
   </warning>
 
-  <procedure id="pro-ocfs2-mount-cluster">
+  <procedure xml:id="pro-ocfs2-mount-cluster">
    <title>使用叢集管理員掛接 OCFS2 磁碟區</title>
    <para>
     若要使用 High Availability 軟體掛接 OCFS2 磁碟區，請在叢集中設定 ocf 檔案系統資源。下面的程序將使用 <command>crm</command> 外圍程序來設定叢集資源。或者，您也可以使用 Pacemaker GUI 設定資源。
    </para>
-   <step performance="required">
+   <step>
     <para>
      啟動外圍程序，並以 <systemitem class="username">root</systemitem> 或同等身分登入。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
-     執行 <command>crm <option>configure</option></command>。
+     執行 <command>crm</command> <option>configure</option>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      設定 Pacemaker 以在叢集內各節點上掛接檔案系統︰
     </para>
@@ -532,19 +536,19 @@ Please see LICENSE.txt for this document's license.
       params device="/dev/sdb1" directory="/mnt/shared" fstype="ocfs2" options="acl" \
       op monitor interval="20" timeout="40"</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      將檔案系統基本資源新增至您在<xref linkend="pro-ocfs2-resources"/> 中設定的基礎群組：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        輸入
       </para>
 <screen><prompt role="custom">crm(live)configure# </prompt>edit base-group</screen>
      </step>
 
-     <step performance="required">
+     <step>
       <para>
        在開啟的 vi 編輯器中，對群組做如下修改並儲存所做的變更：
       </para>
@@ -556,19 +560,19 @@ Please see LICENSE.txt for this document's license.
     </substeps>
    </step>
 
-   <step performance="required">
+   <step>
     <para>
      使用 <command>show</command> 檢閱所做的變更。若要檢查您是否已設定所有的必要資源，另請參閱<xref linkend="cha-ha-config-example"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      如果所有設定都正確，請使用 <command>commit</command> 提交變更，然後使用 <command>exit</command> 離開 crm 即時組態。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-ocfs2-quota">
+ </section>
+ <section xml:id="sec-ha-ocfs2-quota">
   <title>在 OCFS2 檔案系統上使用配額</title>
 
 
@@ -592,8 +596,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    出於效能的考量，每個叢集每隔 10 秒會在本地執行一次配額計算，並將此資訊同步至通用中央儲存。您可以使用 <command>tunefs.ocfs2</command>、選項 <option>usrquota-sync-interval</option> 和 <option>grpquota-sync-interval</option> 來調整此間隔。因此，配額資訊並非一直都是精確的，所以，當使用者或群組同時操作多個叢集節點時，可能會略微超出其配額限制。
   </para>
- </sect1>
- <sect1 id="sec-ha-ocfs2-more">
+ </section>
+ <section xml:id="sec-ha-ocfs2-more">
   <title>更多資訊</title>
 
   <para>
@@ -602,7 +606,7 @@ Please see LICENSE.txt for this document's license.
 
   <variablelist>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </term>
     <listitem>
      <para>
@@ -611,7 +615,7 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><ulink url="http://oss.oracle.com/projects/ocfs2/documentation"/>
+    <term><link xlink:href="http://oss.oracle.com/projects/ocfs2/documentation"/>
     </term>
     <listitem>
      <para>
@@ -620,5 +624,5 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist><indexterm class="endofrange" startref="idx-filesystems-ocfs2"/>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_rear.xml
+++ b/zh_TW/xml/ha_rear.xml
@@ -1,26 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_rear.xml" id="cha-ha-rear">
- <title>使用 Rear 進行災難備援</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_rear.xml" xml:id="cha-ha-rear"><title>使用 Rear 進行災難備援</title><info><abstract>
   <para> Relax-and-Recover (以前稱為 <quote>ReaR</quote>，本章中縮寫為 Rear) 是由系統管理員使用的災難備援架構。Rear 是一個 Bash 程序檔集合，您需要依據要在發生災難時加以保護的特定線上環境調整這些程序檔。</para>
   <para>沒有任何災難備援解決方案能夠現成地解決問題。因此，必須在任何災難發生<emphasis>之前</emphasis>做好準備。 </para>
   
- </abstract>
+ </abstract></info>
  
-  <sect1 id="sec-ha-rear-concept">
+ 
+ 
+  <section xml:id="sec-ha-rear-concept">
   <title>概念綜覽</title>
   
  
   <para>以下幾節介紹了一般性的災難備援概念，以及您要使用 Rear 成功復原所需執行的基本步驟。此外，還提供了一些關於 Rear 要求、目前產品隨附的 Rear 版本、要注意的一些限制、案例和備份工具的指導。</para>
    
    
-   <sect2 id="sec-ha-rear-concept-drp">
+   <section xml:id="sec-ha-rear-concept-drp">
     <title>建立災難備援計畫</title>
     
     <para>
@@ -59,21 +63,21 @@ Please see LICENSE.txt for this document's license.
       </formalpara>
      </listitem>
     </itemizedlist>
-   </sect2>
+   </section>
   
-  <sect2 id="sec-ha-rear-concept-recovery">
+  <section xml:id="sec-ha-rear-concept-recovery">
    <title>災難備援意味著什麼？</title>
    <para>如果線上環境中的某個系統已經損毀 (可能出於任何原因，例如，硬體損壞、組態不當或軟體問題)，您需要重新建立該系統。可以在相同的硬體或者相容的替代硬體上重新建立。重新建立系統並不只是意味著從備份中還原檔案，還包括準備系統的儲存區 (與檔案系統、分割區或掛接點相關)，以及重新安裝開機載入程式。</para>
-  </sect2>
+  </section>
    
-  <sect2 id="sec-ha-rear-concept-basics">
+  <section xml:id="sec-ha-rear-concept-basics">
    <title>災難備援如何與 Rear 一起運作？</title>
    <para>在系統正常運作時建立檔案的備份，並在復原媒體上建立復原系統。該復原系統包含一個復原安裝程式。</para>
    <para>當系統已經損毀時，您可以更換受損的硬體 (如果需要)，將復原系統從復原媒體開機，然後啟動復原安裝程式。復原安裝程式會重新建立系統：首先，它會準備儲存區 (分割區、檔案系統、掛接點)，然後從備份中還原檔案。最後，它會重新安裝開機載入程式。 </para>
-  </sect2>
+  </section>
    
    
-  <sect2 id="sec-ha-rear-concept-requirements">
+  <section xml:id="sec-ha-rear-concept-requirements">
    <title>Rear 要求</title>
    <para>
     若要使用 Rear，您至少需要兩個相同的系統：用來執行線上環境的機器，以及相同的測試機器。這裡所指的<quote>相同</quote>，舉例而言就是使用相同核心驅動程式的網路卡，可以用其中一個來取代另一個。 </para>
@@ -81,14 +85,14 @@ Please see LICENSE.txt for this document's license.
     <title>需要相同的驅動程式</title>
     <para>如果某個硬體元件使用的驅動程式不同於線上環境中所用的驅動程式，則 Rear 不會將該元件視為相同。</para>
    </warning>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-versions">
+  <section xml:id="sec-ha-rear-concept-versions">
    <title>Rear 版本</title>
    <para><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP4 隨附了兩個 Rear 版本：</para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
-     <para>Rear 版本 <literal>1.10.0</literal> (包含在 RPM 套件 <systemitem class="resource">rear</systemitem> 中)。如需此 Rear 版本的文件，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。</para>
+     <para>Rear 版本 <literal>1.10.0</literal> (包含在 RPM 套件 <systemitem class="resource">rear</systemitem> 中)。如需此 Rear 版本的文件，請參閱《<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 11 SP3 高可用性指南》。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。</para>
     </listitem>
     <listitem>
      <para>Rear 版本 <literal>1.16</literal> (包含在 RPM 套件 <systemitem class="resource">rear116</systemitem> 中)。本章將會介紹此版本。 </para>
@@ -99,9 +103,9 @@ Please see LICENSE.txt for this document's license.
     <para>但是，如果 Rear 版本 1.10.0 不能滿足您的特定需求 (另請參閱<xref linkend="sec-ha-rear-concept-limit" xrefstyle="select:label"/>)，您可以手動升級到 Rear 版本 1.16。<systemitem class="resource">rear</systemitem> 和 <systemitem class="resource">rear116</systemitem> 套件被有意設定為相互衝突，以防止另一個版本意外地取代所安裝的版本。</para>
     <para>每次升級 Rear 版本時，都必須仔細重新驗證您的特定災難備援程序是否仍然發揮作用。</para>
    </important>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-limit">
+  <section xml:id="sec-ha-rear-concept-limit">
    <title>針對 Btrfs 的限制</title>
     <para>如果您使用 Btrfs，會存在以下限制。</para>
    
@@ -124,17 +128,17 @@ Please see LICENSE.txt for this document's license.
       </listitem>
      </varlistentry>
     </variablelist>
-  </sect2>
+  </section>
   
-  <sect2 id="sec-ha-rear-concept-scenarios">
+  <section xml:id="sec-ha-rear-concept-scenarios">
    <title>案例和備份工具</title>
    <para>Rear 能夠建立可從本地媒體 (例如硬碟、隨身碟、DVD/CD-R) 或透過 PXE 開機的災難備援系統 (包括一個特定的復原安裝程式)。可以依照<xref linkend="ex-ha-rear-nfs-server-backup" xrefstyle="select:label"/>所述，將備份資料儲存在網路檔案系統 (例如 NFS) 中。
     </para>
    <para>Rear 不會取代檔案備份，而是對其進行補充。依預設，Rear 支援一般 <command>tar</command> 指令和多種協力廠商備份工具 (例如 Tivoli Storage Manager、QNetix Galaxy、Symantec NetBackup、EMC NetWorker 或 HP DataProtector)。如需將 Rear 與 EMC NetWorker (用做備份工具) 一起使用的範例組態，請參閱<xref linkend="ex-ha-rear-config-EMC" xrefstyle="select:label"/>。</para>
-  </sect2>
+  </section>
   
   
-  <sect2 id="sec-ha-rear-concept-overview">
+  <section xml:id="sec-ha-rear-concept-overview">
    <title>基本步驟</title>
    <para>若要在發生災難時使用 Rear 成功復原，需要執行以下基本步驟： </para>
 
@@ -166,10 +170,10 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
- </sect1>
+  </section>
+ </section>
   
- <sect1 id="sec-ha-rear-config">
+ <section xml:id="sec-ha-rear-config">
   <title>設定 Rear 和您的備份解決方案</title>
   <para>若要設定 Rear，您至少需要編輯 Rear 組態檔案 <filename>/etc/rear/local.conf</filename>，此外可以根據需要編輯屬於 Rear 架構一部分的 Bash 程序檔。 </para>
   <para>具體而言，您需要定義 Rear 應執行的以下任務：</para>
@@ -200,27 +204,27 @@ Please see LICENSE.txt for this document's license.
   <para>變更 Rear 組態檔案後，執行以下指令並檢查該指令的輸出：</para>
    <screen>rear dump</screen>
   
-  <example id="ex-ha-rear-nfs-server-backup">
+  <example xml:id="ex-ha-rear-nfs-server-backup">
    <title>使用 NFS 伺服器儲存檔案備份</title>
    <para>Rear 可以在多種不同的情況下使用。以下範例使用 NFS 伺服器做為檔案備份的儲存區。
    </para>
   </example>
   
   <procedure>
-     <step performance="required">
-    <para>依照《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 管理指南》的「<citetitle>使用 NFS 共享檔案系統</citetitle>」一章所述，使用 YaST 設定 NFS 伺服器。此文件位於 <ulink url="http://www.suse.com/documentation/"/>。 </para>
+     <step>
+    <para>依照《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> 管理指南》的「<citetitle>使用 NFS 共享檔案系統</citetitle>」一章所述，使用 YaST 設定 NFS 伺服器。此文件位於 <link xlink:href="http://www.suse.com/documentation/"/>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>在 <filename>/etc/exports</filename> 檔案中定義 NFS 伺服器的組態。確定 NFS 伺服器上的目錄 (要儲存備份資料的位置) 具有適當的掛接選項。例如：</para>
      <screen><replaceable>/srv/nfs</replaceable> *(fsid=0,crossmnt,rw,no_root_squash,sync,no_subtree_check)</screen>
     <para>如果需要，請用 NFS 伺服器上的備份資料路徑取代 <filename>/srv/nfs</filename>，並調整掛接選項。您可能需要使用 <literal>no_root_squash</literal> 來存取備份資料，因為 <command>rear mkbackup</command> 指令是以 <systemitem class="username">root</systemitem> 身分執行。</para>
    </step>
-   <step performance="required">
+   <step>
     <para> 調整各個 <varname>BACKUP</varname> 參數 (在組態檔案 <filename>/etc/rear/local.conf</filename> 中)，以便 Rear 將檔案備份儲存在相應的 NFS 伺服器上。所安裝系統中的 <filename>/usr/share/rear/conf/SLE11-ext3-example.conf</filename> 下提供了範例。 </para>
     </step>
   </procedure>
   
-  <example id="ex-ha-rear-config-EMC">
+  <example xml:id="ex-ha-rear-config-EMC">
    <title>使用 EMC NetWorker 等協力廠商備份工具</title>
    <para> 若要使用協力廠商備份工具代替 <command>tar</command>，您需要在 Rear 組態檔案中進行相應的設定。</para>
    <para>以下是 EMC NetWorker 的範例組態。將此組態片段新增至 <filename>/etc/rear/local.conf</filename> 中，並依據您的設定調整該片段：</para>
@@ -232,9 +236,9 @@ Please see LICENSE.txt for this document's license.
     RETENTION_TIME="Month"</screen>
   </example>
   
- </sect1>
+ </section>
 
- <sect1 id="sec-ha-rear-mkbackup">
+ <section xml:id="sec-ha-rear-mkbackup">
  <title>建立復原安裝系統</title>
   <para>依照<xref linkend="sec-ha-rear-config" xrefstyle="select:label"/>所述設定 Rear 後，使用以下指令建立復原安裝系統 (包括 Rear 復原安裝程式) 和檔案備份：</para>
   <screen>rear -d  -D mkbackup</screen> 
@@ -256,9 +260,9 @@ Please see LICENSE.txt for this document's license.
   </listitem>
   
  </orderedlist>
-</sect1>
+</section>
  
- <sect1 id="sec-ha-rear-testing">
+ <section xml:id="sec-ha-rear-testing">
   <title>測試復原程序</title>
 
   <para> 建立復原系統後，在具有相同硬體的測試機器上測試復原程序。並請參閱<xref linkend="sec-ha-rear-concept-requirements"/>。確定測試機器的設定正確，並且可以取代您的主要機器運作。
@@ -269,37 +273,37 @@ Please see LICENSE.txt for this document's license.
    <para>必須在機器上全面測試災難備援程序。請定期測試復原程序，以確定一切如預期運作。 </para>
   </warning>
 
-  <procedure id="pro-ha-rear-testing">
+  <procedure xml:id="pro-ha-rear-testing">
    <title>在測試機器上執行災難備援</title>
-   <step performance="required">
+   <step>
     <para>將您在<xref linkend="sec-ha-rear-mkbackup" xrefstyle="select:label"/>中建立的復原系統燒錄到 DVD 或 CD 上，以建立復原媒體。或者，您可以透過 PXE 使用網路開機。</para>
    </step>
-   <step performance="required">
+   <step>
     <para>從復原媒體將測試機器開機。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 從功能表中，選取<guimenu>復原</guimenu>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 以 <systemitem class="username">root</systemitem> 的身分登入 (不需要密碼)。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para> 輸入以下指令來啟動復原安裝程式：</para>
     <screen>rear -d -D recover</screen>
     <para>如需 Rear 在此過程中執行之步驟的詳細資料，請參閱<xref linkend="ol-ha-rear-recovers-steps"/>。 </para>
    </step>
-   <step performance="required">
+   <step>
     <para>完成復原程序後，檢查是否已成功地重新建立系統，並且該系統是否可在線上環境中取代原始系統。</para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-rear-recover">
+ </section>
+ <section xml:id="sec-ha-rear-recover">
   <title>從災難中復原</title>
   <para>如果發生災難，請視需要更換任何受損的硬體。然後依照<xref linkend="pro-ha-rear-testing" xrefstyle="select:label"/>所述，使用已修復的機器 (或使用已經測試並可取代原始系統運作的相同機器) 繼續操作。</para>
   
 <para><command>rear recover</command> 指令將執行以下步驟：</para>  
   
-  <orderedlist id="ol-ha-rear-recovers-steps" spacing="normal">
+  <orderedlist xml:id="ol-ha-rear-recovers-steps" spacing="normal">
    <title>復原程序</title>
    <listitem>
    <para>
@@ -317,10 +321,10 @@ Please see LICENSE.txt for this document's license.
    </para>
    </listitem>
    </orderedlist>
-  </sect1>
+  </section>
  
   
- <sect1 id="sec-ha-rear-more">
+ <section xml:id="sec-ha-rear-more">
   <title>更多資訊</title>
 
 
@@ -328,7 +332,7 @@ Please see LICENSE.txt for this document's license.
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://en.opensuse.org/SDB:Disaster_Recovery"/>
+     <link xlink:href="http://en.opensuse.org/SDB:Disaster_Recovery"/>
     </para>
    </listitem>
    <listitem>
@@ -342,5 +346,5 @@ Please see LICENSE.txt for this document's license.
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_requirements.xml
+++ b/zh_TW/xml/ha_requirements.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_requirements.xml" id="cha-ha-requirements">
- <title>系統要求與建議</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_requirements.xml" xml:id="cha-ha-requirements"><?dbfo-need height="10em"?><title>系統要求與建議</title><info><abstract>
   <para>
    下面的小節介紹 <phrase role="productnamereg"><phrase os="sles">SUSE® Linux Enterprise High Availability Extension</phrase></phrase> 的系統要求和一些必要條件。此外，還提供了關於叢集設定的建議。
   </para>
- </abstract>
- <sect1 id="sec-ha-requirements-hw">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-requirements-hw">
   <title>硬體要求</title>
 
   <para>
@@ -40,11 +44,11 @@ Please see LICENSE.txt for this document's license.
     
    </listitem>
   </itemizedlist>
- </sect1>
-<?dbfo-need height="10em"?>
+ </section>
 
 
- <sect1 id="sec-ha-requirements-sw">
+
+ <section xml:id="sec-ha-requirements-sw">
   <title>軟體需求</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     <para>如果您要使用地理叢集，請確定所有將要加入叢集的節點上都安裝了 Geo Clustering for SUSE Linux Enterprise High Availability Extension <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> (包含所有可用的線上更新)。 </para>
    </listitem>
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-disk">
+ </section>
+ <section xml:id="sec-ha-requirements-disk">
   <title>儲存需求</title>
 
   <para> 為了確保資料的高可用性，我們建議您為叢集使用共享磁碟系統 (儲存區域網路，即 SAN)。如果使用共享磁碟子系統，請注意下列事項： </para>
@@ -97,12 +101,12 @@ Please see LICENSE.txt for this document's license.
    </listitem>
    
   </itemizedlist>
- </sect1>
- <sect1 id="sec-ha-requirements-other">
+ </section>
+ <section xml:id="sec-ha-requirements-other">
   <title>其他要求與建議</title>
   <para>為了實現受支援且有用的高可用性設定，請考慮以下建議：</para>
   <variablelist>
-   <varlistentry id="vle-ha-req-nodes">
+   <varlistentry xml:id="vle-ha-req-nodes">
     <term>叢集節點數</term>
     <listitem>
      <para>
@@ -115,7 +119,7 @@ Please see LICENSE.txt for this document's license.
      </important>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-stonith">
+   <varlistentry xml:id="vle-ha-req-stonith">
     <term>STONITH</term>
     <listitem>
      <important>
@@ -133,7 +137,7 @@ Please see LICENSE.txt for this document's license.
      </itemizedlist>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-communication">
+   <varlistentry xml:id="vle-ha-req-communication">
     <term>備援通訊路徑</term>
     <listitem>
      <para>為了實現受支援的高可用性設定，您需要透過兩個或更多個備援路徑建立叢集通訊。可以透過以下方式來實現︰ </para>
@@ -152,7 +156,7 @@ Please see LICENSE.txt for this document's license.
    <varlistentry>
     <term>時間同步</term>
     <listitem>
-     <para> 叢集節點應與叢集外的 NTP 伺服器同步。如需詳細資訊，請參閱 <ulink url="http://www.suse.com/doc/"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。詳情位於「<citetitle>使用 NTP 進行時間同步化</citetitle>」一章。 </para>
+     <para> 叢集節點應與叢集外的 NTP 伺服器同步。如需詳細資訊，請參閱 <link xlink:href="http://www.suse.com/doc/"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。詳情位於「<citetitle>使用 NTP 進行時間同步化</citetitle>」一章。 </para>
      <para> 如果節點未同步化，將很難分析記錄檔案和叢集報告。 </para>
     </listitem>
    </varlistentry>
@@ -174,18 +178,18 @@ Please see LICENSE.txt for this document's license.
        <para> 在此檔案中以完全合格的主機名稱和簡短主機名稱列出所有叢集節點。叢集的成員必須能夠籍由名稱找到彼此，這是一項基本要求。如果名稱不可用，內部叢集通訊將會失敗。 </para>
       </listitem>
      </itemizedlist>
-     <para> 如需詳細資訊，請參閱 <ulink url="http://www.suse.com/doc"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。請參閱「<citetitle>基本網路</citetitle>」一章中的「<citetitle>使用 YaST 設定網路連接</citetitle>」&gt;「<citetitle>設定主機名稱和 DNS</citetitle>」小節。 </para>
+     <para> 如需詳細資訊，請參閱 <link xlink:href="http://www.suse.com/doc"/> 上的《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">11 SP4</phrase></phrase> <citetitle>管理指南</citetitle>》。請參閱「<citetitle>基本網路</citetitle>」一章中的「<citetitle>使用 YaST 設定網路連接</citetitle>」&gt;「<citetitle>設定主機名稱和 DNS</citetitle>」小節。 </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-storage">
+   <varlistentry xml:id="vle-ha-req-storage">
     <term>儲存需求</term>
     <listitem>
      
      <para>有些服務可能需要使用共享儲存。有關相應要求，請參閱<xref linkend="sec-ha-requirements-disk"/>。您也可以使用外部 NFS 共享或 DRBD。如果使用外部 NFS 共享，必須能夠從所有叢集節點透過備援通訊路徑可靠地存取該共享。請參閱<xref linkend="vle-ha-req-communication"/>。 </para>
-     <para>如果使用 SBD 做為 STONITH 裝置，則共享儲存還需要滿足其他要求。如需詳細資料，請參閱 <ulink url="http://linux-ha.org/wiki/SBD_Fencing"/> 上的「<citetitle>Requirements</citetitle>」(要求) 部分。</para>
+     <para>如果使用 SBD 做為 STONITH 裝置，則共享儲存還需要滿足其他要求。如需詳細資料，請參閱 <link xlink:href="http://linux-ha.org/wiki/SBD_Fencing"/> 上的「<citetitle>Requirements</citetitle>」(要求) 部分。</para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-req-ssh">
+   <varlistentry xml:id="vle-ha-req-ssh">
     <term>SSH</term>
     <listitem>
      <para> 所有叢集節點必須能透過 SSH 互相存取。諸如 <command>hb_report</command> 或 <command>crm_report</command> (用於疑難排解) 等工具以及 Hawk 的<guimenu>歷程總管</guimenu>，要求節點之間透過無密碼的 SSH 方式來存取，否則它們只能從目前節點收集資料。如果您使用的是非標準 SSH 連接埠，請使用 <option>-X</option> 選項 (請參閱 man 頁面)。例如，如果 SSH 連接埠為 <literal>3479</literal>，請使用以下指令呼叫 <literal>hb_report</literal>：</para>
@@ -207,5 +211,5 @@ Please see LICENSE.txt for this document's license.
    </varlistentry>
 
   </variablelist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_samba.xml
+++ b/zh_TW/xml/ha_samba.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_samba.xml" id="cha-ha-samba">
- <title>Samba 叢集</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_samba.xml" xml:id="cha-ha-samba"><title>Samba 叢集</title><info><abstract>
   <para>
    叢集化 Samba 伺服器為您的異質網路提供了高可用性解決方案。本章介紹了一些背景知識並說明如何設定叢集化 Samba 伺服器。
   </para>
- </abstract>
- <sect1 id="sec-ha-samba-overview">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-samba-overview">
   <title>概念綜覽</title>
 
   <para>
@@ -37,7 +41,7 @@ Please see LICENSE.txt for this document's license.
    </para>
   </note>
 
-  <figure id="fig-ha-samba-overview">
+  <figure xml:id="fig-ha-samba-overview">
    <title>CTDB 叢集的結構</title>
    <mediaobject>
     <imageobject role="fo">
@@ -79,8 +83,8 @@ Please see LICENSE.txt for this document's license.
   <para>
    目的是讓擁有 N+1 個節點的叢集化 Samba 伺服器快於僅有 N 個節點的 Samba 伺服器。一個節點不會慢於一部未叢集化的 Samba 伺服器。
   </para>
- </sect1>
- <sect1 id="sec-ha-samba-basicconf">
+ </section>
+ <section xml:id="sec-ha-samba-basicconf">
   <title>基本組態</title>
   
   <note>
@@ -94,24 +98,24 @@ Please see LICENSE.txt for this document's license.
    若要設定叢集化的 Samba 伺服器，請執行下列步驟：
   </para>
 
-  <procedure id="pro-ha-samba-basicconf">
+  <procedure xml:id="pro-ha-samba-basicconf">
    <title>設定基本的叢集化 Samba 伺服器</title>
-   <step performance="required">
+   <step>
     <para>
      準備叢集：
     </para>
     <substeps performance="required">
-     <step performance="required">
+     <step>
       <para>
        依本指南<xref linkend="part-config"/> 所述設定叢集 (OpenAIS、Pacemaker、OCFS2)。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        設定共享檔案系統 (例如 OCFS2) 並予以掛接 (例如，掛接至 <filename>/shared</filename>)。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果想要開啟 POSIX ACL，則將其啟用：
       </para>
@@ -134,7 +138,7 @@ Please see LICENSE.txt for this document's license.
        </listitem>
       </itemizedlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        確定 <systemitem class="service">ctdb</systemitem>、<systemitem class="service">smb</systemitem>、<systemitem class="service">nmb</systemitem> 與 <systemitem class="service">winbind</systemitem> 服務已停用：
       </para>
@@ -145,20 +149,20 @@ Please see LICENSE.txt for this document's license.
      </step>
     </substeps>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在共享檔案系統上建立一個 CTDB 鎖定目錄：
     </para>
     <screen><prompt role="root">root # </prompt><command>mkdir</command> -p /shared/samba/</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在 <filename>/etc/ctdb/nodes</filename> 中插入包含叢集中每個節點之全部私人 IP 位址的所有節點：
     </para>
 <screen>192.168.1.10
 192.168.1.11</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      使用 <command>csync2</command> 將組態檔案複製到所有節點：
     </para>
@@ -169,7 +173,7 @@ Please see LICENSE.txt for this document's license.
    </step>
 
 
-   <step performance="required">
+   <step>
     <para>
      將 CTDB 資源新增至叢集：
     </para>
@@ -188,7 +192,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ctdb-after-fs inf: fs-clone ctdb-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      新增叢集化 IP 位址：
     </para>
@@ -199,7 +203,7 @@ Please see LICENSE.txt for this document's license.
 <prompt role="custom">crm(live)configure# </prompt><command>order</command> start-ip-after-ctdb inf: ctdb-clone ip-clone
 <prompt role="custom">crm(live)configure# </prompt><command>commit</command></screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      檢查結果：
     </para>
@@ -216,19 +220,19 @@ Clone Set: dlm-clone
      ip:0       (ocf::heartbeat:IPaddr2):       Started hex-13
      ip:1       (ocf::heartbeat:IPaddr2):       Started hex-14</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>從用戶端機器執行測試。在 Linux 用戶端上，新增一個用於存取 Samba 的使用者：
     </para>
     <screen><prompt role="root">root # </prompt><command>smbpasswd</command> <option>-a</option> <replaceable>USERNAME</replaceable></screen>
    </step>
-   <step performance="required"><para>測試您是否可以連接至該新使用者的主目錄：</para>
+   <step><para>測試您是否可以連接至該新使用者的主目錄：</para>
     <screen><prompt role="root">root # </prompt>smbclient -u <replaceable>USERNAME</replaceable>//192.168.2.222/<replaceable>USERNAME</replaceable></screen>
    </step>
 
 
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-ad">
+ </section>
+ <section xml:id="sec-ha-samba-ad">
   <title>加入 Active Directory 網域</title>
 
   
@@ -242,7 +246,7 @@ Clone Set: dlm-clone
   </para>
 
   <procedure>
-   <step performance="required">
+   <step>
     <para>
      查閱 Windows 伺服器文件，以獲取如何設定 Active Directory 網域的指示。在本範例中，我們使用了以下參數：
     </para>
@@ -284,12 +288,12 @@ Clone Set: dlm-clone
     </informaltable>
 
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-ctdb"/>
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      <xref linkend="pro-ha-samba-config-join-ad"/>
     </para>
@@ -300,20 +304,20 @@ Clone Set: dlm-clone
    下一步是設定 CTDB：
   </para>
 
-  <procedure id="pro-ha-samba-config-ctdb">
+  <procedure xml:id="pro-ha-samba-config-ctdb">
    <title>設定 CTDB</title>
-   <step performance="required">
+   <step>
     <para>
      確定已依<xref linkend="sec-ha-samba-basicconf"/> 中所示設定了叢集。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在一個節點上停止 CTDB 資源：
     </para>
 <screen><prompt role="root">root # </prompt> crm resource stop ctdb-clone</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      開啟 <filename>/etc/samba/smb.conf</filename> 組態檔案，新增 NetBIOS 名稱，然後關閉該檔案：
     </para>
@@ -323,13 +327,13 @@ Clone Set: dlm-clone
      其他設定，例如安全性、工作群組等透過 YaST 精靈新增。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在所有節點上更新檔案 <filename>/etc/samba.conf</filename>：
     </para>
 <screen><prompt role="root">root # </prompt>csync2 -xv</screen>
    </step>
-   <step performance="required">
+   <step>
     <para>
      重新啟動 CTDB 資源：
     </para>
@@ -341,9 +345,9 @@ Clone Set: dlm-clone
    最後，將您的叢集加入 Active Directory 伺服器：
   </para>
 
-  <procedure id="pro-ha-samba-config-join-ad">
+  <procedure xml:id="pro-ha-samba-config-join-ad">
    <title>加入 Active Directory</title>
-   <step performance="required">
+   <step>
     <para>
      確定下列檔案包含在要在所有叢集主機上安裝的 Csync2 組態中。
     </para>
@@ -357,24 +361,24 @@ Clone Set: dlm-clone
      您也可以使用 YaST 的<guimenu>設定 Csync2</guimenu>模組來完成此任務，請參閱<xref linkend="sec-ha-installation-setup-csync2"/>。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      依<xref linkend="pro-ha-samba-basicconf"/> 所述建立 CTDB 資源。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      執行 YaST 並從<guimenu>網路服務</guimenu>項目中開啟<guimenu>Windows 網域成員</guimenu>模組。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      輸入網域或工作群組設定，然後按一下<guimenu>確定</guimenu>完成操作。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-testing">
+ </section>
+ <section xml:id="sec-ha-samba-testing">
   <title>對叢集化 Samba 進行除錯與測試</title>
 
   <para>
@@ -416,7 +420,7 @@ Clone Set: dlm-clone
     </term>
     <listitem>
      <para>
-      使用 <command>ping_pong</command> 可以檢查您的檔案系統是否適用 CTDB。它會對叢集檔案系統執行某些測試，例如連貫性和效能測試 (請參閱 <ulink url="http://wiki.samba.org/index.php/Ping_pong"/>)，讓您瞭解叢集在高負載下的表現。
+      使用 <command>ping_pong</command> 可以檢查您的檔案系統是否適用 CTDB。它會對叢集檔案系統執行某些測試，例如連貫性和效能測試 (請參閱 <link xlink:href="http://wiki.samba.org/index.php/Ping_pong"/>)，讓您瞭解叢集在高負載下的表現。
      </para>
     </listitem>
    </varlistentry>
@@ -428,7 +432,7 @@ Clone Set: dlm-clone
       <systemitem class="resource">SendArp</systemitem> 資源代辦位於 <filename>/usr/lib/heartbeat/send_arp</filename> (或 <filename>/usr/lib64/heartbeat/send_arp</filename>)。<command>send_arp</command> 工具會送出無故 ARP (位址解析通訊協定) 封包，可以用來更新其他機器的 ARP 表。這有助於確認容錯移轉程序完成後的通訊問題。如果節點對 samba 顯示了叢集 IP 位址，而您卻無法連接到此節點或 ping 通此節點，請使用 <command>send_arp</command> 指令測試節點是否只需要 ARP 表更新。
      </para>
      <para>
-      如需詳細資訊，請參閱<ulink url="http://wiki.wireshark.org/Gratuitous_ARP"/>。
+      如需詳細資訊，請參閱<link xlink:href="http://wiki.wireshark.org/Gratuitous_ARP"/>。
      </para>
     </listitem>
    </varlistentry>
@@ -440,7 +444,7 @@ Clone Set: dlm-clone
 
   <procedure>
    <title>測試叢集檔案系統的連貫性和效能</title>
-   <step performance="required">
+   <step>
     <para>
      在一個節點上啟動指令 <command>ping_pong</command> 並將預留位址 <replaceable>N</replaceable> 取代為節點數量加 1。該檔案存放於 <filename><replaceable>ABSPATH</replaceable>/data.txt</filename> 共享儲存，因此從任何節點上都可存取 (<replaceable>ABSPATH </replaceable> 表示絕對路徑)：
     </para>
@@ -449,7 +453,7 @@ Clone Set: dlm-clone
      僅執行一個節點時，鎖定率應該會很高。如果程式未顯示鎖定率，請更換您的叢集檔案系統。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      在另一個節點上啟動第二個 <command>ping_pong</command>，並使用相同的參數。
     </para>
@@ -474,42 +478,42 @@ Clone Set: dlm-clone
      </listitem>
     </itemizedlist>
    </step>
-   <step performance="required">
+   <step>
     <para>
      啟動第三個 <command>ping_pong</command>。新增其他節點並注意鎖定率的變化。
     </para>
    </step>
-   <step performance="required">
+   <step>
     <para>
      逐個停止 <command>ping_pong</command> 指令。在回到單一節點的情況之前，應會看到鎖定率不斷提高。如果未發生預期的情況，請參閱<xref linkend="cha-ha-ocfs2"/> 中的詳細資訊。
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 id="sec-ha-samba-moreinfo">
+ </section>
+ <section xml:id="sec-ha-samba-moreinfo">
   <title>更多資訊</title>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <ulink url="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
+     <link xlink:href="http://linux-ha.org/wiki/CTDB_(resource_agent)"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/CTDB_Setup"/>
+     <link xlink:href="http://wiki.samba.org/index.php/CTDB_Setup"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://ctdb.samba.org"/>
+     <link xlink:href="http://ctdb.samba.org"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <ulink url="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
+     <link xlink:href="http://wiki.samba.org/index.php/Samba_%26_Clustering"/>
     </para>
    </listitem>
   </itemizedlist>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_storage_protection.xml
+++ b/zh_TW/xml/ha_storage_protection.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_storage_protection.xml" id="cha-ha-storage-protect">
- <title>儲存保護</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_storage_protection.xml" xml:id="cha-ha-storage-protect"><title>儲存保護</title><info><abstract>
 
   <para>
    高可用性叢集堆疊的首要任務是保護資料的完整性。具體是透過防止在未經協調的情況下同時存取資料儲存來實現此目標。舉例來說，叢集中只會掛接一次 Ext3 檔案系統，以及只有在與其他叢集節點協調後才會掛接 OCFS2 磁碟區。在正常運作的叢集中，如果使用中的資源超出其同步限制，Pacemaker 會偵測到此情況，並啟動復原操作。而且，其規則引擎永遠不會超出這些限制。
@@ -24,15 +26,17 @@ Please see LICENSE.txt for this document's license.
   <para>
    本章先介紹可充分利用自身儲存的 IO 圍籬區隔機制，然後介紹為確保獨佔式儲存存取而增設的保護層。這兩項機制聯合可實現更高級別的保護。
   </para>
- </abstract>
- <sect1 id="sec-ha-storage-protect-fencing">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-storage-protect-fencing">
   <title>基於儲存的圍籬區隔</title>
 
   <para>
    使用一或多個 STONITH 區塊裝置 (SBD)、<literal>監視程式</literal>支援和 <literal>external/sbd</literal> STONITH 代辦，可以有效地避免出現電腦分裂的情況。
   </para>
 
-  <sect2 id="sec-ha-storage-protect-fencing-oview">
+  <section xml:id="sec-ha-storage-protect-fencing-oview">
    <title>綜覽</title>
    <para>
     如果一個環境中的所有節點都可以存取共享儲存，系統會格式化裝置的一小塊分割區用於 SBD。該分割區的大小取決於所用磁碟的區塊大小 (對於區塊大小為 512 位元組的標準 SCSI 磁碟，該分割區大小為 1 MB；區塊大小為 4 KB 的 DASD 磁碟需要 4 MB)。設定各自的精靈之後，系統會連接每個節點上 SBD，然後啟動其餘的叢集堆疊。當其他所有叢集元件都關閉後，SBD 才會終止，這樣便確保了只要叢集資源啟動，SBD 就會加以監督。
@@ -49,11 +53,11 @@ Please see LICENSE.txt for this document's license.
    <para>
     如果已啟動 Pacemaker 整合，則在大部分裝置的連接已中斷的情況下，SBD 將不會自我圍籬區隔。例如，假定您的叢集包含 3 個節點：A、B 和 C。由於網路分隔，A 只能看到它自己，而 B 和 C 之間仍然能夠通訊。此時就有兩個叢集分割區，一個由於節點占多數 (B 和 C) 而達到最低節點數，另一個 (A) 則未達到。如果在大部分圍籬區隔裝置無法連接時發生這種情況，節點 A 將立即確認終止，但是節點 B 和 C 將繼續執行。
    </para>
-  </sect2>
+  </section>
 
 
 
-  <sect2 id="sec-ha-storage-protect-fencing-number">
+  <section xml:id="sec-ha-storage-protect-fencing-number">
    <title>SBD 裝置數量</title>
    <para>
     SBD 支援使用 1-3 個裝置：
@@ -87,35 +91,35 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-fencing-setup">
+  <section xml:id="sec-ha-storageprotection-fencing-setup">
    <title>設定基於儲存的保護</title>
    <para>
     設定基於儲存的保護時必須執行下列步驟︰
    </para>
    <procedure>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-create" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-watchdog" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-daemon" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-sbd-test" xrefstyle="select:title"/>
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       <xref linkend="pro-ha-storage-protect-fencing" xrefstyle="select:title"/>
      </para>
@@ -145,7 +149,7 @@ Please see LICENSE.txt for this document's license.
      </listitem>
     </itemizedlist>
    </important>
-   <sect3 id="pro-ha-storage-protect-sbd-create">
+   <section xml:id="pro-ha-storage-protect-sbd-create">
     <title>建立 SBD 分割區</title>
     <para>
      建議在裝置啟動時建立 1MB 的分割區。如果 SBD 裝置位於多重路徑群組中，MPIO 的向下路徑偵測可能會導致一定程度的延遲，因此需要調整 SBD 使用的逾時。達到 <literal>msgwait</literal> 逾時後，系統會認為訊息已傳送到節點。對多重路徑而言，這一時間也就是 MPIO 偵測到路徑故障並切換到下一個路徑所需的時間。您可能需要在自己的環境中對此進行測試。如果節點上執行的 SBD 精靈更新監視程式計時器的速度不夠快，此節點將自行終止。請在特定的環境中測試所選逾時。如果只對一個 SBD 裝置使用多路徑儲存，請密切關注發生的容錯移轉延遲。
@@ -163,7 +167,7 @@ Please see LICENSE.txt for this document's license.
      </para>
     </important>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        使用下列指令啟始化 SBD 裝置︰
       </para>
@@ -176,12 +180,12 @@ Please see LICENSE.txt for this document's license.
       </para>
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD1</replaceable> -d /dev/<replaceable>SBD2</replaceable> -d /dev/<replaceable>SBD3</replaceable> create</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        如果 SBD 裝置位於多重路徑群組中，則調整 SBD 使用的逾時。逾時可以在啟始化 SBD 裝置時指定 (所有逾時均以秒計)︰
       </para>
 
-<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co id="co-msgwait"/> -1 90<co id="co-watchdog"/> create</screen>
+<screen><prompt role="root">root # </prompt><command>/usr/sbin/sbd</command> -d /dev/<replaceable>SBD</replaceable> -4 180<co xml:id="co-msgwait"/> -1 90<co xml:id="co-watchdog"/> create</screen>
       <calloutlist>
        <callout arearefs="co-msgwait">
         <para>
@@ -195,7 +199,7 @@ Please see LICENSE.txt for this document's license.
        </callout>
       </calloutlist>
      </step>
-     <step performance="required">
+     <step>
       <para>
        使用下列指令查看寫入裝置的內容︰
       </para>
@@ -212,8 +216,8 @@ Timeout (msgwait)  : 10</screen>
     <para>
      如您所見，逾時也會存入標頭，以確保所有參與的節點在逾時上達成一致。
     </para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-watchdog">
+   </section>
+   <section xml:id="pro-ha-storage-protect-watchdog">
     <title>設定軟體監視程式</title>
     <para>在未由其他軟體使用的情況下，監視程式可以在發生 SBD 失敗時保護系統。</para>
      
@@ -222,7 +226,7 @@ Timeout (msgwait)  : 10</screen>
      </important>
      
      <para>
-     依預設，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 的核心中會啟用監視程式支援：本產品隨附了多個不同的核心模組，可提供特定於硬體的監視程式驅動程式。High Availability Extension 使用 SBD 精靈做為給監視程式<quote>餵食</quote>的軟體元件。如果已依<xref linkend="pro-ha-storage-protect-sbd-daemon"/> 所述進行設定，SBD 精靈會在您使用 <command>rcopenais <option>start</option></command> 將相應的節點上線時自動啟動。
+     依預設，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise High Availability Extension</phrase></phrase> 的核心中會啟用監視程式支援：本產品隨附了多個不同的核心模組，可提供特定於硬體的監視程式驅動程式。High Availability Extension 使用 SBD 精靈做為給監視程式<quote>餵食</quote>的軟體元件。如果已依<xref linkend="pro-ha-storage-protect-sbd-daemon"/> 所述進行設定，SBD 精靈會在您使用 <command>rcopenais</command> <option>start</option> 將相應的節點上線時自動啟動。
     </para>
     <para>
      通常，適當的硬體監視程式驅動程式會在系統開機時自動載入。<literal>softdog</literal> 是最常見的驅動程式，不過建議您使用實際硬體中整合的驅動程式。例如︰
@@ -252,7 +256,7 @@ Timeout (msgwait)  : 10</screen>
      <para>以下<quote>公式</quote>大致表達了這三個值之間的關係：
     </para>
      
-     <example id="ex-ha-storage-protect-sbd-timings">
+     <example xml:id="ex-ha-storage-protect-sbd-timings">
        <title>使用 SBD 做為 STONITH 裝置的叢集計時</title>
        <screen>Timeout (msgwait) = (Timeout (watchdog) * 2)
 stonith-timeout = Timeout (msgwait) + 20%</screen>
@@ -273,15 +277,15 @@ Timeout (loop)     : 1
 Timeout (msgwait)  : 40
 ==Header on disk /dev/sdb is dumped</screen>
      <para>如果您要設定新叢集，<command>sleha-init</command> 指令會將上述因素納入考量。</para>
-    <para>如需 SBD 相關計時變數的詳細資料，請參閱 <ulink url="https://www.suse.com/support/kb/doc.php?id=7011346"/> 上的《<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>》(HAE 叢集的 SBD 操作準則)。</para>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-daemon">
+    <para>如需 SBD 相關計時變數的詳細資料，請參閱 <link xlink:href="https://www.suse.com/support/kb/doc.php?id=7011346"/> 上的《<citetitle>SBD Operation Guidelines for HAE Clusters</citetitle>》(HAE 叢集的 SBD 操作準則)。</para>
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-daemon">
     <title>啟動 SBD 精靈</title>
     <para>
      SBD 精靈是叢集堆疊的重要組成部分。只要叢集堆疊正在執行，SBD 精靈就必須執行，即使叢集堆疊的一部分損毀時也是如此，這樣才能圍籬區隔節點。
     </para>
     <procedure>
-        <step performance="required">
+        <step>
        <para>執行 <command>sleha-init</command>。此程序檔可確保正確設定 SBD，並將組態檔案 <filename>/etc/sysconfig/sbd</filename> 新增至需要與 Csync2 同步化的檔案清單。 </para>
        <para>若要手動設定 SBD，請執行以下步驟：</para>
             <para> 若要啟動 OpenAIS init 程序檔和停止 SBD，請編輯 <filename>/etc/sysconfig/sbd</filename> 檔案，搜尋下面一行，搜尋時用您的 SBD 裝置取代 <replaceable>SBD</replaceable>： </para>
@@ -299,17 +303,17 @@ Timeout (msgwait)  : 40
        </para>
       </note>
      </step>     
-     <step performance="required">
+     <step>
       <para>
-       繼續下一步之前，先執行 <command>rcopenais <option>restart</option></command> 來確保所有節點上都已啟動 SBD。
+       繼續下一步之前，先執行 <command>rcopenais</command> <option>restart</option> 來確保所有節點上都已啟動 SBD。
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-sbd-test">
+   </section>
+   <section xml:id="pro-ha-storage-protect-sbd-test">
     <title>測試 SBD</title>
     <procedure>
-     <step performance="required">
+     <step>
       <para>
        下列指令會從 SBD 裝置傾印節點插槽及其目前的訊息︰
       </para>
@@ -318,14 +322,14 @@ Timeout (msgwait)  : 40
        現在您會看到，此處列出 SBD 的所有叢集節點均已啟動，訊息槽應顯示<literal>清除</literal>。
       </para>
      </step>
-     <step performance="required">
+     <step>
       <para>
        嘗試向其中一個節點傳送一則測試訊息︰
       </para>
       
 <screen><prompt role="root">root # </prompt><command>sbd</command> -d /dev/<replaceable>SBD</replaceable> message alice test</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        節點會在系統記錄檔案中確認收到訊息︰
       </para>
@@ -335,8 +339,8 @@ Timeout (msgwait)  : 40
       </para>
      </step>
     </procedure>
-   </sect3>
-   <sect3 id="pro-ha-storage-protect-fencing">
+   </section>
+   <section xml:id="pro-ha-storage-protect-fencing">
     <title>設定圍籬區隔資源</title>
     <para>
      若要完成 SBD 設定，請將 SBD 設定為 CIB 中的 STONITH/圍籬區隔機制。
@@ -347,16 +351,16 @@ Timeout (msgwait)  : 40
      <para>在雙節點叢集 (及 <literal>no-quorum-policy</literal> 設定為 <literal>ignore</literal> 的其他叢集) 中，經常會發生不合時宜的圍籬區隔，因為這兩個節點會在發生電腦分裂時相互圍籬區隔。若要避免這種雙重圍籬區隔，請將 <literal>pcmk_delay_max</literal> 參數新增至 STONITH 資源的組態中。如此，網路卡正常運作的伺服器就更有機會得以留存。</para>
     </tip>
     <procedure>
-     <step performance="required">
+     <step>
       <para>登入某個節點，然後使用 <command>crm configure</command> 啟動互動式 crmsh。</para>
      </step>
-     <step performance="required">
+     <step>
       <para>輸入以下內容：</para>
       
       <screen><prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-enabled="true"
-<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co id="co-ha-sbd-stonith-timeout"/>
+<prompt role="custom">crm(live)configure# </prompt><command>property</command> stonith-timeout="40s" <co xml:id="co-ha-sbd-stonith-timeout"/>
 <prompt role="custom">crm(live)configure# </prompt><command>primitive</command> stonith_sbd stonith:external/sbd \
-   pcmk_delay_max="30" <co id="co-ha-sbd-pcmk-delay-max"/></screen>
+   pcmk_delay_max="30" <co xml:id="co-ha-sbd-pcmk-delay-max"/></screen>
       <para> 不需要複製資源。由於系統會自動配置節點插槽，因此不需要手動定義主機清單。 </para>
       <calloutlist>
        <callout arearefs="co-ha-sbd-stonith-timeout">
@@ -369,11 +373,11 @@ Timeout (msgwait)  : 40
        </callout>
       </calloutlist>
       </step>
-     <step performance="required">
+     <step>
       <para> 提交變更： </para>
       <screen><prompt role="custom">crm(live)# </prompt><command>configure</command> commit</screen>
      </step>
-     <step performance="required">
+     <step>
       <para>
        因為現在透過 SBD 機制來實現圍籬區隔功能，所以請停用先前設定過的其他所有圍籬區隔裝置。
       </para>
@@ -382,16 +386,16 @@ Timeout (msgwait)  : 40
     <para>
      資源啟動後，叢集的共享儲存圍籬區隔組態即已成功設定，叢集將在需要對節點進行圍籬區隔時使用此方法。
     </para>
-   </sect3>
-   <sect3>
+   </section>
+   <section>
     <title>更多資訊</title>
     <para>
-     <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/>
+     <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/>
     </para>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storageprotection-exstoract">
+   </section>
+  </section>
+ </section>
+ <section xml:id="sec-ha-storageprotection-exstoract">
   <title>確保啟動獨佔性儲存</title>
 
   <para>
@@ -402,7 +406,7 @@ Timeout (msgwait)  : 40
    由於內在設計的原因，sfex 無法用於要求同時操作的工作負載 (如 OCFS2)，但可用做傳統容錯移轉式工作負載的保護層。其效果與保留 SCSI-2 類似，但更加常用。
   </para>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-description">
+  <section xml:id="sec-ha-storageprotection-exstoract-description">
    <title>綜覽</title>
    <para>
     在共享儲存環境中，會額外設定一個小分割區，用於儲存一或多個鎖定。
@@ -413,9 +417,9 @@ Timeout (msgwait)  : 40
    <para>
     系統必須定期重新整理鎖定，這樣即使節點停止回應，也不會永久封鎖鎖定，其他節點仍能繼續處理。
    </para>
-  </sect2>
+  </section>
 
-  <sect2 id="sec-ha-storageprotection-exstoract-requirements">
+  <section xml:id="sec-ha-storageprotection-exstoract-requirements">
    <title>設定</title>
    <para>
     下例說明了如何建立用於 sfex 的共享分割區，以及如何在 CIB 中為 sfex 鎖定設定資源。一個 sfex 分割區可保存任意個鎖定 (預設為一個)，每個鎖定需要配置 1 KB 儲存空間。
@@ -442,18 +446,18 @@ Timeout (msgwait)  : 40
    </important>
    <procedure>
     <title>建立 sfex 分割區</title>
-    <step performance="required">
+    <step>
      <para>
       建立一個共享分割區用於 sfex。記下此分割區的名稱，並用其取代下面的 <filename>/dev/sfex</filename>。
      </para>
     </step>
-    <step performance="required">
+    <step>
      <para>
       使用以下指令建立 sfex 中繼資料︰
      </para>
 <screen><prompt role="root">root # </prompt><command>sfex_init</command> -n 1 /dev/sfex</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       驗證該中繼資料已正確建立︰
      </para>
@@ -465,7 +469,7 @@ Timeout (msgwait)  : 40
    </procedure>
    <procedure>
     <title>設定 sfex 鎖定的資源</title>
-    <step performance="required">
+    <step>
      <para>
       sfex 鎖定透過 CIB 中的資源表示，設定如下所示︰
      </para>
@@ -474,27 +478,27 @@ Timeout (msgwait)  : 40
       lock_timeout="70" monitor_interval="10" \
 #	op monitor interval="10s" timeout="30s" on_fail="fence"</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       若要透過 sfex 鎖定保護資源，請在保護對象與 sfex 資源之間建立強制性順序和配置條件約束。假設要保護之資源的 ID 為 <literal>filesystem1</literal>︰
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>order</command> order-sfex-1 inf: sfex_1 filesystem1
 <prompt role="custom">crm(live)configure# </prompt><command>colocation</command> colo-sfex-1 inf: filesystem1 sfex_1</screen>
     </step>
-    <step performance="required">
+    <step>
      <para>
       如果使用群組語法，請將 sfex 資源做為第一個資源新增到群組中︰
      </para>
 <screen><prompt role="custom">crm(live)configure# </prompt><command>group</command> LAMP sfex_1 filesystem1 apache ipaddr</screen>
     </step>
    </procedure>
-  </sect2>
- </sect1>
- <sect1 id="sec-ha-storage-moreinfo">
+  </section>
+ </section>
+ <section xml:id="sec-ha-storage-moreinfo">
   <title>更多資訊</title>
 
   <para>
-   請參閱 <ulink url="http://www.linux-ha.org/wiki/SBD_Fencing"/> 和 <command>man sbd</command>。
+   請參閱 <link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/> 和 <command>man sbd</command>。
   </para>
- </sect1>
+ </section>
 </chapter>

--- a/zh_TW/xml/ha_troubleshooting.xml
+++ b/zh_TW/xml/ha_troubleshooting.xml
@@ -1,18 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//Novell//DTD NovDoc XML V1.0//EN" "novdocx.dtd">
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+    type="text/xml"
+    title="Profiling step"
+?>
+<!DOCTYPE chapter>
 <!--
 *********************************
 Please see LICENSE.txt for this document's license.
 *********************************
 -->
-<chapter xml:base="ha_troubleshooting.xml" id="app-ha-troubleshooting">
- <title>疑難排解</title>
- <abstract>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:base="ha_troubleshooting.xml" xml:id="app-ha-troubleshooting"><title>疑難排解</title><info><abstract>
   <para>
    當出現奇怪的現象時，使用者可能會搞不清楚狀況，尤其是剛剛開始使用 High Availability 的使用者。不過，您可以借助幾個公用程式來深入瞭解 High Availability 的內部程序。本章推薦了各種解決方案。
   </para>
- </abstract>
- <sect1 id="sec-ha-troubleshooting-install">
+ </abstract></info>
+ 
+ 
+ <section xml:id="sec-ha-troubleshooting-install">
   <title>安裝和前期階段的步驟</title>
 
   <para>
@@ -68,8 +72,8 @@ Please see LICENSE.txt for this document's license.
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-log">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-log">
   <title>記錄</title>
 
   <variablelist>
@@ -125,11 +129,11 @@ Operations:
       * Node alice:</screen>
      </example>
      <para>
-      <ulink url="http://www.clusterlabs.org/doc/"/> 上《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明) PDF 檔案中的「<citetitle>How are OCF Return Codes Interpreted?</citetitle>」(如何解譯 OCF 傳回代碼？) 一節介紹了三種不同的復原類型。
+      <link xlink:href="http://www.clusterlabs.org/doc/"/> 上《<citetitle>Pacemaker Explained</citetitle>》(Pacemaker 說明) PDF 檔案中的「<citetitle>How are OCF Return Codes Interpreted?</citetitle>」(如何解譯 OCF 傳回代碼？) 一節介紹了三種不同的復原類型。
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="vle-ha-crm-report">
+   <varlistentry xml:id="vle-ha-crm-report">
     
     <term>如何建立一份包含所有叢集節點分析資訊的報告？</term>
     <listitem>
@@ -235,8 +239,8 @@ Operations:
    </varlistentry>
    
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-resource">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-resource">
   <title>資源</title>
 
   <variablelist>
@@ -303,8 +307,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-stonith">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-stonith">
   <title>STONITH 和圍籬區隔</title>
 
   <variablelist>
@@ -345,8 +349,8 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-misc">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-misc">
   <title>其他</title>
 
   <variablelist>
@@ -423,12 +427,12 @@ Jan 12 16:04:22 alice modprobe: FATAL: Module ocfs2_stackglue not found.</screen
     </listitem>
    </varlistentry>
   </variablelist>
- </sect1>
- <sect1 id="sec-ha-troubleshooting-moreinfo">
+ </section>
+ <section xml:id="sec-ha-troubleshooting-moreinfo">
   <title>更多資訊</title>
 
   <para>
-   如需有關 Linux 上高可用性的其他資訊，包括設定叢集資源及管理和自定高可用性叢集，請參閱 <ulink url="http://clusterlabs.org/wiki/Documentation"/>。
+   如需有關 Linux 上高可用性的其他資訊，包括設定叢集資源及管理和自定高可用性叢集，請參閱 <link xlink:href="http://clusterlabs.org/wiki/Documentation"/>。
   </para>
- </sect1>
+ </section>
 </chapter>


### PR DESCRIPTION
This PR contains:

* Converted ja, zh_CN, and zh_TW to DocBook5 with the [migration script](https://github.com/sknorr/daps-migrate-tools/blob/master/migrate2docbook5.sh)
* Adapted `STYLEROOT` in DC files.

I tested:

* Run `daps -d DC-SLE-ha-all validate` which was ok.
* Run `daps -v -d DC-SLE-ha-guide pdf` which created a PDF; looked good.

